### PR TITLE
feat: use private loguru logger

### DIFF
--- a/pymmcore_plus/_logger.py
+++ b/pymmcore_plus/_logger.py
@@ -1,0 +1,42 @@
+import atexit
+import os
+import sys
+from typing import TYPE_CHECKING
+
+__all__ = ["logger"]
+
+if TYPE_CHECKING:
+    from loguru import logger
+else:
+    from loguru._logger import Core, Logger
+
+    # avoid using the global loguru logger
+    logger = Logger(
+        core=Core(),
+        exception=None,
+        depth=0,
+        record=False,
+        lazy=False,
+        colors=False,
+        raw=False,
+        capture=True,
+        patcher=None,
+        extra={},
+    )
+
+DEBUG = os.getenv("MM_DEBUG", "0") in ("1", "true", "True", "yes")
+DEFAULT_LOG_LEVEL = "DEBUG" if DEBUG else "INFO"
+
+
+def set_log_level(level: str = DEFAULT_LOG_LEVEL):
+    logger.remove()
+
+    # automatically log to stderr
+    if sys.stderr:
+        logger.add(sys.stderr, level=level, backtrace=False)
+
+    # TODO: add file outputs
+
+
+set_log_level()
+atexit.register(logger.remove)

--- a/pymmcore_plus/_logger.py
+++ b/pymmcore_plus/_logger.py
@@ -35,6 +35,7 @@ def set_log_level(level: str = DEFAULT_LOG_LEVEL):
     if sys.stderr:
         logger.add(sys.stderr, level=level, backtrace=False)
 
+    logger.debug('log level set to "{}"', level)
     # TODO: add file outputs
 
 

--- a/pymmcore_plus/_tests/conftest.py
+++ b/pymmcore_plus/_tests/conftest.py
@@ -1,6 +1,8 @@
 import pytest
+from _pytest.logging import LogCaptureFixture
 
 import pymmcore_plus
+from pymmcore_plus._logger import logger
 from pymmcore_plus.core.events import CMMCoreSignaler, QCoreSignaler
 from pymmcore_plus.mda.events import MDASignaler, QMDASignaler
 
@@ -22,3 +24,12 @@ def core(request):
         )
     core.loadSystemConfiguration()
     return core
+
+
+@pytest.fixture
+def caplog(caplog: LogCaptureFixture):
+    handler_id = logger.add(caplog.handler, format="{message}")
+    try:
+        yield caplog
+    finally:
+        logger.remove(handler_id)

--- a/pymmcore_plus/_util.py
+++ b/pymmcore_plus/_util.py
@@ -4,6 +4,8 @@ import sys
 from pathlib import Path
 from typing import Optional
 
+from ._logger import logger
+
 __all__ = [
     "find_micromanager",
     "_qt_app_is_running",
@@ -22,7 +24,6 @@ def find_micromanager() -> Optional[str]:
         - `/Applications` on mac
         - `/usr/local/lib` on linux
     """
-    from loguru import logger
 
     # environment variable takes precedence
     env_path = os.getenv("MICROMANAGER_PATH")

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -25,11 +25,11 @@ from typing import (
 )
 
 import pymmcore
-from loguru import logger
 from psygnal import SignalInstance
 from typing_extensions import Literal
 from wrapt import synchronized
 
+from .._logger import logger
 from .._util import find_micromanager
 from ..mda import MDAEngine, PMDAEngine
 from ._config import Configuration
@@ -865,11 +865,8 @@ class _MMCallbackRelay(pymmcore.MMEventCallback):
             try:
                 getattr(self._emitter, sig_name).emit(*args)
             except Exception as e:
-                import logging
-
-                logging.getLogger(__name__).error(
-                    "Exception occured in MMCorePlus callback %s: %s"
-                    % (repr(sig_name), str(e))
+                logger.error(
+                    f"Exception occured in MMCorePlus callback {sig_name!r}: {e}"
                 )
 
         return reemit

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -149,7 +149,7 @@ class CMMCorePlus(pymmcore.CMMCore):
             if p not in env_path:
                 env_path = p + os.pathsep + env_path
         os.environ["PATH"] = env_path
-        logger.info(f"setting adapter search paths: {adapter_paths}")
+        logger.debug(f"setting adapter search paths: {adapter_paths}")
         super().setDeviceAdapterSearchPaths(adapter_paths)
 
     @synchronized(lock)
@@ -171,7 +171,7 @@ class CMMCorePlus(pymmcore.CMMCore):
     def unloadAllDevices(self) -> None:
         # this log won't appear when exiting ipython
         # but the method is still called
-        logger.info("Unloading all devices")
+        logger.debug("Unloading all devices")
         return super().unloadAllDevices()
 
     def getDeviceType(self, label: str) -> DeviceType:

--- a/pymmcore_plus/mda/_engine.py
+++ b/pymmcore_plus/mda/_engine.py
@@ -259,7 +259,7 @@ class MDAEngine(PMDAEngine):
                 if cancelled:
                     break
 
-                logger.info(event)
+                logger.debug(event)
                 self._prep_hardware(event)
 
                 self._mmc.snapImage()

--- a/pymmcore_plus/mda/_engine.py
+++ b/pymmcore_plus/mda/_engine.py
@@ -3,9 +3,9 @@ import time
 from abc import abstractmethod
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
-from loguru import logger
 from useq import MDAEvent, MDASequence
 
+from .._logger import logger
 from .events import PMDASignaler, _get_auto_MDA_callback_class
 
 if TYPE_CHECKING:

--- a/pymmcore_plus/remote/client/_client.py
+++ b/pymmcore_plus/remote/client/_client.py
@@ -5,10 +5,10 @@ import threading
 import time
 from typing import Optional
 
-from loguru import logger
 from Pyro5 import api, core, errors
 from typing_extensions import Protocol
 
+from ..._logger import logger
 from .. import server
 from .._serialize import register_serializers
 

--- a/pymmcore_plus/remote/server/_pyrocore.py
+++ b/pymmcore_plus/remote/server/_pyrocore.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Set
 from Pyro5 import errors
 from Pyro5.api import behavior, expose, oneway
 
+from ..._logger import logger
 from ...core._mmcore_plus import CMMCorePlus
 from ...core.events import CMMCoreSignaler
 from .._util import wrap_for_pyro
@@ -47,7 +48,6 @@ class pyroCMMCore(CMMCorePlus):
 
     @oneway
     def emit_signal(self, signal_name: str, *args):
-        from loguru import logger
 
         logger.debug("{}: {}", signal_name, args)
         for handler in list(self._callback_handlers):

--- a/pymmcore_plus/remote/server/_server.py
+++ b/pymmcore_plus/remote/server/_server.py
@@ -30,9 +30,9 @@ def try_kill_server(host: str = None, port: int = None):
     proc = _get_remote_pid(host, port)
     if proc is not None:
         proc.kill()
-        logger.info(f"Killed process on {host=}:{port=}")
+        logger.debug(f"Killed process on {host=}:{port=}")
     else:
-        logger.info("No process found")
+        logger.debug("No process found")
 
 
 def serve():

--- a/pymmcore_plus/remote/server/_server.py
+++ b/pymmcore_plus/remote/server/_server.py
@@ -20,7 +20,7 @@ def _get_remote_pid(host, port) -> Optional["Process"]:
 
 
 def try_kill_server(host: str = None, port: int = None):
-    from loguru import logger
+    from ..._logger import logger
 
     if host is None:
         host = DEFAULT_HOST
@@ -39,10 +39,11 @@ def serve():
     import argparse
 
     import Pyro5
-    from loguru import logger
 
     from pymmcore_plus.remote._serialize import register_serializers
     from pymmcore_plus.remote.server import pyroCMMCore
+
+    from ..._logger import logger
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--port", type=int, default=DEFAULT_PORT, help="port")


### PR DESCRIPTION
this PR uses a private loguru logger instead of the global one.  It's not a "endorsed" way to use loguru, but the standard method appears to leaves the logger open to the whims of any other library using loguru.  So, if they set the log level by using `logger.remove(); ...` then it can bonk whatever setup we've done.

so, after this, use `from pymmcore_plus._logger import logger`