### PR TITLE
fix: fix missing typing import from psygnal

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -37,7 +37,9 @@ jobs:
           pip install -e .[remote,testing]
 
       - name: Install Micro-Manager
-        run: python -m pymmcore_plus.install
+        # pinning install until upstream is fixed:
+        # https://github.com/micro-manager/mmCoreAndDevices/issues/288
+        run: python -m pymmcore_plus.install -r 20221024
 
       - name: Test
         run: pytest -v --color=yes --cov=pymmcore_plus --cov-report=xml

--- a/pymmcore_plus/core/events/_prop_event_mixin.py
+++ b/pymmcore_plus/core/events/_prop_event_mixin.py
@@ -1,15 +1,21 @@
-from typing import Any, Callable, Dict, Optional, Tuple, TypeVar
+from __future__ import annotations
 
-from psygnal._signal import NormedCallback, _normalize_slot
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Tuple, TypeVar
+
+from psygnal._signal import _normalize_slot
+
+if TYPE_CHECKING:
+    from psygnal._signal import NormedCallback
+
+    PropKey = Tuple[str, Optional[str], NormedCallback]
+    PropKeyDict = Dict[PropKey, Callable]
 
 from ._protocol import PCoreSignaler
 
 _C = TypeVar("_C", bound=Callable[..., Any])
-PropKey = Tuple[str, Optional[str], NormedCallback]
-PropKeyDict = Dict[PropKey, Callable]
 
 
-def _denormalize_slot(slot: "NormedCallback") -> Optional[Callable]:
+def _denormalize_slot(slot: NormedCallback) -> Optional[Callable]:
     if not isinstance(slot, tuple):
         return slot
 
@@ -28,7 +34,7 @@ def _denormalize_slot(slot: "NormedCallback") -> Optional[Callable]:
 class _PropertySignal:
     def __init__(
         self,
-        core_events: "_DevicePropertyEventMixin",
+        core_events: _DevicePropertyEventMixin,
         device: str,
         property: Optional[str] = None,
     ) -> None:

--- a/pymmcore_plus/core/events/_qsignals.py
+++ b/pymmcore_plus/core/events/_qsignals.py
@@ -1,8 +1,11 @@
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from qtpy.QtCore import QObject, Signal
 
-from ._prop_event_mixin import PropKeyDict, _PropertySignal
+from ._prop_event_mixin import _PropertySignal
+
+if TYPE_CHECKING:
+    from ._prop_event_mixin import PropKeyDict
 
 
 class QCoreSignaler(QObject):


### PR DESCRIPTION
I had imported a type from a private psygnal module that is no longer exported in the recent psygnal version (naughty me).

This hides that import being TYPE_CHECKING

this also includes and closes #150 