### PR TITLE
tests: pin micromanager to 20221024 until upstream fixes

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -37,7 +37,9 @@ jobs:
           pip install -e .[remote,testing]
 
       - name: Install Micro-Manager
-        run: python -m pymmcore_plus.install
+        # pinning install until upstream is fixed:
+        # https://github.com/micro-manager/mmCoreAndDevices/issues/288
+        run: python -m pymmcore_plus.install -r 20221024
 
       - name: Test
         run: pytest -v --color=yes --cov=pymmcore_plus --cov-report=xml


### PR DESCRIPTION
note sure what happened, but since the 10/25 nightly release, tests are failing
https://github.com/micro-manager/mmCoreAndDevices/issues/288

pinning for now