### PR TITLE
docs: fix api docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,14 +38,13 @@ subprocess.call(
             "--no-toc",
             "--templatedir _templates",
             "--separate",
-            "../pymmcore_plus/",
+            str(Path(pymmcore_plus.__file__).parent),
             # excluded modules
             # nothing here for cookiecutter
         ]
     ),
     shell=True,
 )
-
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -199,4 +199,4 @@ def linkcode_resolve(domain, info):
     startdir = Path(pymmcore_plus.__file__).parent
     fn = os.path.relpath(fn, start=startdir).replace(os.path.sep, "/")
 
-    return f"https://github.com/pymmcore-plus/pymmcore-plus/blob/main/pymmcore_plus/{fn}{linespec}"  # noqa
+    return f"https://github.com/pymmcore-plus/pymmcore-plus/blob/main/src/pymmcore_plus/{fn}{linespec}"  # noqa


### PR DESCRIPTION
the move to `src` layout in #153 broke the api docs building