### PR TITLE
docs: remove direct griffe from extra

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,5 +11,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
-      - run: pip install -e .[docs]
+      - run: |
+          pip install -e .[docs]
+          # bugfix until https://github.com/mkdocstrings/griffe/pull/115
+          pip install git+https://github.com/tlambert03/griffe@recursion#egg=griffe -U
       - run: mkdocs gh-deploy --force

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,6 @@ dependencies = [
 # https://peps.python.org/pep-0621/#dependencies-optional-dependencies
 [project.optional-dependencies]
 docs = [
-    # bugfix until https://github.com/mkdocstrings/griffe/pull/115
-    "griffe @ git+https://github.com/tlambert03/griffe@recursion#egg=griffe",
     "mkdocs >=1.4",
     "mkdocs-material",
     "mkdocstrings-python",


### PR DESCRIPTION
because of https://github.com/mkdocstrings/griffe/pull/115, I'm using a direct url for building docs, but twine didn't like that and rejected the last build.  So I'm only using it in the github build action here: