### PR TITLE
fix: vendor private psygnal func

### DIFF
--- a/src/pymmcore_plus/_util.py
+++ b/src/pymmcore_plus/_util.py
@@ -52,10 +52,10 @@ def find_micromanager() -> Optional[str]:
         pth = str(next(app_path.glob("[m,M]icro-[m,M]anager*")))
         logger.debug(f"using MM path found in applications: {pth}")
         return pth
-    except KeyError:
+    except KeyError as e:
         raise NotImplementedError(
             f"MM autodiscovery not implemented for platform: {sys.platform}"
-        )
+        ) from e
     except StopIteration:
         logger.error(f"could not find micromanager directory in {app_path}")
         return None

--- a/src/pymmcore_plus/core/_config.py
+++ b/src/pymmcore_plus/core/_config.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Any, DefaultDict, Dict, Iterator, Tuple, cast
+from typing import Any, DefaultDict, Iterator, cast
 
 import pymmcore
 
@@ -95,7 +95,7 @@ class Configuration(pymmcore.Configuration):
             lines.append("")
         return "\n".join(lines)
 
-    def __iter__(self) -> Iterator[Tuple[str, str, str]]:
+    def __iter__(self) -> Iterator[tuple[str, str, str]]:
         for i in range(self.size()):
             ps = self.getSetting(i)
             yield ps.getDeviceLabel(), ps.getPropertyName(), ps.getPropertyValue()
@@ -128,9 +128,9 @@ class Configuration(pymmcore.Configuration):
         """Return config as HTML."""
         return self.getVerbose()
 
-    def dict(self) -> Dict[str, Dict[str, str]]:
+    def dict(self) -> dict[str, dict[str, str]]:
         """Return config as a nested dict."""
-        d: DefaultDict[str, Dict[str, str]] = defaultdict(dict)
+        d: DefaultDict[str, dict[str, str]] = defaultdict(dict)
         for label, prop, value in self:
             d[label][prop] = value
         return dict(d)
@@ -145,8 +145,10 @@ class Configuration(pymmcore.Configuration):
         """Dump config to YAML string (requires that PyYAML is installed)."""
         try:
             from yaml import safe_dump
-        except ImportError:  # pragma: no cover
-            raise ImportError("Could not import yaml.  Please `pip install PyYAML`.")
+        except ImportError as e:  # pragma: no cover
+            raise ImportError(
+                "Could not import yaml.  Please `pip install PyYAML`."
+            ) from e
 
         return cast(str, safe_dump(self.dict()))
 

--- a/src/pymmcore_plus/core/_device.py
+++ b/src/pymmcore_plus/core/_device.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Tuple
+from typing import TYPE_CHECKING
 
 from ._property import DeviceProperty
 from .events._device_signal_view import _DevicePropValueSignal
@@ -78,12 +78,12 @@ class Device:
         """Return the device name (this is not the same as the device label)."""
         return self._mmc.getDeviceName(self.label)
 
-    def propertyNames(self) -> Tuple[str, ...]:
+    def propertyNames(self) -> tuple[str, ...]:
         """Return all property names supported by this device."""
         return self._mmc.getDevicePropertyNames(self.label)
 
     @property
-    def properties(self) -> Tuple[DeviceProperty, ...]:
+    def properties(self) -> tuple[DeviceProperty, ...]:
         """Get all properties supported by device as DeviceProperty objects."""
         return tuple(
             DeviceProperty(self.label, name, self._mmc) for name in self.propertyNames()
@@ -138,7 +138,7 @@ class Device:
                             f". Device name {device_name!r} not in devices provided by "
                             f"adapter {adapter_name!r}: {devices}"
                         )
-            raise RuntimeError(msg)  # sourcery skip
+            raise RuntimeError(msg) from e
 
     def unload(self) -> None:
         """Unload device from the core and adjust all configuration data."""

--- a/src/pymmcore_plus/core/_metadata.py
+++ b/src/pymmcore_plus/core/_metadata.py
@@ -27,8 +27,8 @@ class Metadata(pymmcore.Metadata):
     def __getitem__(self, name: str) -> Any:
         try:
             return self.GetSingleTag(name).GetValue()
-        except ValueError:
-            raise KeyError(str(name))
+        except ValueError as e:
+            raise KeyError(str(name)) from e
 
     def __setitem__(self, name: str, value: Any) -> None:
         tag = pymmcore.MetadataSingleTag(name, "_", False)

--- a/src/pymmcore_plus/core/events/__init__.py
+++ b/src/pymmcore_plus/core/events/__init__.py
@@ -1,7 +1,5 @@
 from typing import TYPE_CHECKING, Any, List, Type
 
-from psygnal._signal import _normalize_slot
-
 from ..._util import _qt_app_is_running
 from ._protocol import PCoreSignaler
 from ._psygnal import CMMCoreSignaler
@@ -14,7 +12,6 @@ __all__ = [
     "QCoreSignaler",
     "PCoreSignaler",
     "_get_auto_core_callback_class",
-    "_normalize_slot",
     "_denormalize_slot",
 ]
 

--- a/src/pymmcore_plus/core/events/_norm_slot.py
+++ b/src/pymmcore_plus/core/events/_norm_slot.py
@@ -1,0 +1,79 @@
+"""Module vendored from psygnal. Only for internal use."""
+from __future__ import annotations
+
+import weakref
+from functools import partial
+from types import MethodType
+from typing import TYPE_CHECKING, Any, Callable, Union
+
+if TYPE_CHECKING:
+    from typing import Tuple
+
+    from typing_extensions import TypeGuard
+
+    MethodRef = Tuple[weakref.ReferenceType[object], str, Callable | None]
+    NormedCallback = Union[MethodRef, Callable]
+    StoredSlot = Tuple[NormedCallback, int | None]
+    ReducerFunc = Callable[[tuple, tuple], tuple]
+
+
+def normalize_slot(slot: Callable | NormedCallback) -> NormedCallback:
+    if isinstance(slot, MethodType):
+        return _get_method_name(slot) + (None,)
+    if _is_partial_method(slot):
+        return _partial_weakref(slot)
+    if isinstance(slot, tuple) and not isinstance(slot[0], weakref.ref):
+        return (weakref.ref(slot[0]), slot[1], slot[2])
+    return slot
+
+
+def _partial_weakref(slot_partial: partial) -> tuple[weakref.ref, str, Callable]:
+    """For partial methods, make the weakref point to the wrapped object."""
+    ref, name = _get_method_name(slot_partial.func, MethodType)  # type: ignore
+    args_ = slot_partial.args
+    kwargs_ = slot_partial.keywords
+
+    def wrap(*args: Any, **kwargs: Any) -> Any:
+        getattr(ref(), name)(*args_, *args, **kwargs_, **kwargs)
+
+    return (ref, name, wrap)
+
+
+def _is_partial_method(inst: object) -> TypeGuard[partial]:
+    return isinstance(inst, partial) and isinstance(inst.func, MethodType)
+
+
+def _get_method_name(slot: MethodType) -> tuple[weakref.ref, str]:
+    obj = slot.__self__
+    # some decorators will alter method.__name__, so that obj.method
+    # will not be equal to getattr(obj, obj.method.__name__).
+    # We check for that case here and find the proper name in the function's closures
+    if getattr(obj, slot.__name__, None) != slot:
+        for c in slot.__closure__ or ():
+            cname = getattr(c.cell_contents, "__name__", None)
+            if cname and getattr(obj, cname, None) == slot:
+                return weakref.ref(obj), cname
+        # slower, but catches cases like assigned functions
+        # that won't have function in closure
+        for name in reversed(dir(obj)):  # most dunder methods come first
+            if getattr(obj, name) == slot:
+                return weakref.ref(obj), name
+        # we don't know what to do here.
+        raise RuntimeError(  # pragma: no cover
+            f"Could not find method on {obj} corresponding to decorated function {slot}"
+        )
+    return weakref.ref(obj), slot.__name__
+
+
+def denormalize_slot(slot: NormedCallback) -> Callable | None:
+    if not isinstance(slot, tuple):
+        return slot
+
+    _ref, name, method = slot
+    obj = _ref()
+    if obj is None:
+        return None
+    if method is not None:
+        return method
+    _cb = getattr(obj, name, None)
+    return None if _cb is None else _cb

--- a/src/pymmcore_plus/core/events/_prop_event_mixin.py
+++ b/src/pymmcore_plus/core/events/_prop_event_mixin.py
@@ -1,33 +1,18 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Tuple, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, Dict, Tuple, TypeVar
 
-# FIXME: private import
-from psygnal._signal import _normalize_slot
+from ._norm_slot import denormalize_slot, normalize_slot
+from ._protocol import PCoreSignaler
 
 if TYPE_CHECKING:
     from psygnal._signal import NormedCallback
 
-    PropKey = Tuple[str, Optional[str], NormedCallback]
+    PropKey = Tuple[str, str | None, NormedCallback]
     PropKeyDict = Dict[PropKey, Callable]
 
-from ._protocol import PCoreSignaler
 
 _C = TypeVar("_C", bound=Callable[..., Any])
-
-
-def _denormalize_slot(slot: NormedCallback) -> Optional[Callable]:
-    if not isinstance(slot, tuple):
-        return slot
-
-    _ref, name, method = slot
-    obj = _ref()
-    if obj is None:
-        return None
-    if method is not None:
-        return method
-    _cb = getattr(obj, name, None)
-    return None if _cb is None else _cb
 
 
 class _PropertySignal:
@@ -35,7 +20,7 @@ class _PropertySignal:
         self,
         core_events: _DevicePropertyEventMixin,
         device: str,
-        property: Optional[str] = None,
+        property: str | None = None,
     ) -> None:
         self._events = core_events
         self._device = device
@@ -60,11 +45,11 @@ class _PropertySignal:
         callback
             the callback is returned for use as a decorator.
         """
-        slot = _normalize_slot(callback)
+        slot = normalize_slot(callback)
         key = (self._device, self._property, slot)
 
         def _wrapper(dev: str, prop: str, new_value: Any) -> None:
-            cb = _denormalize_slot(slot)
+            cb = denormalize_slot(slot)
             if cb is None:
                 self._events._prop_callbacks.pop(key)
                 return
@@ -81,17 +66,20 @@ class _PropertySignal:
 
     def disconnect(self, callback: Callable) -> None:
         """Disconnect `callback` from this device and/or property."""
-        key = (self._device, self._property, _normalize_slot(callback))
+        key = (self._device, self._property, normalize_slot(callback))
         if key not in self._events._prop_callbacks:
             raise ValueError("callback not connected")
         self._events.propertyChanged.disconnect(self._events._prop_callbacks.pop(key))
+
+    def emit(self, *args: Any) -> Any:
+        raise NotImplementedError("emit not implemented for _PropertySignal")
 
 
 class _DevicePropertyEventMixin(PCoreSignaler):
     _prop_callbacks: PropKeyDict = {}
 
-    def devicePropertyChanged(  # type: ignore[override]
-        self, device: str, property: Optional[str] = None
+    def devicePropertyChanged(
+        self, device: str, property: str | None = None
     ) -> _PropertySignal:
         """Return object to connect/disconnect to device/property-specific changes.
 

--- a/src/pymmcore_plus/core/events/_protocol.py
+++ b/src/pymmcore_plus/core/events/_protocol.py
@@ -161,4 +161,28 @@ class PCoreSignaler(Protocol):
     def devicePropertyChanged(
         self, device: str, property: Optional[str] = None
     ) -> PSignalInstance:
-        ...
+        """Return object to connect/disconnect to device/property-specific changes.
+
+        Note that the callback provided to `.connect()` must take *two* parameters
+        (property_name, new_value) if only `device` is provided, and *one* parameter
+        (new_value) of both `device` and `property` are provided.
+
+        Parameters
+        ----------
+        device : str
+            A device label
+        property : Optional[str]
+            Optional property label.  If not provided, all property changes on `device`
+            will trigger an event emission. by default None
+
+        Returns
+        -------
+        _PropertySignal
+            Object with `connect` and `disconnect` methods that attach a callback to
+            the change event of a specific property or device.
+
+        Examples
+        --------
+        >>> core.events.devicePropertyChanged('Camera', 'Gain').connect(callback)
+        >>> core.events.devicePropertyChanged('Camera').connect(callback)
+        """


### PR DESCRIPTION
This vendors a private function from psygnal that we were using `_normalize_slot`.  (the purpose of the function is to retain the functionality of a callable without holding any strong references to a bound method)