### PR TITLE
feat: add config group object

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,6 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies:
-          - types-PyYAML
           - pymmcore
           - useq-schema
           - psygnal

--- a/docs/api/configuration.md
+++ b/docs/api/configuration.md
@@ -1,3 +1,61 @@
-# Configuration
+# Configuration & Groups
+
+Configuring a microscope with micro-manager entails storing and retrieving
+a number of device parameters settings.  In general, a single setting comprises
+a device name, a property name, and a value.  A **Configuration** object
+represents a *collection* of individual settings; that is, it represents a number
+of device parameters all in a specific state, such as would be used to prepare
+the microscope to image a specific channel, like "DAPI", or "FITC".
+
+A **Configuration Group** is, in turn, a *collection* of `Configuration` objects;
+for example, all of the `Configuration` objects that represent different
+"Channel" settings.
+
+Conceptually, Configurations and Groups are organized like this:
+
+```YAML
+ConfigGroupA:
+    Configuration1:
+        deviceA:
+            propertyA: 'value_a'
+            propertyB: 'value_b'
+        deviceB:
+            propertyC: 'value_c'
+        ...
+    Configuration2:
+        deviceA:
+            propertyA: 'value_d'
+            propertyB: 'value_e'
+        deviceB:
+            propertyC: 'value_f'
+        ...
+    ...
+ConfigGroupB:
+    Configuration1:
+        deviceC:
+            propertyA: 'value_g'
+        ...
+    ...
+```
+
+## `pymmcore-plus` Objects
+
+MMCore and pymmcore's
+[configuration](https://valelab4.ucsf.edu/~MM/doc/MMCore/html/class_configuration.html)
+object implements a basic mutable mapping interface, but with custom method
+names like `addSetting`, `getSetting`, and `deleteSetting` methods).
+
+`pymmcore-plus` provides a [`Configuration`][pymmcore_plus.Configuration]
+subclass that implements a standard python [collections.abc.MutableMapping][]
+interface, allowing dict-like access to the configuration.
+
+`pymmcore-plus` also organizes related Configuration objects into a
+[`ConfigGroup`][pymmcore_plus.ConfigGroup] object, which also
 
 ::: pymmcore_plus.Configuration
+    options:
+        heading_level: 3
+
+::: pymmcore_plus.ConfigGroup
+    options:
+        heading_level: 3

--- a/docs/api/configuration.md
+++ b/docs/api/configuration.md
@@ -46,11 +46,17 @@ object implements a basic mutable mapping interface, but with custom method
 names like `addSetting`, `getSetting`, and `deleteSetting` methods).
 
 `pymmcore-plus` provides a [`Configuration`][pymmcore_plus.Configuration]
-subclass that implements a standard python [collections.abc.MutableMapping][]
-interface, allowing dict-like access to the configuration.
+subclass that implements a [`MutableMapping`][collections.abc.MutableMapping] interface,
+allowing dict-like access to the configuration, where the keys are 2-tuples of
+`(deviceLabel, propertyLabel)` and the values are the property values. (Note,
+however, that iterating of a `Configuration` object behaves like iterating over
+a list of 3-tuples `(deviceLabel, propertyLabel, value)`, not a dict.)
 
-`pymmcore-plus` also organizes related Configuration objects into a
-[`ConfigGroup`][pymmcore_plus.ConfigGroup] object, which also
+`pymmcore-plus` also offers a [`ConfigGroup`][pymmcore_plus.ConfigGroup] object,
+which is a [`MutableMapping`][collections.abc.MutableMapping] where the keys are
+[Configuration
+Preset](https://micro-manager.org/Micro-Manager_Configuration_Guide#configuration-presets)
+names and the values are `Configuration` objects.
 
 ::: pymmcore_plus.Configuration
     options:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,6 @@ dev = [
     "rich",
     "ruff",
     "types-psutil",
-    "types-PyYAML",
 ]
 
 [project.urls]

--- a/src/pymmcore_plus/__init__.py
+++ b/src/pymmcore_plus/__init__.py
@@ -9,6 +9,7 @@ from ._util import find_micromanager
 from .core import (
     ActionType,
     CMMCorePlus,
+    ConfigGroup,
     Configuration,
     Device,
     DeviceDetectionStatus,
@@ -29,6 +30,7 @@ __all__ = [
     "ActionType",
     "CMMCorePlus",
     "CMMCoreSignaler",
+    "ConfigGroup",
     "Configuration",
     "Device",
     "DeviceDetectionStatus",

--- a/src/pymmcore_plus/core/__init__.py
+++ b/src/pymmcore_plus/core/__init__.py
@@ -1,6 +1,7 @@
 __all__ = [
     "ActionType",
     "CMMCorePlus",
+    "ConfigGroup",
     "Configuration",
     "DeviceDetectionStatus",
     "DeviceNotification",
@@ -14,6 +15,7 @@ __all__ = [
 ]
 
 from ._config import Configuration
+from ._config_group import ConfigGroup
 from ._constants import (
     ActionType,
     DeviceDetectionStatus,

--- a/src/pymmcore_plus/core/_config.py
+++ b/src/pymmcore_plus/core/_config.py
@@ -158,7 +158,7 @@ class Configuration(pymmcore.Configuration):
 
     def __str__(self) -> str:
         lines = []
-        for device, prop in self.as_dict().items():
+        for device, prop in self.dict().items():
             lines.append(f"{device}:")
             lines.extend(f"  - {name}: {value}" for name, value in prop.items())
         return "\n".join(lines)
@@ -167,7 +167,7 @@ class Configuration(pymmcore.Configuration):
         """Return config representation as HTML."""
         return self.getVerbose()
 
-    def as_dict(self) -> dict[str, dict[str, str]]:
+    def dict(self) -> dict[str, dict[str, str]]:
         """Return config as a nested dict {Device: {Property: Value}}."""
         d: DefaultDict[str, dict[str, str]] = defaultdict(dict)
         for label, prop, value in self:
@@ -221,7 +221,7 @@ class Configuration(pymmcore.Configuration):
         return cfg
 
     def __eq__(self, o: Any) -> bool:
-        return o.as_dict() == self.as_dict() if isinstance(o, Configuration) else False
+        return o.dict() == self.dict() if isinstance(o, Configuration) else False
 
 
 # class PropertySetting(pymmcore.PropertySetting):

--- a/src/pymmcore_plus/core/_config.py
+++ b/src/pymmcore_plus/core/_config.py
@@ -85,14 +85,13 @@ class Configuration(pymmcore.Configuration):
         return self.size()
 
     def __repr__(self) -> str:
-        return f"<MMCore Configuration with {self.size()} settings>"
+        return f"<MMCorePlus Configuration with {self.size()} settings>"
 
     def __str__(self) -> str:
         lines = []
         for device, prop in self.dict().items():
             lines.append(f"{device}:")
-            lines.extend(f"  {name}={value}" for name, value in prop.items())
-            lines.append("")
+            lines.extend(f"  - {name}: {value}" for name, value in prop.items())
         return "\n".join(lines)
 
     def __iter__(self) -> Iterator[tuple[str, str, str]]:

--- a/src/pymmcore_plus/core/_config.py
+++ b/src/pymmcore_plus/core/_config.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Any, DefaultDict, Iterable, Iterator, Tuple, cast, overload
+from typing import Any, DefaultDict, Iterable, Iterator, Tuple, overload
 
 import pymmcore
 from typing_extensions import TypeAlias
@@ -14,10 +14,20 @@ DevPropTuple: TypeAlias = Tuple[str, str]
 class Configuration(pymmcore.Configuration):
     """Encapsulation of configuration information.
 
+    This is the type of object returned by default (provided `native==False`) by:
+    [`getConfigData][pymmcore_plus.CMMCorePlus.getConfigData],
+    [`getPixelSizeConfigData][pymmcore_plus.CMMCorePlus.getPixelSizeConfigData]
+    [`getSystemState][pymmcore_plus.CMMCorePlus.getSystemState]
+    [`getSystemStateCache][pymmcore_plus.CMMCorePlus.getSystemStateCache]
+    [`getConfigState][pymmcore_plus.CMMCorePlus.getConfigState]
+    [`getConfigGroupState][pymmcore_plus.CMMCorePlus.getConfigGroupState]
+    [`getConfigGroupStateFromCache][pymmcore_plus.CMMCorePlus.getConfigGroupStateFromCache]
+
+
     This class is a subclass of `pymmcore.Configuration` that implements an
-    [`collections.abc.MutableSequence`][] (i.e. it behaves like a Python list)... though
-    it also behaves much like a MutableMapping, where the keys are 2-tuples of
-    (deviceLabel, propertyLabel) and the values are the property values.
+    [`collections.abc.MutableSequence`][] (i.e. it behaves like a Python list).
+    It also behaves much like a [`collections.abc.MutableMapping`][], where the keys
+    are 2-tuples of (deviceLabel, propertyLabel) and the values are the property values.
 
     Note that the "order" of this collection is not well-defined, so while you *can*
     index with an integer, you should not rely on the order of the items in the
@@ -148,38 +158,21 @@ class Configuration(pymmcore.Configuration):
 
     def __str__(self) -> str:
         lines = []
-        for device, prop in self.dict().items():
+        for device, prop in self.as_dict().items():
             lines.append(f"{device}:")
             lines.extend(f"  - {name}: {value}" for name, value in prop.items())
         return "\n".join(lines)
 
     def html(self) -> str:
-        """Return config as HTML."""
+        """Return config representation as HTML."""
         return self.getVerbose()
 
-    def dict(self) -> dict[str, dict[str, str]]:
+    def as_dict(self) -> dict[str, dict[str, str]]:
         """Return config as a nested dict {Device: {Property: Value}}."""
         d: DefaultDict[str, dict[str, str]] = defaultdict(dict)
         for label, prop, value in self:
             d[label][prop] = value
         return dict(d)
-
-    def json(self) -> str:
-        """Dump config to JSON string."""
-        from json import dumps
-
-        return dumps(self.dict())
-
-    def yaml(self) -> str:
-        """Dump config to YAML string (requires that PyYAML is installed)."""
-        try:
-            from yaml import safe_dump
-        except ImportError as e:  # pragma: no cover
-            raise ImportError(
-                "Could not import yaml.  Please `pip install PyYAML`."
-            ) from e
-
-        return cast(str, safe_dump(self.dict()))
 
     @classmethod
     def from_configuration(cls, config: pymmcore.Configuration) -> Configuration:
@@ -228,7 +221,7 @@ class Configuration(pymmcore.Configuration):
         return cfg
 
     def __eq__(self, o: Any) -> bool:
-        return o.dict() == self.dict() if isinstance(o, Configuration) else False
+        return o.as_dict() == self.as_dict() if isinstance(o, Configuration) else False
 
 
 # class PropertySetting(pymmcore.PropertySetting):

--- a/src/pymmcore_plus/core/_config_group.py
+++ b/src/pymmcore_plus/core/_config_group.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Iterator, Literal, MutableMapping, overload
+
+import pymmcore
+
+from ._config import Configuration
+from ._property import DeviceProperty
+
+
+if TYPE_CHECKING:
+    from ..core._mmcore_plus import CMMCorePlus
+
+
+class ConfigGroup(MutableMapping[str, Configuration]):
+    def __init__(self, group_name: str, mmcore: CMMCorePlus) -> None:
+        self._mmc = mmcore
+        self._name = group_name
+
+    @property
+    def name(self) -> str:
+        """Return the name of this ConfigGroup."""
+        return self._name
+
+    @property
+    def core(self) -> CMMCorePlus:
+        """Return the `CMMCorePlus` instance to which this Device is bound."""
+        return self._mmc
+
+    def exists(self) -> bool:
+        """Return `True` if this ConfigGroup exists in the current configuration."""
+        return self._mmc.isGroupDefined(self._name)
+
+    def create(self) -> None:
+        """Create this configuration group in core (as an empty group).
+
+        If the group already exists, this is a no-op.
+        """
+        if not self._mmc.isGroupDefined(self._name):
+            self._mmc.defineConfigGroup(self._name)
+
+    def delete(self) -> None:
+        """Delete this entire configuration group and all presets in it."""
+        self._mmc.deleteConfigGroup(self._name)
+
+    def __contains__(self, configName: object) -> bool:
+        """Return `True` if this group already has a preset named `configName`."""
+        return (
+            self._mmc.isConfigDefined(self._name, configName)
+            if isinstance(configName, str)
+            else False
+        )
+
+    def __delitem__(self, configName: str) -> None:
+        self._mmc.deleteConfig(self._name, configName)
+
+    def __getitem__(self, configName: str) -> Configuration:
+        try:
+            return self._mmc.getConfigData(self._name, configName)
+        except ValueError as e:
+            if configName not in self:
+                raise KeyError(
+                    f"Group {self._name!r} does not have a config {configName!r}"
+                ) from e
+            raise  # pragma: no cover
+
+    def __setitem__(self, configName: str, value: Any) -> None:
+        if isinstance(value, (tuple, list)):
+            if len(value) != 3:
+                raise ValueError("Expected a 3-tuple of (deviceLabel, propName, value)")
+            self._mmc.defineConfig(self._name, configName, *value)
+        elif isinstance(value, pymmcore.Configuration):
+            if configName in self:
+                del self[configName]
+            for i in range(value.size()):
+                ps = value.getSetting(i)
+                self._mmc.defineConfig(
+                    self._name,
+                    configName,
+                    ps.getDeviceLabel(),
+                    ps.getPropertyName(),
+                    ps.getPropertyValue(),
+                )
+        elif isinstance(value, dict):
+            for k in value:
+                if not (isinstance(k, tuple) and len(k) == 2):
+                    raise ValueError(
+                        "Expected a dict of {(deviceLabel, propName): value}"
+                    )
+            if configName in self:
+                del self[configName]
+            for k, val in value.items():
+                self._mmc.defineConfig(self._name, configName, *k, val)  # type: ignore
+        else:
+            raise ValueError(
+                "Expected a 3-tuple of (deviceLabel, propName, value), "
+                "a dict of {(deviceLabel, propName): value}, "
+                "or a pymmcore.Configuration object"
+            )
+
+    def __iter__(self) -> Iterator[str]:
+        yield from self._mmc.getAvailableConfigs(self._name)
+
+    def __len__(self) -> int:
+        return len(self._mmc.getAvailableConfigs(self._name))
+
+    def __repr__(self) -> str:
+        n_props = len(list(self.iterDeviceProperties()))
+        return f"ConfigGroup(presets={list(self)}, n_properties={n_props})"
+
+    def iterDeviceProperties(self) -> Iterator[DeviceProperty]:
+        """Iterate `DeviceProperty` for all properties in this ConfigGroup.
+
+        Note, this only iterates over properties that are defined in the first preset of
+        this ConfigGroup. This *should* be the same for all presets in this ConfigGroup,
+        but it is not guaranteed.  Use `is_consistent` to check if all presets in this
+        ConfigGroup have the same properties.
+        """
+        presets = self._mmc.getAvailableConfigs(self._name)
+        if not presets:
+            return  # pragma: no cover
+
+        for (dev, prop, _) in self._mmc.getConfigData(self._name, presets[0]):
+            yield DeviceProperty(dev, prop, self._mmc)
+
+    @property
+    def is_consistent(self) -> bool:
+        """Return `True` if all presets in this group have the same properties.
+
+        Note that a group with 0 or 1 presets is always considered consistent.  If two
+        or more presets are present, they must all have the same device properties.
+        (values of course may vary.)
+        """
+        values = list(self.values())
+        if len(values) < 2:
+            # A group with 0 or 1 presets is always consistent.
+            return True
+
+        return len({frozenset(v[:2] for v in item) for item in values}) == 1
+
+    def renameConfig(self, oldConfigName: str, newConfigName: str) -> None:
+        """Rename a configuration in this group.
+
+        If the configuration does not exist, a KeyError is thrown.
+        """
+        if oldConfigName not in self:
+            raise KeyError(
+                f"Group {self._name!r} does not have a config {oldConfigName!r}"
+            )
+        self._mmc.renameConfig(self._name, oldConfigName, newConfigName)
+
+    def setConfig(self, configName: str) -> None:
+        """Set the current configuration to `configName`.
+
+        This actually updates the hardware state to match what is stored in the
+        preset `configName`.
+        """
+        self._mmc.setConfig(self._name, configName)
+
+    @overload
+    def getCurrentConfig(self, as_object: Literal[True]) -> Configuration:
+        ...
+
+    @overload
+    def getCurrentConfig(self, as_object: Literal[False] = False) -> str:
+        ...
+
+    def getCurrentConfig(self, as_object: bool = False) -> str | Configuration:
+        """Returns the current configuration for a given group."""
+        current = self._mmc.getCurrentConfig(self._name)
+        return self[current] if as_object else current
+
+    @overload
+    def getCurrentConfigFromCache(self, as_object: Literal[True]) -> Configuration:
+        ...
+
+    @overload
+    def getCurrentConfigFromCache(self, as_object: Literal[False] = False) -> str:
+        ...
+
+    def getCurrentConfigFromCache(self, as_object: bool = False) -> str | Configuration:
+        """Returns the current configuration for a given group from the cache."""
+        current = self._mmc.getCurrentConfigFromCache(self._name)
+        return self[current] if as_object else current
+
+    def wait(self, configName: str | None = None) -> None:
+        """Blocks until all devices included in the configuration group ready.
+
+        If `configName` not provided, then the first configuration in the group is used.
+        """
+        if configName:
+            self._mmc.waitForConfig(self._name, configName)
+            return
+
+        presets = self._mmc.getAvailableConfigs(self._name)
+        if presets:
+            self._mmc.waitForConfig(self._name, presets[0])
+
+    def rename(self, newGroupName: str) -> None:
+        """Rename this configuration group."""
+        self._mmc.renameConfigGroup(self._name, newGroupName)
+        self._name = newGroupName
+
+    def __str__(self) -> str:
+        from textwrap import indent
+
+        title = f"ConfigGroup {self._name!r}"
+        lines: list[str] = [title, "=" * len(title)]
+        for k, v in self.items():
+            lines.extend((f"{k}:", indent(str(v), "  ")))
+        return "\n".join(lines)

--- a/src/pymmcore_plus/core/_config_group.py
+++ b/src/pymmcore_plus/core/_config_group.py
@@ -13,6 +13,22 @@ if TYPE_CHECKING:
 
 
 class ConfigGroup(MutableMapping[str, Configuration]):
+    """Convenience object for dealing with a set of related Configuration objects.
+
+    This object behaves as a [`collections.abc.MutableMapping`][] of `str`
+    (configuration group name) to [`Configuration`][pymmcore_plus.Configuration]
+    objects.
+
+    It is object type returned by [`pymmcore_plus.CMMCorePlus.getConfigGroupObject`][].
+
+    Parameters
+    ----------
+    group_name : str
+        The name of the configuration group to manage.  (It needn't exist yet)
+    mmcore : CMMCorePlus
+        The core object managing this config group.
+    """
+
     def __init__(self, group_name: str, mmcore: CMMCorePlus) -> None:
         self._mmc = mmcore
         self._name = group_name

--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -658,7 +658,7 @@ class CMMCorePlus(pymmcore.CMMCore):
 
         Yields
         ------
-        Iterator[Device | str]
+        Device | str
             `Device` objects (if `as_object==True`) or device label strings.
         """
         for dev in (
@@ -719,7 +719,7 @@ class CMMCorePlus(pymmcore.CMMCore):
 
         Yields
         ------
-        Iterator[DeviceProperty | tuple[str, str]]
+        DeviceProperty | tuple[str, str]
             `DeviceProperty` objects (if `as_object==True`) or 2-tuples of (device_name,
             property_name)
         """
@@ -851,6 +851,19 @@ class CMMCorePlus(pymmcore.CMMCore):
                 "Use `allow_missing=True` to create create non-existent config groups."
             )
         return group
+
+    def iterConfigGroups(self) -> Iterator[ConfigGroup]:
+        """Iterate `ConfigGroup` objects for all configs.
+
+        :sparkles: *This method is new in `CMMCorePlus`.*
+
+        Yields
+        ------
+        ConfigGroup
+            `ConfigGroup` objects
+        """
+        for group in self.getAvailableConfigGroups():
+            yield ConfigGroup(group, mmcore=self)
 
     def getDeviceSchema(self, device_label: str) -> DeviceSchema:
         """Return JSON-schema describing device `device_label` and its properties.

--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -828,9 +828,12 @@ class CMMCorePlus(pymmcore.CMMCore):
         :sparkles: *This method is new in `CMMCorePlus`.*
 
         [`ConfigGroup`][pymmcore_plus.ConfigGroup] objects are a convenient object
-        oriented way to interact with configuration groups. They allow you to call any
-        method on `CMMCore` that normally requires a `groupName` as the first argument
-        as an argument-free method on the `ConfigGroup` object.
+        oriented way to interact with configuration groups (i.e. groups of
+        [Configuration
+        Presets](https://micro-manager.org/Micro-Manager_Configuration_Guide#configuration-presets)
+        in Micro-Manager). They allow you to call any method on `CMMCore` that normally
+        requires a `groupName` as the first argument as an argument-free method on the
+        `ConfigGroup` object.
 
         Parameters
         ----------

--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -31,6 +31,7 @@ from .._logger import logger
 from .._util import find_micromanager
 from ..mda import MDAEngine, MDARunner, PMDAEngine
 from ._config import Configuration
+from ._config_group import ConfigGroup
 from ._constants import DeviceDetectionStatus, DeviceType, PropertyType
 from ._device import Device
 from ._metadata import Metadata
@@ -818,6 +819,35 @@ class CMMCorePlus(pymmcore.CMMCore):
         }
         """
         return Device(device_label, mmcore=self)
+
+    def getConfigGroupObject(
+        self, group_name: str, allow_missing: bool = False
+    ) -> ConfigGroup:
+        """Return a `ConfigGroup` object bound to group_name on this core.
+
+        :sparkles: *This method is new in `CMMCorePlus`.*
+
+        [`ConfigGroup`][pymmcore_plus.ConfigGroup] objects are a convenient object
+        oriented way to interact with configuration groups. They allow you to call any
+        method on `CMMCore` that normally requires a `groupName` as the first argument
+        as an argument-free method on the `ConfigGroup` object.
+
+        Parameters
+        ----------
+        group_name : str
+            Configuration group name to get a config group object for.
+
+        Examples
+        --------
+
+        """
+        group = ConfigGroup(group_name, mmcore=self)
+        if not allow_missing and not group.exists():
+            raise KeyError(
+                f"Configuration group {group_name!r} does not exist. "
+                "Use `allow_missing=True` to create create non-existent config groups."
+            )
+        return group
 
     def getDeviceSchema(self, device_label: str) -> DeviceSchema:
         """Return JSON-schema describing device `device_label` and its properties.

--- a/tests/test_config_group_class.py
+++ b/tests/test_config_group_class.py
@@ -1,5 +1,5 @@
 import pytest
-from pymmcore_plus import CMMCorePlus, Configuration
+from pymmcore_plus import CMMCorePlus, ConfigGroup, Configuration
 
 
 def test_config_group():
@@ -135,3 +135,10 @@ def test_group_consistency():
     assert group.is_consistent  # 2 groups with same property
     group["Config4"] = ("Excitation", "Label", "Chroma-HQ570")
     assert not group.is_consistent  # config4 is broken
+
+
+def test_iter_config_group():
+    core = CMMCorePlus()
+    core.loadSystemConfiguration()
+    for i in core.iterConfigGroups():
+        assert isinstance(i, ConfigGroup)

--- a/tests/test_config_group_class.py
+++ b/tests/test_config_group_class.py
@@ -1,0 +1,137 @@
+import pytest
+from pymmcore_plus import CMMCorePlus, Configuration
+
+
+def test_config_group():
+    core = CMMCorePlus()
+    core.loadSystemConfiguration()
+    group = core.getConfigGroupObject("Channel")
+    assert group.exists()
+    assert group.name == "Channel"
+    assert group.core is core
+
+    assert len(group) == 4
+    assert isinstance(repr(group), str) and "ConfigGroup" in repr(group)
+    assert isinstance(str(group), str) and "Channel" in str(group)
+
+    assert set(group) == {"DAPI", "FITC", "Cy5", "Rhodamine"}
+    assert "DAPI" in group
+
+    dapi = group["DAPI"]
+    assert isinstance(dapi, Configuration)
+
+    del group["DAPI"]
+    assert "DAPI" not in group
+    with pytest.raises(KeyError, match="Group 'Channel' does not have a config 'DAPI'"):
+        group["DAPI"]
+
+
+def test_set_config():
+    core = CMMCorePlus()
+    core.loadSystemConfiguration()
+    group = core.getConfigGroupObject("Channel")
+
+    group.setConfig("DAPI")
+    group.wait()
+    assert group.getCurrentConfig() == "DAPI"
+
+    obj = list(group.getCurrentConfig(as_object=True))
+    assert obj[0] == ("Dichroic", "Label", "400DCLP")
+    assert core.getProperty("Dichroic", "Label") == "400DCLP"
+
+    group.setConfig("FITC")
+    group.wait("FITC")
+    assert group.getCurrentConfig() == "FITC"
+    assert core.getProperty("Dichroic", "Label") == "Q505LP"
+
+    assert group.getCurrentConfigFromCache() == "FITC"
+
+
+def test_config_group_create():
+    core = CMMCorePlus()
+    NAME1 = "MyGroup"
+    with pytest.raises(KeyError, match="Configuration group"):
+        group = core.getConfigGroupObject(NAME1)
+
+    group = core.getConfigGroupObject(NAME1, allow_missing=True)
+    assert not group.exists()
+    group.create()
+    assert group.exists()
+    assert not group
+    assert len(group) == 0
+    assert not list(group.iterDeviceProperties())
+
+    group.delete()
+    assert not group.exists()
+
+    group["Config"] = ("Dichroic", "Label", "Q585LP")
+    group["Config"] = ("Emission", "Label", "Chroma-HQ700")
+    # setting  as a sequence must be len 3
+    with pytest.raises(ValueError, match="Expected a 3-tuple"):
+        group["Config"] = (
+            "Emission",
+            "Label",
+        )
+
+    assert "Config" in group
+    assert list(group["Config"]) == [
+        ("Dichroic", "Label", "Q585LP"),
+        ("Emission", "Label", "Chroma-HQ700"),
+    ]
+
+    group["Config"] = {
+        ("Dichroic", "Label"): "400DCLP",
+        ("Emission", "Label"): "Chroma-HQ700",
+        ("Excitation", "Label"): "Chroma-HQ570",
+    }
+
+    # setting as a dict must be a dict of 2-tuples -> str
+    with pytest.raises(ValueError, match="Expected a dict of {\\(deviceLabel"):
+        group["Config"] = {("Dichroic",): "400DCLP"}
+
+    assert list(group["Config"]) == [
+        ("Dichroic", "Label", "400DCLP"),
+        ("Emission", "Label", "Chroma-HQ700"),
+        ("Excitation", "Label", "Chroma-HQ570"),
+    ]
+
+    group["Config"] = group["Config"]  # set directly with a config object
+    assert list(group["Config"]) == [
+        ("Dichroic", "Label", "400DCLP"),
+        ("Emission", "Label", "Chroma-HQ700"),
+        ("Excitation", "Label", "Chroma-HQ570"),
+    ]
+
+    with pytest.raises(ValueError, match="Expected a 3-tuple"):
+        group["Bad"] = 1
+    assert "Bad" not in group
+
+    group.renameConfig("Config", "NewConfig")
+    assert list(group["NewConfig"]) == [
+        ("Dichroic", "Label", "400DCLP"),
+        ("Emission", "Label", "Chroma-HQ700"),
+        ("Excitation", "Label", "Chroma-HQ570"),
+    ]
+    assert "Config" not in group
+    with pytest.raises(KeyError):
+        group.renameConfig("asdfdsf", "asdfsd")
+
+    group.rename("NewGroupName")
+    assert group.name == "NewGroupName"
+    assert "NewGroupName" in core.getAvailableConfigGroups()
+    assert NAME1 not in core.getAvailableConfigGroups()
+
+
+def test_group_consistency():
+    core = CMMCorePlus()
+    core.loadSystemConfiguration()
+    group = core.getConfigGroupObject("MyGroup", allow_missing=True)
+    group.create()
+    assert group.is_consistent  # empty group is consistent
+    group["Config"] = ("Dichroic", "Label", "Q585LP")
+    assert group.is_consistent  # 1 group is consistent
+    group["Config2"] = ("Dichroic", "Label", "Q585LP")
+    group["Config3"] = ("Dichroic", "Label", "400DCLP")
+    assert group.is_consistent  # 2 groups with same property
+    group["Config4"] = ("Excitation", "Label", "Chroma-HQ570")
+    assert not group.is_consistent  # config4 is broken

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,4 +1,3 @@
-import json
 import os
 import re
 from pathlib import Path
@@ -353,15 +352,7 @@ def test_config_create():
     assert list(cfg1) == list(cfg2) == list(cfg3) == aslist
     assert cfg1 == cfg2 == cfg3
 
-    assert cfg1.json() == json.dumps(_input)
     assert cfg1.html()
-
-
-def test_config_yaml():
-    _input = {"a": {"a0": "0", "a1": "1"}, "b": {"b0": "10", "b1": "11"}}
-    cfg1 = Configuration.create(_input)
-    yaml = pytest.importorskip("yaml")
-    assert cfg1.yaml() == yaml.safe_dump(_input)
 
 
 def test_property_schema(core: CMMCorePlus):


### PR DESCRIPTION
This adds a `ConfigGroup` object, akin to the `Device` and `Property` objects, that provide an object oriented API with a pythonic mutable mapping interface  (tests show how it works pretty well)