### PR TITLE
feat: add `mmcore` command line program

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -43,8 +43,6 @@ jobs:
 
       - name: Install Micro-Manager
         run: mmcore install
-        env:
-          PYTHONIOENCODING: utf-8
 
       - name: Test
         run: pytest -v --color=yes --cov=pymmcore_plus --cov-report=xml

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -43,6 +43,8 @@ jobs:
 
       - name: Install Micro-Manager
         run: mmcore install
+        env:
+          PYTHONIOENCODING: utf-8
 
       - name: Test
         run: pytest -v --color=yes --cov=pymmcore_plus --cov-report=xml

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -42,7 +42,7 @@ jobs:
           pip install -e .[remote,testing]
 
       - name: Install Micro-Manager
-        run: python -m pymmcore_plus.install
+        run: mmcore install
 
       - name: Test
         run: pytest -v --color=yes --cov=pymmcore_plus --cov-report=xml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,4 +43,5 @@ repos:
           - pymmcore
           - useq-schema
           - psygnal
+          - typer
         files: "^src/"

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Usually, you'll then want to install the device adapters (though
 you can also download these manually from [micro-manager.org](https://micro-manager.org/Micro-Manager_Nightly_Builds)):
 
 ```sh
-python -m pymmcore_plus.install
+mmcore install
 ```
 
 *See [installation documentation ](https://pymmcore-plus.github.io/pymmcore-plus/install/) for more details.*

--- a/docs/index.md
+++ b/docs/index.md
@@ -71,7 +71,7 @@ You will also need the micro-manager device adapters on your system.
 To get them quickly, you can run:
 
 ```bash
-python -m pymmcore_plus.install
+mmcore install
 ```
 
 > *See [install](install) for more details.*

--- a/docs/install.md
+++ b/docs/install.md
@@ -28,18 +28,18 @@ There are two ways to do this:
     micro-manager:
 
     ```bash
-    python -m pymmcore_plus.install
+    mmcore install
     ```
 
     This will download the latest release of micro-manager and place it in the
     pymmcore-plus folder.  If you would like to modify the location of the
-    installation, or the version of micro-manager to install, you can use the
-    `--dest` and `--version` flags respectively.
+    installation, or the release of micro-manager to install, you can use the
+    `--dest` and `--release` flags respectively.
 
     For more information, run:
 
     ```bash
-    python -m pymmcore_plus.install --help
+    mmcore install --help
     ```
 
 2. **Download manually from micro-manager.org**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,10 +35,12 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
+    "appdirs",
     "loguru",
     "numpy",
     "psygnal>=0.4.2",
     "pymmcore>=10.1.1.70.4",
+    "typer",
     "typing-extensions",
     "useq-schema",
     "wrapt",
@@ -71,6 +73,9 @@ dev = [
 Source = "https://github.com/pymmcore-plus/pymmcore-plus"
 Tracker = "https://github.com/pymmcore-plus/pymmcore-plus/issues"
 Documentation = "https://pymmcore-plus.github.io/pymmcore-plus"
+
+[project.scripts]
+mmcore = "pymmcore_plus._cli:main"
 
 # https://hatch.pypa.io/latest/config/metadata/
 [tool.hatch.version]
@@ -120,6 +125,7 @@ extend-ignore = [
 [tool.ruff.per-file-ignores]
 "tests/*.py" = ["D"]
 "examples/*.py" = ["D"]
+"_cli.py" = ["B008"]
 "_mmcore_plus*.py" = ["D4"]
 "docs/*.py" = ["A", "D"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "psygnal>=0.4.2",
     "pymmcore>=10.1.1.70.4",
     "typer",
+    "rich",
     "typing-extensions",
     "useq-schema",
     "wrapt",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,8 +167,7 @@ exclude_lines = [
     "raise NotImplementedError",
 ]
 [tool.coverage.run]
-omit = ["*_tests*", "*/install.py"]
-
+source = ['src/pymmcore_plus']
 
 # https://github.com/mgedmin/check-manifest#configuration
 [tool.check-manifest]

--- a/src/pymmcore_plus/__init__.py
+++ b/src/pymmcore_plus/__init__.py
@@ -45,6 +45,7 @@ __all__ = [
     "PropertyType",
     "RemoteMMCore",
     "server",
+    "__version__",
 ]
 
 

--- a/src/pymmcore_plus/_cli.py
+++ b/src/pymmcore_plus/_cli.py
@@ -135,13 +135,23 @@ def install(
             )
         url = available[release]
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-        installer = Path(tmpdir) / ("mm.dmg" if PLATFORM == "Darwin" else "mm.exe")
+    with tempfile.TemporaryDirectory() as tmpdir: 
+        installer = Path(tmpdir) / url.split("/")[-1]
         _download_url(url=url, output_path=installer)
         if PLATFORM == "Darwin":
             _mac_install(installer, dest)
         elif PLATFORM == "Windows":
-            _win_install(installer, dest)
+            # for windows, we need to know the latest version
+            import cgi
+        
+            with urlopen(url) as tmp:
+                blah = tmp.info().get('Content-Disposition')
+                _, params = cgi.parse_header(blah)
+                filename = params["filename"]
+                filename = filename.replace("MMSetup_64bit", "Micro-Manager")
+                filename = filename.replace(".exe", "")
+
+            _win_install(installer, dest / filename)
 
     print(f":sparkles: [bold green]Installed to {dest}![/bold green] :sparkles:")
 

--- a/src/pymmcore_plus/_cli.py
+++ b/src/pymmcore_plus/_cli.py
@@ -147,18 +147,22 @@ def install(
             _mac_install(installer, dest)
         elif PLATFORM == "Windows":
             # for windows, we need to know the latest version
-            import cgi
-
-            with urlopen(url) as tmp:
-                blah = tmp.info().get("Content-Disposition")
-                _, params = cgi.parse_header(blah)
-                filename = params["filename"]
-                filename = filename.replace("MMSetup_64bit", "Micro-Manager")
-                filename = filename.replace(".exe", "")
-
+            filename = _get_download_name(url)
+            filename = filename.replace("MMSetup_64bit", "Micro-Manager")
+            filename = filename.replace(".exe", "")
             _win_install(installer, dest / filename)
 
     print(f":sparkles: [bold green]Installed to {dest}![/bold green] :sparkles:")
+
+
+def _get_download_name(url: str) -> str:
+    """Return the name of the file to be downloaded from `url`."""
+    with urlopen(url) as tmp:
+        content: str = tmp.headers.get("Content-Disposition")
+        for part in content.split(";"):
+            if "filename=" in part:
+                return part.split("=")[1].strip('"')
+    return ""
 
 
 @contextmanager

--- a/src/pymmcore_plus/_cli.py
+++ b/src/pymmcore_plus/_cli.py
@@ -2,6 +2,7 @@ import os
 import re
 import shutil
 import subprocess
+import sys
 import tempfile
 from contextlib import contextmanager, suppress
 from pathlib import Path
@@ -14,7 +15,6 @@ import typer
 from pymmcore_plus._logger import set_log_level
 from pymmcore_plus._util import USER_DATA_MM_PATH
 from rich import print, progress
-
 
 PLATFORM = system()
 BASE_URL = "https://download.micro-manager.org"
@@ -47,6 +47,10 @@ def _main(
 
     For additional help on a specific command: type 'mmcore [command] --help'
     """
+    # fix for windows CI encoding and emoji printing
+    if getattr(sys.stdout, "encoding", None) != "utf-8":
+        with suppress(AttributeError):
+            sys.stdout.reconfigure(encoding="utf-8")  # type: ignore [attr-defined]
 
 
 _main.__doc__ = typer.style(
@@ -118,7 +122,8 @@ def install(
     if PLATFORM not in ("Darwin", "Windows"):
         print(f":x: [bold red]Unsupported platform: {PLATFORM!r}")
         raise typer.Exit(1)
-
+    print("hi")
+    return
     if release == "latest":
         plat = {
             "Darwin": "macos/Micro-Manager-x86_64-latest.dmg",

--- a/src/pymmcore_plus/_cli.py
+++ b/src/pymmcore_plus/_cli.py
@@ -97,9 +97,10 @@ def find() -> None:
             for p in rest:
                 print(f"   • [cyan]{p}")
         raise typer.Exit(0)
-    print(":x: [bold red]No Micro-Manager installation found")
-    print("[magenta]run `mmcore install` to install a version of Micro-Manager")
-    raise typer.Exit(1)
+    else:  # pragma: no cover
+        print(":x: [bold red]No Micro-Manager installation found")
+        print("[magenta]run `mmcore install` to install a version of Micro-Manager")
+        raise typer.Exit(1)
 
 
 @app.command()
@@ -119,7 +120,7 @@ def install(
     ),
 ) -> None:
     """Install Micro-Manager Device adapters."""
-    if PLATFORM not in ("Darwin", "Windows"):
+    if PLATFORM not in ("Darwin", "Windows"):  # pragma: no cover
         print(f":x: [bold red]Unsupported platform: {PLATFORM!r}")
         raise typer.Exit(1)
 
@@ -187,7 +188,7 @@ def _mac_install(dmg: Path, dest: Path) -> None:
             ["hdiutil", "attach", "-nobrowse", str(dmg)],
             capture_output=True,
         )
-        if proc.returncode != 0:
+        if proc.returncode != 0:  # pragma: no cover
             typer.secho(
                 f"\nError mounting {dmg.name}:\n{proc.stderr.decode()}",
                 fg="bright_red",
@@ -201,7 +202,7 @@ def _mac_install(dmg: Path, dest: Path) -> None:
         try:
             try:
                 src = next(Path(mount).glob("Micro-Manager*"))
-            except StopIteration:
+            except StopIteration:  # pragma: no cover
                 typer.secho(
                     "\nError: Could not find Micro-Manager in dmg.\n"
                     "Please report this at https://github.com/pymmcore-plus/"

--- a/src/pymmcore_plus/_cli.py
+++ b/src/pymmcore_plus/_cli.py
@@ -99,8 +99,12 @@ def mmgui() -> None:
     """Run the Java Micro-Manager GUI for the MM install returned by `mmcore find`."""
     import subprocess
 
-    found = pymmcore_plus.find_micromanager()
-    app = next(Path(found).glob("ImageJ*"), None) if found else None
+    mm = pymmcore_plus.find_micromanager()
+    app = (
+        next((x for x in Path(mm).glob("ImageJ*") if not str(x).endswith("cfg")), None)
+        if mm
+        else None
+    )
     if not app:  # pragma: no cover
         print(":x: [bold red]No Micro-Manager installation found")
         print("[magenta]run `mmcore install` to install a version of Micro-Manager")

--- a/src/pymmcore_plus/_cli.py
+++ b/src/pymmcore_plus/_cli.py
@@ -122,8 +122,7 @@ def install(
     if PLATFORM not in ("Darwin", "Windows"):
         print(f":x: [bold red]Unsupported platform: {PLATFORM!r}")
         raise typer.Exit(1)
-    print("hi")
-    return
+
     if release == "latest":
         plat = {
             "Darwin": "macos/Micro-Manager-x86_64-latest.dmg",

--- a/src/pymmcore_plus/_cli.py
+++ b/src/pymmcore_plus/_cli.py
@@ -8,8 +8,8 @@ import pymmcore_plus
 import typer
 from pymmcore_plus._logger import set_log_level
 from pymmcore_plus._util import USER_DATA_MM_PATH
+from pymmcore_plus.install import PLATFORM
 from rich import print
-
 
 app = typer.Typer(no_args_is_help=True, add_completion=False)
 
@@ -92,6 +92,21 @@ def find() -> None:
         print(":x: [bold red]No Micro-Manager installation found")
         print("[magenta]run `mmcore install` to install a version of Micro-Manager")
         raise typer.Exit(1)
+
+
+@app.command()
+def mmgui() -> None:
+    """Run the Java Micro-Manager GUI for the MM install returned by `mmcore find`."""
+    import subprocess
+
+    found = pymmcore_plus.find_micromanager()
+    app = next(Path(found).glob("ImageJ*"), None) if found else None
+    if not app:  # pragma: no cover
+        print(":x: [bold red]No Micro-Manager installation found")
+        print("[magenta]run `mmcore install` to install a version of Micro-Manager")
+        raise typer.Exit(1)
+    cmd = ["open", "-a", str(app)] if PLATFORM == "Darwin" else [str(app)]
+    raise typer.Exit(subprocess.run(cmd).returncode)
 
 
 @app.command()

--- a/src/pymmcore_plus/_cli.py
+++ b/src/pymmcore_plus/_cli.py
@@ -1,24 +1,15 @@
-import os
-import re
 import shutil
-import subprocess
 import sys
-import tempfile
-from contextlib import contextmanager, suppress
+from contextlib import suppress
 from pathlib import Path
-from platform import system
-from typing import Dict, Iterator, Optional
-from urllib.request import urlopen, urlretrieve
+from typing import Optional
 
 import pymmcore_plus
 import typer
 from pymmcore_plus._logger import set_log_level
 from pymmcore_plus._util import USER_DATA_MM_PATH
-from rich import print, progress
+from rich import print
 
-PLATFORM = system()
-BASE_URL = "https://download.micro-manager.org"
-_list = list
 
 app = typer.Typer(no_args_is_help=True, add_completion=False)
 
@@ -71,8 +62,8 @@ def clean() -> None:
         print(":sparkles: [bold green]No files to remove.")
 
 
-@app.command()
-def list() -> None:  # noqa: A001
+@app.command(name="list")
+def _list() -> None:
     """Show all Micro-Manager installs downloaded by pymmcore-plus."""
     if USER_DATA_MM_PATH.exists():
         print(f":file_folder:[bold green] {USER_DATA_MM_PATH}")
@@ -120,159 +111,9 @@ def install(
     ),
 ) -> None:
     """Install Micro-Manager Device adapters."""
-    if PLATFORM not in ("Darwin", "Windows"):  # pragma: no cover
-        print(f":x: [bold red]Unsupported platform: {PLATFORM!r}")
-        raise typer.Exit(1)
+    import pymmcore_plus.install
 
-    if release == "latest":
-        plat = {
-            "Darwin": "macos/Micro-Manager-x86_64-latest.dmg",
-            "Windows": "windows/MMSetup_x64_latest.exe",
-        }[PLATFORM]
-        url = f"{BASE_URL}/latest/{plat}"
-    else:
-        available = _available_versions()
-        if release not in available:
-            n = 15
-            avail = ", ".join(_list(available)[:n]) + " ..."
-            raise typer.BadParameter(
-                f"Release {release!r} not found. Last {n} releases:\n{avail}"
-            )
-        url = available[release]
-
-    with tempfile.TemporaryDirectory() as tmpdir:
-        installer = Path(tmpdir) / url.split("/")[-1]
-        _download_url(url=url, output_path=installer)
-        if PLATFORM == "Darwin":
-            _mac_install(installer, dest)
-        elif PLATFORM == "Windows":
-            # for windows, we need to know the latest version
-            filename = _get_download_name(url)
-            filename = filename.replace("MMSetup_64bit", "Micro-Manager")
-            filename = filename.replace(".exe", "")
-            _win_install(installer, dest / filename)
-
-    print(f":sparkles: [bold green]Installed to {dest}![/bold green] :sparkles:")
-
-
-def _get_download_name(url: str) -> str:
-    """Return the name of the file to be downloaded from `url`."""
-    with urlopen(url) as tmp:
-        content: str = tmp.headers.get("Content-Disposition")
-        for part in content.split(";"):
-            if "filename=" in part:
-                return part.split("=")[1].strip('"')
-    return ""
-
-
-@contextmanager
-def _spinner(
-    text: str = "Processing...", color: str = "bold blue"
-) -> Iterator[progress.Progress]:
-    with progress.Progress(
-        progress.SpinnerColumn(),
-        progress.TextColumn(f"[{color}]{text}"),
-        transient=True,
-    ) as pbar:
-        pbar.add_task(description=text, total=None)
-        yield pbar
-
-
-def _win_install(exe: Path, dest: Path) -> None:
-    cmd = [str(exe), "/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART", f"/DIR={dest}"]
-    with _spinner("Installing ..."):
-        subprocess.run(cmd, check=True)
-
-
-def _mac_install(dmg: Path, dest: Path) -> None:
-    """Install Micro-Manager `dmg` to `dest`."""
-    # with progress bar, mount dmg
-    with _spinner("Mounting ..."):
-        proc = subprocess.run(
-            ["hdiutil", "attach", "-nobrowse", str(dmg)],
-            capture_output=True,
-        )
-        if proc.returncode != 0:  # pragma: no cover
-            typer.secho(
-                f"\nError mounting {dmg.name}:\n{proc.stderr.decode()}",
-                fg="bright_red",
-            )
-            raise typer.Exit(code=proc.returncode)
-
-    # with progress bar, mount dmg
-    with _spinner(f"Installing to {dest} ..."):
-        # get mount point
-        mount = proc.stdout.splitlines()[-1].split()[-1].decode()
-        try:
-            try:
-                src = next(Path(mount).glob("Micro-Manager*"))
-            except StopIteration:  # pragma: no cover
-                typer.secho(
-                    "\nError: Could not find Micro-Manager in dmg.\n"
-                    "Please report this at https://github.com/pymmcore-plus/"
-                    "pymmcore-plus/issues/new",
-                    fg="bright_red",
-                )
-                raise typer.Exit(code=1) from None
-            install_path = dest / src.name
-            shutil.copytree(src, install_path, dirs_exist_ok=True)
-        finally:
-            subprocess.run(
-                ["hdiutil", "detach", mount], check=True, capture_output=True
-            )
-
-    # fix gatekeeper ... requires password
-    typer.secho(
-        "(Your password may be required to install Micro-manager.)",
-        fg=typer.colors.GREEN,
-    )
-    cmd = ["sudo", "xattr", "-r", "-d", "com.apple.quarantine", str(install_path)]
-    subprocess.run(cmd, check=True)
-
-    # # fix path randomization by temporarily copying elsewhere and back
-    with tempfile.TemporaryDirectory() as tmpdir:
-        _tmp = Path(tmpdir)
-        os.rename(install_path / "ImageJ.app", _tmp / "ImageJ.app")
-        os.rename(_tmp / "ImageJ.app", install_path / "ImageJ.app")
-
-
-def _available_versions() -> Dict[str, str]:
-    """Return a map of version -> url available for download."""
-    plat = {"Darwin": "Mac", "Windows": "Windows"}[PLATFORM]
-    with urlopen(f"{BASE_URL}/nightly/2.0/{plat}/") as resp:
-        html = resp.read().decode("utf-8")
-
-    return {
-        ref.rsplit("-", 1)[-1].split(".")[0]: BASE_URL + ref
-        for ref in re.findall(r"href=\"([^\"]+)\"", html)
-        if ref != "/"
-    }
-
-
-def _download_url(url: str, output_path: Path) -> None:
-    """Download `url` to `output_path` with a nice progress bar."""
-    import ssl
-
-    ctx = ssl.create_default_context()
-    ctx.check_hostname = False
-    ctx.verify_mode = ssl.CERT_NONE
-
-    pbar = progress.Progress(
-        progress.BarColumn(bar_width=None),
-        "[progress.percentage]{task.percentage:>3.1f}%",
-        "•",
-        progress.DownloadColumn(),
-    )
-    task_id = pbar.add_task("Download..", filename=output_path.name, start=False)
-
-    def hook(count: float, block_size: float, total_size: float) -> None:
-        pbar.update(task_id, total=int(total_size))
-        pbar.start_task(task_id)
-        pbar.update(task_id, advance=block_size)
-
-    print(f"[bold blue]Downloading {url} ...")
-    with pbar:
-        urlretrieve(url=url, filename=output_path, reporthook=hook)
+    pymmcore_plus.install._install(dest, release)
 
 
 def main() -> None:

--- a/src/pymmcore_plus/_cli.py
+++ b/src/pymmcore_plus/_cli.py
@@ -1,0 +1,225 @@
+import os
+import re
+import shutil
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from platform import system
+from typing import Iterator, Optional
+from urllib.request import urlopen, urlretrieve
+
+import pymmcore_plus
+import typer
+from pymmcore_plus._util import USER_DATA_MM_PATH
+from rich import print, progress
+
+PLATFORM = system()
+
+BASE_URL = "https://download.micro-manager.org"
+_list = list
+
+app = typer.Typer(no_args_is_help=True, add_completion=False)
+
+
+def _show_version_and_exit(value: bool) -> None:
+    if value:
+        import pymmcore
+
+        typer.echo(f"pymmcore-plus v{pymmcore_plus.__version__}")
+        typer.echo(f"pymmcore v{pymmcore.__version__}")  # type: ignore [attr-defined]
+        typer.echo(f"MMCore v{pymmcore.CMMCore().getAPIVersionInfo()}")
+        raise typer.Exit()
+
+
+@app.callback()
+def _main(
+    version: Optional[bool] = typer.Option(
+        None,
+        "--version",
+        callback=_show_version_and_exit,
+        help="Show version and exit.",
+        is_eager=True,
+    ),
+) -> None:
+    """mmcore: pymmcore-plus command line (v{version}).
+
+    For additional help on a specific command: type 'mmcore [command] --help'
+    """
+
+
+_main.__doc__ = typer.style(
+    (_main.__doc__ or "").format(version=pymmcore_plus.__version__),
+    fg=typer.colors.BRIGHT_YELLOW,
+)
+
+
+@app.command()
+def clean() -> None:
+    """Remove all Micro-Manager installs downloaded by pymmcore-plus."""
+    if USER_DATA_MM_PATH.exists():
+        for p in USER_DATA_MM_PATH.iterdir():
+            shutil.rmtree(p, ignore_errors=True)
+            print(f":wastebasket: [bold red] {p.name}")
+        shutil.rmtree(USER_DATA_MM_PATH, ignore_errors=True)
+    else:
+        print(":sparkles: [bold green]No files to remove.")
+
+
+@app.command()
+def list() -> None:  # noqa: A001
+    """Show all Micro-Manager installs downloaded by pymmcore-plus."""
+    if USER_DATA_MM_PATH.exists():
+        print(f":file_folder:[bold green] {USER_DATA_MM_PATH}")
+        for path in USER_DATA_MM_PATH.iterdir():
+            print(f"   • [cyan]{path.name}")
+    else:
+        print(":sparkles: [bold green]There are no pymmcore-plus Micro-Manager files.")
+
+
+@app.command()
+def install(
+    dest: Path = typer.Option(
+        USER_DATA_MM_PATH,
+        "-d",
+        "--dest",
+        file_okay=False,
+        dir_okay=True,
+        writable=True,
+        resolve_path=True,
+        help="Installation directory.",
+    ),
+    release: str = typer.Option(
+        "latest", "-r", "--release", help="Release date. e.g. 20210201"
+    ),
+) -> None:
+    """Install Micro-Manager Device adapters."""
+    if release == "latest":
+        plat = {
+            "Darwin": "macos/Micro-Manager-x86_64-latest.dmg",
+            "Windows": "windows/MMSetup_x64_latest.exe",
+        }[PLATFORM]
+        url = f"{BASE_URL}/latest/{plat}"
+    else:
+        available = _available_versions()
+        if release not in available:
+            n = 15
+            avail = ", ".join(_list(available)[:n]) + " ..."
+            raise typer.BadParameter(
+                f"Release {release!r} not found. Last {n} releases:\n{avail}"
+            )
+        url = available[release]
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _tmp_dest = Path(tmpdir) / "mm"
+        _download_url(url=url, output_path=_tmp_dest)
+        _mac_install(_tmp_dest, dest)
+
+    print(f":sparkles: [bold green]Installed to {dest}![/bold green] :sparkles:")
+
+
+@contextmanager
+def _spinner(
+    text: str = "Processing...", color: str = "bold blue"
+) -> Iterator[progress.Progress]:
+    with progress.Progress(
+        progress.SpinnerColumn(),
+        progress.TextColumn(f"[{color}]{text}"),
+        transient=True,
+    ) as pbar:
+        pbar.add_task(description=text, total=None)
+        yield pbar
+
+
+def _mac_install(dmg: Path, dest: Path) -> None:
+    """Install Micro-Manager `dmg` to `dest`."""
+    from subprocess import run
+
+    # with progress bar, mount dmg
+    with _spinner("Mounting ..."):
+        proc = run(
+            ["hdiutil", "attach", "-nobrowse", str(dmg)],
+            capture_output=True,
+        )
+        if proc.returncode != 0:
+            typer.secho(
+                f"\nError mounting {dmg.name}:\n{proc.stderr.decode()}",
+                fg="bright_red",
+            )
+            raise typer.Exit(code=proc.returncode)
+
+    # with progress bar, mount dmg
+    with _spinner(f"Installing to {dest} ..."):
+        # get mount point
+        mount = proc.stdout.splitlines()[-1].split()[-1].decode()
+        try:
+            try:
+                src = next(Path(mount).glob("Micro-Manager*"))
+            except StopIteration:
+                typer.secho(
+                    "\nError: Could not find Micro-Manager in dmg.\n"
+                    "Please report this at https://github.com/pymmcore-plus/"
+                    "pymmcore-plus/issues/new",
+                    fg="bright_red",
+                )
+                raise typer.Exit(code=1) from None
+            install_path = dest / src.name
+            shutil.copytree(src, install_path, dirs_exist_ok=True)
+        finally:
+            run(["hdiutil", "detach", mount], check=True, capture_output=True)
+
+    # fix gatekeeper ... requires password
+    typer.secho(
+        "(Your password may be required to install Micro-manager.)",
+        fg=typer.colors.GREEN,
+    )
+    cmd = ["sudo", "xattr", "-r", "-d", "com.apple.quarantine", str(install_path)]
+    run(cmd, check=True)
+
+    # # fix path randomization by temporarily copying elsewhere and back
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _tmp = Path(tmpdir)
+        os.rename(install_path / "ImageJ.app", _tmp / "ImageJ.app")
+        os.rename(_tmp / "ImageJ.app", install_path / "ImageJ.app")
+
+
+def _available_versions() -> dict[str, str]:
+    """Return a map of version -> url available for download."""
+    plat = {"Darwin": "Mac", "Windows": "Windows"}[PLATFORM]
+    with urlopen(f"{BASE_URL}/nightly/2.0/{plat}/") as resp:
+        html = resp.read().decode("utf-8")
+
+    return {
+        ref.rsplit("-", 1)[-1].split(".")[0]: BASE_URL + ref
+        for ref in re.findall(r"href=\"([^\"]+)\"", html)
+        if ref != "/"
+    }
+
+
+def _download_url(url: str, output_path: Path = Path("thing")) -> None:
+    """Download `url` to `output_path` with a nice progress bar."""
+    import ssl
+
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+
+    pbar = progress.Progress(
+        progress.BarColumn(bar_width=None),
+        "[progress.percentage]{task.percentage:>3.1f}%",
+        "•",
+        progress.DownloadColumn(),
+    )
+    task_id = pbar.add_task("Download..", filename=output_path.name, start=False)
+
+    def hook(count: float, block_size: float, total_size: float) -> None:
+        pbar.update(task_id, total=int(total_size))
+        pbar.start_task(task_id)
+        pbar.update(task_id, advance=block_size)
+
+    print(f"[bold blue]Downloading {url} ...")
+    with pbar:
+        urlretrieve(url=url, filename=output_path, reporthook=hook)
+
+
+def main() -> None:
+    app()

--- a/src/pymmcore_plus/_cli.py
+++ b/src/pymmcore_plus/_cli.py
@@ -5,7 +5,7 @@ import tempfile
 from contextlib import contextmanager, suppress
 from pathlib import Path
 from platform import system
-from typing import Iterator, Optional
+from typing import Dict, Iterator, Optional
 from urllib.request import urlopen, urlretrieve
 
 import pymmcore_plus
@@ -203,7 +203,7 @@ def _mac_install(dmg: Path, dest: Path) -> None:
         os.rename(_tmp / "ImageJ.app", install_path / "ImageJ.app")
 
 
-def _available_versions() -> dict[str, str]:
+def _available_versions() -> Dict[str, str]:
     """Return a map of version -> url available for download."""
     plat = {"Darwin": "Mac", "Windows": "Windows"}[PLATFORM]
     with urlopen(f"{BASE_URL}/nightly/2.0/{plat}/") as resp:

--- a/src/pymmcore_plus/_cli.py
+++ b/src/pymmcore_plus/_cli.py
@@ -136,12 +136,12 @@ def install(
         url = available[release]
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        _tmp_dest = Path(tmpdir) / "mm"
-        _download_url(url=url, output_path=_tmp_dest)
+        installer = Path(tmpdir) / ("mm.dmg" if PLATFORM == "Darwin" else "mm.exe")
+        _download_url(url=url, output_path=installer)
         if PLATFORM == "Darwin":
-            _mac_install(_tmp_dest, dest)
+            _mac_install(installer, dest)
         elif PLATFORM == "Windows":
-            _win_install(_tmp_dest, dest)
+            _win_install(installer, dest)
 
     print(f":sparkles: [bold green]Installed to {dest}![/bold green] :sparkles:")
 
@@ -160,11 +160,9 @@ def _spinner(
 
 
 def _win_install(exe: Path, dest: Path) -> None:
+    cmd = [str(exe), "/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART", f"/DIR={dest}"]
     with _spinner("Installing ..."):
-        subprocess.run(
-            [str(exe), "/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART", f"/DIR={dest}"],
-            check=True,
-        )
+        subprocess.run(cmd, check=True)
 
 
 def _mac_install(dmg: Path, dest: Path) -> None:
@@ -232,7 +230,7 @@ def _available_versions() -> Dict[str, str]:
     }
 
 
-def _download_url(url: str, output_path: Path = Path("thing")) -> None:
+def _download_url(url: str, output_path: Path) -> None:
     """Download `url` to `output_path` with a nice progress bar."""
     import ssl
 

--- a/src/pymmcore_plus/_cli.py
+++ b/src/pymmcore_plus/_cli.py
@@ -160,10 +160,11 @@ def _spinner(
 
 
 def _win_install(exe: Path, dest: Path) -> None:
-    subprocess.run(
-        [exe, "/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART", f"/DIR={dest}"],
-        check=True,
-    )
+    with _spinner("Installing ..."):
+        subprocess.run(
+            [str(exe), "/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART", f"/DIR={dest}"],
+            check=True,
+        )
 
 
 def _mac_install(dmg: Path, dest: Path) -> None:

--- a/src/pymmcore_plus/_cli.py
+++ b/src/pymmcore_plus/_cli.py
@@ -135,7 +135,7 @@ def install(
             )
         url = available[release]
 
-    with tempfile.TemporaryDirectory() as tmpdir: 
+    with tempfile.TemporaryDirectory() as tmpdir:
         installer = Path(tmpdir) / url.split("/")[-1]
         _download_url(url=url, output_path=installer)
         if PLATFORM == "Darwin":
@@ -143,9 +143,9 @@ def install(
         elif PLATFORM == "Windows":
             # for windows, we need to know the latest version
             import cgi
-        
+
             with urlopen(url) as tmp:
-                blah = tmp.info().get('Content-Disposition')
+                blah = tmp.info().get("Content-Disposition")
                 _, params = cgi.parse_header(blah)
                 filename = params["filename"]
                 filename = filename.replace("MMSetup_64bit", "Micro-Manager")

--- a/src/pymmcore_plus/_util.py
+++ b/src/pymmcore_plus/_util.py
@@ -28,7 +28,7 @@ def find_micromanager(return_first: Literal[False]) -> list[str]:
 
 
 def find_micromanager(return_first: bool = True) -> str | None | list[str]:
-    """Locate a Micro-Manager folder (for device adapters).
+    r"""Locate a Micro-Manager folder (for device adapters).
 
     In order, this will look for:
 
@@ -36,7 +36,7 @@ def find_micromanager(return_first: bool = True) -> str | None | list[str]:
     2. A `Micro-Manager*` folder in the `pymmcore-plus` user data directory
        (this is the default install location when running `mmcore install`)
 
-        - **Windows**: C:\\Users\\\<user\>\\AppData\\Local\\pymmcore-plus\\pymmcore-plus
+        - **Windows**: C:\Users\\[user]\AppData\Local\pymmcore-plus\pymmcore-plus
         - **macOS**: ~/Library/Application Support/pymmcore-plus
         - **Linux**: ~/.local/share/pymmcore-plus
 

--- a/src/pymmcore_plus/_util.py
+++ b/src/pymmcore_plus/_util.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import importlib
 import os
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import Literal, overload
 
 import appdirs
 
@@ -12,17 +14,36 @@ __all__ = ["find_micromanager", "_qt_app_is_running"]
 
 USER_DATA_DIR = Path(appdirs.user_data_dir(appname="pymmcore-plus"))
 USER_DATA_MM_PATH = USER_DATA_DIR / "mm"
+PYMMCORE_PLUS_PATH = Path(__file__).parent.parent
 
 
-def find_micromanager() -> Optional[str]:
+@overload
+def find_micromanager(return_first: Literal[True] = True) -> str | None:
+    ...
+
+
+@overload
+def find_micromanager(return_first: Literal[False]) -> list[str]:
+    ...
+
+
+def find_micromanager(return_first: bool = True) -> str | None | list[str]:
     """Locate a Micro-Manager folder (for device adapters).
 
     In order, this will look for:
 
     1. An environment variable named `MICROMANAGER_PATH`
-    2. An installation in the `pymmcore_plus` package directory (this is the
+    2. In the pymmcore-plus user data directory (this is the default install location
+        when running `mmcore install`)
+
+        - ~/Library/Application Support/pymmcore-plus (macOS)
+        - ~/.local/share/pymmcore-plus (Linux)
+        - C:\\Users\\\<user\>\\AppData\\Local\\pymmcore-plus\\pymmcore-plus (Windows)
+
+    3. A `Micro-Manager*` folder in the `pymmcore_plus` package directory (this is the
        default install location when running `python -m pymmcore_plus.install`)
-    3. The default micro-manager install location:
+    4. The default micro-manager install location:
+
         - `C:/Program Files/` on windows
         - `/Applications` on mac
         - `/usr/local/lib` on linux
@@ -36,34 +57,51 @@ def find_micromanager() -> Optional[str]:
         when creating a new `CMMCorePlus` instance.
     """
     # environment variable takes precedence
+    full_list: list[str] = []
     env_path = os.getenv("MICROMANAGER_PATH")
     if env_path and os.path.isdir(env_path):
-        logger.debug(f"using MM path from env var: {env_path}")
-        return env_path
+        if return_first:
+            logger.debug(f"using MM path from env var: {env_path}")
+            return env_path
+        full_list.append(env_path)
+
+    # then look in appdirs.user_data_dir
+    user_install = sorted(USER_DATA_MM_PATH.glob("Micro-Manager*"), reverse=True)
+    if user_install:
+        if return_first:
+            logger.debug(f"using MM path from user install: {user_install[0]}")
+            return str(user_install[0])
+        full_list.extend([str(x) for x in user_install])
+
     # then look for an installation in this folder (from `pymmcore_plus.install`)
     sfx = "_win" if os.name == "nt" else "_mac"
-    local_install = list(Path(__file__).parent.parent.glob(f"**/Micro-Manager*{sfx}"))
+    local_install = list(PYMMCORE_PLUS_PATH.glob(f"**/Micro-Manager*{sfx}"))
     if local_install:
-        logger.debug(f"using MM path from local install: {local_install[0]}")
-        return str(local_install[0])
+        if return_first:
+            logger.debug(f"using MM path from local install: {local_install[0]}")
+            return str(local_install[0])
+        full_list.extend([str(x) for x in local_install])
 
     applications = {
         "darwin": Path("/Applications/"),
         "win32": Path("C:/Program Files/"),
         "linux": Path("/usr/local/lib"),
     }
-    try:
-        app_path = applications[sys.platform]
-        pth = str(next(app_path.glob("[m,M]icro-[m,M]anager*")))
-        logger.debug(f"using MM path found in applications: {pth}")
-        return pth
-    except KeyError as e:
+    if sys.platform not in applications:
         raise NotImplementedError(
             f"MM autodiscovery not implemented for platform: {sys.platform}"
-        ) from e
-    except StopIteration:
-        logger.error(f"could not find micromanager directory in {app_path}")
-        return None
+        )
+    app_path = applications[sys.platform]
+    pth = next(app_path.glob("[m,M]icro-[m,M]anager*"), None)
+    if return_first:
+        if pth is None:
+            logger.error(f"could not find micromanager directory in {app_path}")
+            return None
+        logger.debug(f"using MM path found in applications: {pth}")
+        return str(pth)
+    if pth is not None:
+        full_list.append(str(pth))
+    return full_list
 
 
 def _qt_app_is_running() -> bool:

--- a/src/pymmcore_plus/_util.py
+++ b/src/pymmcore_plus/_util.py
@@ -33,20 +33,20 @@ def find_micromanager(return_first: bool = True) -> str | None | list[str]:
     In order, this will look for:
 
     1. An environment variable named `MICROMANAGER_PATH`
-    2. In the pymmcore-plus user data directory (this is the default install location
-        when running `mmcore install`)
+    2. A `Micro-Manager*` folder in the `pymmcore-plus` user data directory
+       (this is the default install location when running `mmcore install`)
 
-        - ~/Library/Application Support/pymmcore-plus (macOS)
-        - ~/.local/share/pymmcore-plus (Linux)
-        - C:\\Users\\\<user\>\\AppData\\Local\\pymmcore-plus\\pymmcore-plus (Windows)
+        - **Windows**: C:\\Users\\\<user\>\\AppData\\Local\\pymmcore-plus\\pymmcore-plus
+        - **macOS**: ~/Library/Application Support/pymmcore-plus
+        - **Linux**: ~/.local/share/pymmcore-plus
 
     3. A `Micro-Manager*` folder in the `pymmcore_plus` package directory (this is the
        default install location when running `python -m pymmcore_plus.install`)
     4. The default micro-manager install location:
 
-        - `C:/Program Files/` on windows
-        - `/Applications` on mac
-        - `/usr/local/lib` on linux
+        - **Windows**: `C:/Program Files/`
+        - **macOS**: `/Applications`
+        - **Linux**: `/usr/local/lib`
 
     !!! note
 
@@ -55,6 +55,12 @@ def find_micromanager(return_first: bool = True) -> str | None | list[str]:
         is passed to
         [`setDeviceAdapterSearchPaths`][pymmcore_plus.CMMCorePlus.setDeviceAdapterSearchPaths]
         when creating a new `CMMCorePlus` instance.
+
+    Parameters
+    ----------
+    return_first : bool, optional
+        If True (default), return the first found path.  If False, return a list of
+        all found paths.
     """
     # environment variable takes precedence
     full_list: list[str] = []

--- a/src/pymmcore_plus/_util.py
+++ b/src/pymmcore_plus/_util.py
@@ -4,9 +4,14 @@ import sys
 from pathlib import Path
 from typing import Optional
 
+import appdirs
+
 from ._logger import logger
 
 __all__ = ["find_micromanager", "_qt_app_is_running"]
+
+USER_DATA_DIR = Path(appdirs.user_data_dir(appname="pymmcore-plus"))
+USER_DATA_MM_PATH = USER_DATA_DIR / "mm"
 
 
 def find_micromanager() -> Optional[str]:

--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -129,7 +129,8 @@ class CMMCorePlus(pymmcore.CMMCore):
     Parameters
     ----------
     mm_path : str | None, optional
-        Path to the Micro-Manager installation, by default None
+        Path to the Micro-Manager installation. If `None` (default), will use the
+        return value of [`pymmcore_plus.find_micromanager`][].
     adapter_paths : Sequence[str], optional
         Paths to search for device adapters, by default ()
     """

--- a/src/pymmcore_plus/install.py
+++ b/src/pymmcore_plus/install.py
@@ -192,7 +192,7 @@ def _release(value: str) -> str:
     return str(value)
 
 
-def main() -> None:
+def main() -> None:  # pragma: no cover
     """Main entry point for the console_scripts."""
     import argparse
 

--- a/src/pymmcore_plus/install.py
+++ b/src/pymmcore_plus/install.py
@@ -4,125 +4,169 @@ import os
 import re
 import shutil
 import ssl
-import urllib.request
+import subprocess
+import sys
+import tempfile
+from contextlib import contextmanager
 from pathlib import Path
-from subprocess import run
+from platform import system
+from typing import Iterator
+from urllib.request import urlopen, urlretrieve
 
+import typer
+from pymmcore_plus._util import USER_DATA_MM_PATH
+from rich import print, progress
+
+PLATFORM = system()
+BASE_URL = "https://download.micro-manager.org"
 _version_regex = re.compile(r"(\d+\.){2}\d+")
-VERSION = "2.0.1"
-RELEASE = 20211007
-DEFAULT_DEST = Path(__file__).parent
-
-ssl._create_default_https_context = ssl._create_unverified_context
 
 
-def _progressBar(
-    current: float, chunksize: float, total: float, barLength: int = 40
-) -> None:
-    percent = float(current * chunksize) * 100 / total
-    arrow = "-" * int(percent / 100 * barLength - 1) + ">"
-    spaces = " " * (barLength - len(arrow))
-    if not os.getenv("CI"):
-        print("Progress: [%s%s] %d %%" % (arrow, spaces, percent), end="\r")
+def _get_download_name(url: str) -> str:
+    """Return the name of the file to be downloaded from `url`."""
+    with urlopen(url) as tmp:
+        content: str = tmp.headers.get("Content-Disposition")
+        for part in content.split(";"):
+            if "filename=" in part:
+                return part.split("=")[1].strip('"')
+    return ""
 
 
-def _download_url(url: str, output_path: str) -> None:
-    print(f"downloading {url} ...")
+@contextmanager
+def _spinner(
+    text: str = "Processing...", color: str = "bold blue"
+) -> Iterator[progress.Progress]:
+    with progress.Progress(
+        progress.SpinnerColumn(),
+        progress.TextColumn(f"[{color}]{text}"),
+        transient=True,
+    ) as pbar:
+        pbar.add_task(description=text, total=None)
+        yield pbar
+
+
+def _win_install(exe: Path, dest: Path) -> None:
+    cmd = [str(exe), "/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART", f"/DIR={dest}"]
+    with _spinner("Installing ..."):
+        subprocess.run(cmd, check=True)
+
+
+def _mac_install(dmg: Path, dest: Path) -> None:
+    """Install Micro-Manager `dmg` to `dest`."""
+    # with progress bar, mount dmg
+    with _spinner(f"Mounting {dmg.name} ..."):
+        proc = subprocess.run(
+            ["hdiutil", "attach", "-nobrowse", str(dmg)],
+            capture_output=True,
+        )
+        if proc.returncode != 0:  # pragma: no cover
+            print(f"\n[bold red]Error mounting {dmg.name}:\n{proc.stderr.decode()}")
+            sys.exit(1)
+
+    # with progress bar, mount dmg
+    with _spinner(f"Installing to {dest} ..."):
+        # get mount point
+        mount = proc.stdout.splitlines()[-1].split()[-1].decode()
+        try:
+            try:
+                src = next(Path(mount).glob("Micro-Manager*"))
+            except StopIteration:  # pragma: no cover
+                print(
+                    "[bold red]\nError: Could not find Micro-Manager in dmg.\n"
+                    "Please report this at https://github.com/pymmcore-plus/"
+                    "pymmcore-plus/issues/new",
+                )
+                sys.exit(1)
+            install_path = dest / src.name
+            shutil.copytree(src, install_path, dirs_exist_ok=True)
+        finally:
+            subprocess.run(
+                ["hdiutil", "detach", mount], check=True, capture_output=True
+            )
+
+    # fix gatekeeper ... requires password
+    print("[green](Your password may be required to install Micro-manager.)")
+    cmd = ["sudo", "xattr", "-r", "-d", "com.apple.quarantine", str(install_path)]
+    subprocess.run(cmd, check=True)
+
+    # # fix path randomization by temporarily copying elsewhere and back
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _tmp = Path(tmpdir)
+        os.rename(install_path / "ImageJ.app", _tmp / "ImageJ.app")
+        os.rename(_tmp / "ImageJ.app", install_path / "ImageJ.app")
+
+
+def _available_versions() -> dict[str, str]:
+    """Return a map of version -> url available for download."""
+    plat = {"Darwin": "Mac", "Windows": "Windows"}[PLATFORM]
+    with urlopen(f"{BASE_URL}/nightly/2.0/{plat}/") as resp:
+        html = resp.read().decode("utf-8")
+
+    return {
+        ref.rsplit("-", 1)[-1].split(".")[0]: BASE_URL + ref
+        for ref in re.findall(r"href=\"([^\"]+)\"", html)
+        if ref != "/"
+    }
+
+
+def _download_url(url: str, output_path: Path) -> None:
+    """Download `url` to `output_path` with a nice progress bar."""
     ctx = ssl.create_default_context()
     ctx.check_hostname = False
     ctx.verify_mode = ssl.CERT_NONE
-    urllib.request.urlretrieve(url, filename=output_path, reporthook=_progressBar)
 
-
-def _mac_main(
-    dest_dir: Path = DEFAULT_DEST,
-    version: str = VERSION,
-    release: str | int = RELEASE,
-    noprompt: bool = False,
-) -> Path | None:
-    if release == "latest":
-        url = "https://download.micro-manager.org/latest/macos/"
-        fname = "Micro-Manager-x86_64-latest.dmg"
-        dst = dest_dir / "Micro-Manager-latest_mac"
-    else:
-        url = "https://download.micro-manager.org/nightly/2.0/Mac/"
-        fname = f"Micro-Manager-{version}-{release}.dmg"
-        dst = dest_dir / f"{fname[:-4]}_mac"
-
-    if dst.exists() and not noprompt:
-        resp = input(f"Micro-manager already exists at\n{dst}\nOverwrite [Y/n]?")
-        if resp.lower().startswith("n"):
-            print("aborting")
-            return None
-
-    _download_url(f"{url}{fname}", fname)
-    run(["hdiutil", "attach", "-nobrowse", fname], check=True)
-    try:
-        src = next(Path("/Volumes/Micro-Manager").glob("Micro-Manager*"))
-    except StopIteration:
-        src = Path(f"/Volumes/Micro-Manager/{fname[:-4]}")
-    shutil.copytree(src, dst, dirs_exist_ok=True)
-    run(["hdiutil", "detach", "/Volumes/Micro-Manager"], check=True)
-    os.unlink(fname)
-    # fix gatekeeper ... requires password
-    print(
-        "\nYour password may be required to enable Micro-manager "
-        "in your security settings."
-        "\nNote: you can also quit now (cmd-C) and do this "
-        "manually in the Security & Privacy preference pane."
+    pbar = progress.Progress(
+        progress.BarColumn(bar_width=None),
+        "[progress.percentage]{task.percentage:>3.1f}%",
+        "•",
+        progress.DownloadColumn(),
     )
-    cmd = ["sudo", "xattr", "-r", "-d", "com.apple.quarantine", str(dst)]
-    if noprompt:
-        cmd = cmd[1:]
+    task_id = pbar.add_task("Download..", filename=output_path.name, start=False)
 
-    run(cmd, check=True)
-    # # fix path randomization
-    os.rename(dst / "ImageJ.app", "ImageJ.app")
-    os.rename("ImageJ.app", dst / "ImageJ.app")
-    return dst
+    def hook(count: float, block_size: float, total_size: float) -> None:
+        pbar.update(task_id, total=int(total_size))
+        pbar.start_task(task_id)
+        pbar.update(task_id, advance=block_size)
+
+    print(f"[bold blue]Downloading {url} ...")
+    with pbar:
+        urlretrieve(url=url, filename=output_path, reporthook=hook)
 
 
-def _win_main(
-    dest_dir: Path = DEFAULT_DEST,
-    version: str = VERSION,
-    release: str | int = RELEASE,
-    noprompt: bool = False,
-) -> Path | None:
+def _install(dest: Path, release: str) -> None:
+    if PLATFORM not in ("Darwin", "Windows"):  # pragma: no cover
+        print(f":x: [bold red]Unsupported platform: {PLATFORM!r}")
+        raise sys.exit(1)
+
     if release == "latest":
-        url = "https://download.micro-manager.org/latest/windows/"
-        fname = "MMSetup_x64_latest.exe"
-        dst = dest_dir / "Micro-Manager-latest_win"
+        plat = {
+            "Darwin": "macos/Micro-Manager-x86_64-latest.dmg",
+            "Windows": "windows/MMSetup_x64_latest.exe",
+        }[PLATFORM]
+        url = f"{BASE_URL}/latest/{plat}"
     else:
-        url = "https://download.micro-manager.org/nightly/2.0/Windows/"
-        dst = dest_dir / f"Micro-Manager-{version}-{release}_win"
-        fname = f"MMSetup_64bit_{version}_{release}.exe"
+        available = _available_versions()
+        if release not in available:
+            n = 15
+            avail = ", ".join(list(available)[:n]) + " ..."
+            raise typer.BadParameter(
+                f"Release {release!r} not found. Last {n} releases:\n{avail}"
+            )
+        url = available[release]
 
-    if dst.exists() and not noprompt:
-        resp = input(f"Micro-manager already exists at\n{dst}\nOverwrite [Y/n]?")
-        if resp.lower().startswith("n"):
-            print("aborting")
-            return None
+    with tempfile.TemporaryDirectory() as tmpdir:
+        installer = Path(tmpdir) / url.split("/")[-1]
+        _download_url(url=url, output_path=installer)
+        if PLATFORM == "Darwin":
+            _mac_install(installer, dest)
+        elif PLATFORM == "Windows":
+            # for windows, we need to know the latest version
+            filename = _get_download_name(url)
+            filename = filename.replace("MMSetup_64bit", "Micro-Manager")
+            filename = filename.replace(".exe", "")
+            _win_install(installer, dest / filename)
 
-    _download_url(f"{url}{fname}", fname)
-    run(
-        [fname, "/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART", f"/DIR={dst}"],
-        check=True,
-    )
-    os.unlink(fname)
-    return dst
-
-
-def install(
-    dest_dir: Path = DEFAULT_DEST,
-    version: str = VERSION,
-    release: str = "latest",
-    noprompt: bool = False,
-) -> None:
-    """Install Micro-manager to a given directory."""
-    prog = _win_main if os.name == "nt" else _mac_main
-    out = prog(dest_dir, version, release, noprompt)
-    if out:
-        print("installed to", out)
+    print(f":sparkles: [bold green]Installed to {dest}![/bold green] :sparkles:")
 
 
 def _existing_dir(string: str) -> Path:
@@ -140,38 +184,44 @@ def _version(value: str) -> str:
     return value
 
 
-def _release(value: str) -> int | str:
+def _release(value: str) -> str:
     if value.lower() == "latest":
         return "latest"
     if len(value) != 8:
         raise ValueError(f"Invalid date: {value}. Must be eight digits.")
-    return int(value)
+    return str(value)
 
 
 def main() -> None:
     """Main entry point for the console_scripts."""
-    import sys
-
-    print(sys.argv)
     import argparse
+
+    from rich.panel import Panel
+
+    print(
+        Panel(
+            ':exclamation: [bold red]"python -m pymmcore_plus.install" is deprecated. '
+            'Use "mmcore install" instead :eyes:',
+            border_style="red",
+        )
+    )
 
     parser = argparse.ArgumentParser(description="MM Device adapter installer.")
     parser.add_argument(
         "-d",
         "--dest",
-        default=DEFAULT_DEST,
+        default=USER_DATA_MM_PATH,
         type=_existing_dir,
-        help=f"Directory in which to install (default: {DEFAULT_DEST})",
+        help=f"Directory in which to install (default: {USER_DATA_MM_PATH})",
     )
 
-    parser.add_argument(
+    parser.add_argument(  # unused
         "-v",
         "--version",
         metavar="VERSION",
         type=_version,
-        default=VERSION,
-        help="Version number. e.g. 2.0.1 - ignored if release=latest "
-        f"(default: {VERSION})",
+        default="2.0.1",
+        help="Version number. e.g. 2.0.1 - ignored if release=latest (default: 2.0.1)",
     )
     parser.add_argument(
         "-r",
@@ -191,7 +241,7 @@ def main() -> None:
     )
 
     args = parser.parse_args()
-    install(args.dest, args.version, args.release, args.yes)
+    _install(Path(args.dest), args.release)
 
 
 if __name__ == "__main__":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,9 +18,7 @@ def core(request):
     core._callback_relay = pymmcore_plus.core._mmcore_plus.MMCallbackRelay(core.events)
     core.registerCallback(core._callback_relay)
     if not core.getDeviceAdapterSearchPaths():
-        pytest.fail(
-            "To run tests, please install MM with `python -m pymmcore_plus.install`"
-        )
+        pytest.fail("To run tests, please install MM with `mmcore install`")
     core.loadSystemConfiguration()
     return core
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,7 @@
 import shutil
 import subprocess
 from pathlib import Path
-from typing import Callable
+from typing import Any, Callable
 from unittest.mock import patch
 
 from pymmcore_plus import __version__, _cli
@@ -12,7 +12,7 @@ runner = CliRunner()
 subrun = subprocess.run
 
 
-def _mock_urlretrieve(url, filename, reporthook=None):
+def _mock_urlretrieve(url: str, filename: str, reporthook=None) -> None:
     """fake urlretrieve that writes a fake file."""
     with open(filename, "w") as f:
         f.write("test")
@@ -24,7 +24,7 @@ def _mock_run(dest: Path) -> Callable:
     mnt = dest / "vol"
     mmdir = mnt / "Micro-Manager-2.0.0"
 
-    def runner(*args, **kwargs) -> subprocess.CompletedProcess:
+    def runner(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess:
         if not args and args[0]:
             return subrun(*args, **kwargs)
         if args[0][0] == "hdiutil":
@@ -76,7 +76,7 @@ def test_show_version() -> None:
     assert "MMCore" in result.stdout
 
 
-def test_clean(tmp_path: Path):
+def test_clean(tmp_path: Path) -> None:
     """Just cleans up the user data folder."""
     test_file = tmp_path / "test.txt"
     test_file.touch()
@@ -91,7 +91,7 @@ def test_clean(tmp_path: Path):
     assert result.exit_code == 0
 
 
-def test_list(tmp_path: Path):
+def test_list(tmp_path: Path) -> None:
     """Just shows what's in the user data folder."""
     empty_dir = tmp_path / "empty"
     _cli.USER_DATA_MM_PATH = empty_dir  # type: ignore
@@ -106,7 +106,7 @@ def test_list(tmp_path: Path):
     assert "test.txt" in result.stdout
 
 
-def test_find(tmp_path: Path):
+def test_find(tmp_path: Path) -> None:
     # this should pass if any of the tests work :)
     # since we probably need to find mmore for anything to work!
     result = runner.invoke(app, ["find"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,103 @@
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Callable
+from unittest.mock import patch
+
+from pymmcore_plus import __version__, _cli
+from pymmcore_plus._cli import app
+from typer.testing import CliRunner
+
+runner = CliRunner()
+subrun = subprocess.run
+
+
+def _mock_urlretrieve(url, filename, reporthook=None):
+    """fake urlretrieve that writes a fake file."""
+    with open(filename, "w") as f:
+        f.write("test")
+        reporthook(0, 0, 0)
+
+
+def _mock_run(dest: Path) -> Callable:
+    """fake subprocess that handles special cases to test `mmcore install`."""
+    mmdir = dest / "Micro-Manager-2.0.0"
+
+    def runner(*args, **kwargs) -> subprocess.CompletedProcess:
+        if args and args[0] and args[0][0] == "hdiutil":
+            if args[0][1] == "attach":
+                mmdir.mkdir(parents=True)
+                (mmdir / "ImageJ.app").touch()
+                return subprocess.CompletedProcess(args[0], 0, str(dest).encode(), "")
+            if args[0][1] == "detach":
+                shutil.rmtree(mmdir)
+                return subprocess.CompletedProcess(args[0], 0, b"", "")
+        if args and args[0] and args[0][0] == "sudo":
+            return subprocess.CompletedProcess(args[0], 0, b"", "")
+        return subrun(*args, **kwargs)
+
+    return runner
+
+
+def test_app(tmp_path: Path) -> None:
+    patch_download = patch.object(_cli, "urlretrieve", _mock_urlretrieve)
+    patch_run = patch.object(subprocess, "run", _mock_run(tmp_path / "vol"))
+
+    with patch_download as mock, patch_run as mock2:
+        result = runner.invoke(app, ["install", "--dest", str(tmp_path)])
+    assert (tmp_path / "Micro-Manager-2.0.0" / "ImageJ.app").exists()
+    assert result.exit_code == 0
+
+
+def test_available_versions(tmp_path: Path) -> None:
+    """installing with an erroneous version should fail and show available versions."""
+    result = runner.invoke(app, ["install", "-r", "xxxx"])
+    assert result.exit_code > 0
+    assert "Release 'xxxx' not found" in result.stdout
+    assert "Last 15 releases:" in result.stdout
+
+
+def test_show_version() -> None:
+    """show version should work."""
+    result = runner.invoke(app, ["--version"])
+    assert result.exit_code == 0
+    assert "pymmcore-plus" in result.stdout
+    assert __version__ in result.stdout
+    assert "MMCore" in result.stdout
+
+
+def test_clean(tmp_path: Path):
+    """Just cleans up the user data folder."""
+    test_file = tmp_path / "test.txt"
+    test_file.touch()
+    _cli.USER_DATA_MM_PATH = tmp_path  # type: ignore
+    assert test_file.exists()
+    result = runner.invoke(app, ["clean"])
+    assert result.exit_code == 0
+    assert not test_file.exists()
+
+    # this time nothing to clean
+    result = runner.invoke(app, ["clean"])
+    assert result.exit_code == 0
+
+
+def test_list(tmp_path: Path):
+    """Just shows what's in the user data folder."""
+    empty_dir = tmp_path / "empty"
+    _cli.USER_DATA_MM_PATH = empty_dir  # type: ignore
+    result = runner.invoke(app, ["list"])
+    assert "test.txt" not in result.stdout
+
+    empty_dir.mkdir()
+    test_file = empty_dir / "test.txt"
+    test_file.touch()
+    result = runner.invoke(app, ["list"])
+    assert result.exit_code == 0
+    assert "test.txt" in result.stdout
+
+
+def test_find(tmp_path: Path):
+    # this should pass if any of the tests work :)
+    # since we probably need to find mmore for anything to work!
+    result = runner.invoke(app, ["find"])
+    assert result.exit_code == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Any, Callable
 from unittest.mock import patch
 
-from pymmcore_plus import __version__, _cli
+from pymmcore_plus import __version__, _cli, install
 from pymmcore_plus._cli import app
 from typer.testing import CliRunner
 
@@ -50,7 +50,7 @@ def _mock_run(dest: Path) -> Callable:
 
 
 def test_app(tmp_path: Path) -> None:
-    patch_download = patch.object(_cli, "urlretrieve", _mock_urlretrieve)
+    patch_download = patch.object(install, "urlretrieve", _mock_urlretrieve)
     patch_run = patch.object(subprocess, "run", _mock_run(tmp_path))
 
     with patch_download as mock, patch_run as mock2:
@@ -110,4 +110,7 @@ def test_find(tmp_path: Path) -> None:
     # this should pass if any of the tests work :)
     # since we probably need to find mmore for anything to work!
     result = runner.invoke(app, ["find"])
-    assert result.exit_code == 0
+    if result.exit_code != 0:
+        raise AssertionError(
+            "mmcore find failed... is Micro-Manager installed?  (run mmcore install)"
+        )


### PR DESCRIPTION
replacement for `python -m pymmcore_plus.install` ... with the ability to extend lots of stuff

```zsh
╰─❯ mmcore --help

 Usage: mmcore [OPTIONS] COMMAND [ARGS]...

 mmcore: pymmcore-plus command line (v0.6.3.dev2+g37a0cf7).
 For additional help on a specific command: type 'mmcore [command] --help'

╭─ Options ──────────────────────────────────────────────────────────────────────────────────╮
│ --version          Show version and exit.                                                  │
│ --help             Show this message and exit.                                             │
╰────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ Commands ─────────────────────────────────────────────────────────────────────────────────╮
│ clean       Remove all Micro-Manager installs downloaded by pymmcore-plus.                 │
│ find        Show the location of Micro-Manager in use by pymmcore-plus.                    │
│ install     Install Micro-Manager Device adapters.                                         │
│ list        Show all Micro-Manager installs downloaded by pymmcore-plus.                   │
╰────────────────────────────────────────────────────────────────────────────────────────────╯
```