### PR TITLE
feat: emit channelGroupChanged signal when calling setChannelGroup

### DIFF
--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -1559,6 +1559,14 @@ class CMMCorePlus(pymmcore.CMMCore):
             args = (super().getCameraDevice(),) + args
         self.events.roiSet.emit(*args)
 
+    def setChannelGroup(self, channelGroup: str) -> None:
+        """Specifies the group determining the channel selection.
+        
+        ...and send a propertyChanged signal.
+        """
+        super().setChannelGroup(channelGroup)
+        self.events.propertyChanged.emit("Core", "ChannelGroup", channelGroup)
+
     def state(self, exclude: Iterable[str] = ()) -> StateDict:
         """Return `StateDict` with commonly accessed state values.
 

--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -1562,10 +1562,11 @@ class CMMCorePlus(pymmcore.CMMCore):
     def setChannelGroup(self, channelGroup: str) -> None:
         """Specifies the group determining the channel selection.
         
-        ...and send a propertyChanged signal.
+        ...and send a channelGroupChanged signal.
         """
-        super().setChannelGroup(channelGroup)
-        self.events.propertyChanged.emit("Core", "ChannelGroup", channelGroup)
+        if self.getChannelGroup() != channelGroup:
+            super().setChannelGroup(channelGroup)
+            self.events.channelGroupChanged.emit(channelGroup)
 
     def state(self, exclude: Iterable[str] = ()) -> StateDict:
         """Return `StateDict` with commonly accessed state values.

--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -1561,7 +1561,7 @@ class CMMCorePlus(pymmcore.CMMCore):
 
     def setChannelGroup(self, channelGroup: str) -> None:
         """Specifies the group determining the channel selection.
-        
+
         ...and send a channelGroupChanged signal.
         """
         if self.getChannelGroup() != channelGroup:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -282,3 +282,10 @@ def test_pixel_changed_event(core: CMMCorePlus):
     core.setPixelSizeUm("test", 6.5)
     mock.assert_has_calls([call(6.5)])
     assert core.getPixelSizeUmByID("test") == 6.5
+
+def test_set_channelgroup(core: CMMCorePlus):
+    mock = Mock()
+    core.events.propertyChanged.connect(mock)
+
+    core.setChannelGroup("Camera")
+    mock.assert_has_calls([call("Core", "ChannelGroup", "Camera")])

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -285,7 +285,8 @@ def test_pixel_changed_event(core: CMMCorePlus):
 
 def test_set_channelgroup(core: CMMCorePlus):
     mock = Mock()
-    core.events.propertyChanged.connect(mock)
+    core.events.channelGroupChanged.connect(mock)
 
     core.setChannelGroup("Camera")
-    mock.assert_has_calls([call("Core", "ChannelGroup", "Camera")])
+    assert core.getChannelGroup() == "Camera"
+    mock.assert_has_calls([call("Camera")])


### PR DESCRIPTION
`pymmcore` `setChannelGroup` currently does not have/emit any signal when is called. 

This PR adds core `channelGroupChanged.emit()` to the `setChannelGroup` method.