### PR TITLE
fix: fix snap emission events

### DIFF
--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -1193,13 +1193,14 @@ class CMMCorePlus(pymmcore.CMMCore):
         """
         autoshutter = self.getAutoShutter()
         if autoshutter:
-            shutter_dev = self.getShutterDevice()
-            self.events.propertyChanged.emit(shutter_dev, "State", True)
+            self.events.propertyChanged.emit(self.getShutterDevice(), "State", True)
         try:
             super().snapImage()
         finally:
             if autoshutter:
-                self.events.propertyChanged.emit(shutter_dev, "State", False)
+                self.events.propertyChanged.emit(
+                    self.getShutterDevice(), "State", False
+                )
 
     @property
     def mda(self) -> MDARunner:

--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -1191,7 +1191,15 @@ class CMMCorePlus(pymmcore.CMMCore):
 
         **Why Override?** To add a lock to prevent concurrent calls across threads.
         """
-        return super().snapImage()
+        autoshutter = self.getAutoShutter()
+        if autoshutter:
+            shutter_dev = self.getShutterDevice()
+            self.events.propertyChanged.emit(shutter_dev, "State", True)
+        try:
+            super().snapImage()
+        finally:
+            if autoshutter:
+                self.events.propertyChanged.emit(shutter_dev, "State", False)
 
     @property
     def mda(self) -> MDARunner:

--- a/tests/remote/test_client.py
+++ b/tests/remote/test_client.py
@@ -1,3 +1,5 @@
+import os
+
 import numpy as np
 import pytest
 from useq import MDAEvent, MDASequence
@@ -16,6 +18,7 @@ def proxy():
         yield mmcore
 
 
+@pytest.mark.skipif(os.name == "nt", reason="Pyro5 not working on windows")
 def test_client(proxy):
     assert str(proxy._pyroUri) == DEFAULT_URI
     proxy.getConfigGroupState("Channel")
@@ -70,6 +73,7 @@ def test_mda_cancel(qtbot, proxy: RemoteMMCore):
 @pytest.mark.xfail(
     reason="synchronous callbacks not working yet", raises=AssertionError, strict=True
 )
+@pytest.mark.skipif(os.name == "nt", reason="Pyro5 not working on windows")
 def test_cb_without_qt(proxy):
     """This tests that we can call a core method within a callback
 


### PR DESCRIPTION
The `snap_with_shutter` function added in https://github.com/pymmcore-plus/pymmcore-widgets/pull/121/files (which made sure to emit shutter open signals before and after a snap event) should have been added to core instead of widgets.  This PR adds it, and adds a test