### PR TITLE
test: use PyQt6 for testing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ docs = [
     "mkdocstrings-python",
 ]
 remote = ["Pyro5>=5.10", "msgpack", "psutil"]
-testing = ["PyQt5", "pytest", "pytest-cov", "pytest-qt", "qtpy"]
+testing = ["PyQt6", "pytest", "pytest-cov", "pytest-qt", "qtpy"]
 dev = [
     "black",
     "ipython",


### PR DESCRIPTION
Use `PyQt6` instead of `PyQt5` in `pyproject.toml` for testing so it works also on Apple Silicon.