### PR TITLE
refactor: relax signature of `MDARunner.run` to `Iterable[MDAEvent]`

### DIFF
--- a/src/pymmcore_plus/__init__.py
+++ b/src/pymmcore_plus/__init__.py
@@ -22,11 +22,13 @@ from .core import (
     PropertyType,
 )
 from .core.events import CMMCoreSignaler, PCoreSignaler
+from .mda._runner import GeneratorMDASequence
 
 if TYPE_CHECKING:
     from .remote import RemoteMMCore, server
 
 __all__ = [
+    "__version__",
     "ActionType",
     "CMMCorePlus",
     "CMMCoreSignaler",
@@ -35,17 +37,17 @@ __all__ = [
     "Device",
     "DeviceDetectionStatus",
     "DeviceNotification",
+    "DeviceProperty",
     "DeviceType",
     "find_micromanager",
     "FocusDirection",
+    "GeneratorMDASequence",
     "Metadata",
-    "DeviceProperty",
     "PCoreSignaler",
     "PortType",
     "PropertyType",
     "RemoteMMCore",
     "server",
-    "__version__",
 ]
 
 

--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -25,7 +25,6 @@ from typing import (
 
 import pymmcore
 from psygnal import SignalInstance
-from useq import MDAEvent
 
 from pymmcore_plus.core.events import PCoreSignaler
 
@@ -43,6 +42,7 @@ from .events import CMMCoreSignaler, _get_auto_core_callback_class
 if TYPE_CHECKING:
     import numpy as np
     from typing_extensions import TypedDict
+    from useq import MDAEvent
 
     _T = TypeVar("_T")
     _F = TypeVar("_F", bound=Callable[..., Any])
@@ -1210,8 +1210,8 @@ class CMMCorePlus(pymmcore.CMMCore):
         """
         return self._mda_runner
 
-    def run_mda(self, sequence: Iterable[MDAEvent], block: bool = False) -> Thread:
-        """Run MDA defined by *sequence* on a new thread.
+    def run_mda(self, events: Iterable[MDAEvent], block: bool = False) -> Thread:
+        """Run a sequence of [useq.MDAEvent][] on a new thread.
 
         :sparkles: *This method is new in `CMMCorePlus`.*
 
@@ -1223,22 +1223,23 @@ class CMMCorePlus(pymmcore.CMMCore):
 
         Parameters
         ----------
-        sequence : useq.MDASequence
-            The useq.MDASequence to run.
+        events : Iterable[useq.MDAEvent]
+            An iterable of [useq.MDAEvent][] to execute.  This may be an instance
+            of [useq.MDASequence][], or any other iterable of [useq.MDAEvent][].
         block : bool, optional
             If True, block until the sequence is complete, by default False.
 
         Returns
         -------
         Thread
-            The thread the MDA is running on.  Use `thread.join()` to block until
+            The thread the sequence is running on.  Use `thread.join()` to block until
             done, or `thread.is_alive()` to check if the sequence is complete.
         """
         if self.mda.is_running():
             raise ValueError(
                 "Cannot start an MDA while the previous MDA is still running."
             )
-        th = Thread(target=self.mda.run, args=(sequence,))
+        th = Thread(target=self.mda.run, args=(events,))
         th.start()
         if block:
             th.join()

--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -25,6 +25,7 @@ from typing import (
 
 import pymmcore
 from psygnal import SignalInstance
+from useq import MDAEvent
 
 from pymmcore_plus.core.events import PCoreSignaler
 
@@ -42,7 +43,6 @@ from .events import CMMCoreSignaler, _get_auto_core_callback_class
 if TYPE_CHECKING:
     import numpy as np
     from typing_extensions import TypedDict
-    from useq import MDASequence
 
     _T = TypeVar("_T")
     _F = TypeVar("_F", bound=Callable[..., Any])
@@ -1210,7 +1210,7 @@ class CMMCorePlus(pymmcore.CMMCore):
         """
         return self._mda_runner
 
-    def run_mda(self, sequence: MDASequence, block: bool = False) -> Thread:
+    def run_mda(self, sequence: Iterable[MDAEvent], block: bool = False) -> Thread:
         """Run MDA defined by *sequence* on a new thread.
 
         :sparkles: *This method is new in `CMMCorePlus`.*

--- a/src/pymmcore_plus/mda/_runner.py
+++ b/src/pymmcore_plus/mda/_runner.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import contextlib
 import time
-from typing import TYPE_CHECKING, cast
+import warnings
+from typing import TYPE_CHECKING, Iterable, Iterator, cast
 
 from psygnal import EmitLoopError
+from useq import MDASequence
 
 from pymmcore_plus._logger import logger
 
@@ -12,7 +14,28 @@ from ._protocol import PMDAEngine
 from .events import PMDASignaler, _get_auto_MDA_callback_class
 
 if TYPE_CHECKING:
-    from useq import MDAEvent, MDASequence
+    from useq import MDAEvent
+
+
+class GeneratorMDASequence(MDASequence):
+    MSG = (
+        "This sequence is a placeholder for a generator of events with unknown "
+        "length & shape. Iterating over it has no effect."
+    )
+
+    axis_order: str = ""
+
+    @property
+    def sizes(self) -> dict[str, int]:
+        warnings.warn(self.MSG, stacklevel=2)
+        return {}
+
+    def iter_axis(self, axis: str) -> Iterator:
+        warnings.warn(self.MSG, stacklevel=2)
+        yield from []
+
+    def __len__(self) -> int:
+        raise TypeError("GeneratorMDASequence has no len()")
 
 
 class MDARunner:
@@ -118,7 +141,7 @@ class MDARunner:
             self._paused = not self._paused
             self._events.sequencePauseToggled.emit(self._paused)
 
-    def run(self, sequence: MDASequence) -> None:
+    def run(self, events: Iterable[MDAEvent]) -> None:
         """Run the multi-dimensional acquistion defined by `sequence`.
 
         Most users should not use this directly as it will block further
@@ -128,16 +151,17 @@ class MDARunner:
 
         Parameters
         ----------
-        sequence : MDASequence
-            An instance of a `useq.MDASequence` object defining the sequence of events
-            to run.
+        events : Iterable[MDAEvent]
+            An iterable of `useq.MDAEvents` objects to execute.
         """
+        error = None
+        sequence = events if isinstance(events, MDASequence) else GeneratorMDASequence()
         try:
             self._prepare_to_run(sequence)
             self._engine = cast("PMDAEngine", self._engine)
             teardown_event = getattr(self._engine, "teardown_event", lambda e: None)
 
-            for event in sequence:
+            for event in events:
                 cancelled = self._wait_until_event(event)
 
                 # If cancelled break out of the loop
@@ -159,11 +183,11 @@ class MDARunner:
                 teardown_event(event)
 
         except Exception as e:
-            # clean up so future MDAs can be run
-            with contextlib.suppress(Exception):
-                self._finish_run(sequence)
-            raise e
-        self._finish_run(sequence)
+            error = e
+        with contextlib.suppress(Exception):
+            self._finish_run(sequence)
+        if error is not None:
+            raise error
 
     def _prepare_to_run(self, sequence: MDASequence) -> None:
         """Set up for the MDA run.

--- a/tests/test_mda.py
+++ b/tests/test_mda.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import time
-from typing import TYPE_CHECKING
-from unittest.mock import patch
+from typing import TYPE_CHECKING, Iterable, Iterator
+from unittest.mock import Mock, patch
 
 import pytest
 from pymmcore_plus import CMMCorePlus
@@ -56,7 +58,7 @@ class BrokenEngine:
         ...
 
 
-def test_mda_failures(core: CMMCorePlus, qtbot: "QtBot"):
+def test_mda_failures(core: CMMCorePlus, qtbot: QtBot):
     mda = MDASequence(
         channels=["Cy5"],
         time_plan={"interval": 1.5, "loops": 2},
@@ -94,3 +96,35 @@ def test_mda_failures(core: CMMCorePlus, qtbot: "QtBot"):
         assert not core.mda.is_running()
         assert not core.mda.is_paused()
         assert not core.mda._canceled
+
+
+def event_generator() -> Iterator[MDAEvent]:
+    yield MDAEvent()
+    yield MDAEvent()
+    return
+
+
+SEQS = [
+    MDASequence(time_plan={"interval": 0.1, "loops": 2}),
+    (MDAEvent(), MDAEvent()),
+    # the core fixture runs twice ... so we need to make this generator each time
+    "event_generator()",
+]
+
+
+@pytest.mark.parametrize("seq", SEQS)
+def test_mda_iterable_of_events(
+    core: CMMCorePlus, seq: Iterable[MDAEvent], qtbot: QtBot
+) -> None:
+    if seq == "event_generator()":  # type: ignore
+        seq = event_generator()
+    start_mock = Mock()
+    frame_mock = Mock()
+    core.mda.events.sequenceStarted.connect(start_mock)
+    core.mda.events.frameReady.connect(frame_mock)
+
+    with qtbot.waitSignal(core.mda.events.sequenceFinished):
+        core.mda.run(seq)
+
+    assert start_mock.call_count == 1
+    assert frame_mock.call_count == 2


### PR DESCRIPTION
This changes the signature of MDARunner.run from 

```py
    def run(self, sequence: MDASequence) -> None:
```

to 

```py
    def run(self, events: Iterable[MDAEvent]) -> None:
```

as discussed elsewhere, this is the more powerful approach, and doesn't tie the engine to sequences of known length/shape, etc...  So, it could accept _any_ custom sequence/generator/iterable of `useq.MDAEvent` (which includes instances of `MDASequence`.)

The only tricky bit were the `setup_sequence` callback and `sequenceStarted` signal.  To avoid breaking uses like @ianhi 's [engine](https://github.com/ianhi/raman-mda-engine/blob/f7238bc286aa9642331eb5c6215c458e31327115/raman_mda_engine/_engine.py#L214) ... When a non `MDASequence` object is passed to `run()`, a mock `GeneratorMDASequence` is created and passed to those signals. It will warn and do nothing if someone tries to iterate over it or check its length/shape, etc...  That object is also exported at the top level so one can check `isinstance(obj, GeneratorMDASequence)`  if they'd like

@ianhi how does this look to you?