### PR TITLE
feat: add general retry utility

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -14,7 +14,7 @@ def test_retry() -> None:
             raise ValueError("nope")
         return x
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="nope"):
         retry(tries=3, exceptions=RuntimeError, delay=0.5)(works_on_third_try)(1)
 
     i = 0

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -15,7 +15,7 @@ def test_retry() -> None:
         return x
 
     with pytest.raises(ValueError):
-        retry(tries=3, exceptions=RuntimeError)(works_on_third_try)(1)
+        retry(tries=3, exceptions=RuntimeError, delay=0.5)(works_on_third_try)(1)
 
     i = 0
     mock = Mock()

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,0 +1,26 @@
+from unittest.mock import Mock
+
+import pytest
+from pymmcore_plus._util import retry
+
+
+def test_retry() -> None:
+    i: int = 0
+
+    def works_on_third_try(x: str) -> str:
+        nonlocal i
+        i += 1
+        if i < 3:
+            raise ValueError("nope")
+        return x
+
+    with pytest.raises(ValueError):
+        retry(tries=3, exceptions=RuntimeError)(works_on_third_try)(1)
+
+    i = 0
+    mock = Mock()
+    good_retry = retry(tries=3, exceptions=ValueError, logger=mock)(works_on_third_try)
+
+    assert good_retry("hi") == "hi"
+    assert mock.call_count == 2
+    mock.assert_called_with("ValueError nope caught, trying 1 more times")


### PR DESCRIPTION
Since it's a common thing to retry stuff a couple times in MMCore, this adds a utility to help with it:

```python
from pymmcore_plus._util import retry

@retry(exceptions=RuntimeError, delay=0.5, logger=print)
def autofocus(core) -> float:
    core.fullFocus()
    core.waitForSystem()
    return core.getZPosition()
```