### PR TITLE
Add set_mda to use custom MDARunner

### DIFF
--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -1343,6 +1343,20 @@ class CMMCorePlus(pymmcore.CMMCore):
         """
         return self._mda_runner
 
+    def set_mda(self, mda) -> None:
+        """Set the `MDARunner` for this `CMMCorePlus` instance.
+
+        :sparkles: *This method is new in `CMMCorePlus`.*
+
+        Parameters
+        ----------
+        mda : MDARunner
+            Any object conforming to the `MDARunner` protocol.
+        """
+        self._mda_runner = mda()
+        self._mda_runner.set_engine(MDAEngine(self))
+
+
     def run_mda(self, events: Iterable[MDAEvent], block: bool = False) -> Thread:
         """Run a sequence of [useq.MDAEvent][] on a new thread.
 

--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -1356,7 +1356,6 @@ class CMMCorePlus(pymmcore.CMMCore):
         self._mda_runner = mda()
         self._mda_runner.set_engine(MDAEngine(self))
 
-
     def run_mda(self, events: Iterable[MDAEvent], block: bool = False) -> Thread:
         """Run a sequence of [useq.MDAEvent][] on a new thread.
 

--- a/tests/test_mda.py
+++ b/tests/test_mda.py
@@ -6,8 +6,8 @@ from unittest.mock import Mock, patch
 
 import pytest
 from pymmcore_plus import CMMCorePlus
-from pymmcore_plus.mda.events import MDASignaler
 from pymmcore_plus.mda import MDARunner
+from pymmcore_plus.mda.events import MDASignaler
 from useq import MDAEvent, MDASequence
 
 if TYPE_CHECKING:
@@ -130,8 +130,11 @@ def test_mda_iterable_of_events(
     assert start_mock.call_count == 1
     assert frame_mock.call_count == 2
 
+
 @pytest.mark.parametrize("seq", SEQS)
-def test_mda_replace_runner(core: CMMCorePlus, seq: Iterable[MDAEvent], qtbot: QtBot) -> None:
+def test_mda_replace_runner(
+    core: CMMCorePlus, seq: Iterable[MDAEvent], qtbot: QtBot
+) -> None:
     core.set_mda(MDARunner)
     test_mda_iterable_of_events(core, seq, qtbot)
     test_mda_failures(core, qtbot)

--- a/tests/test_mda.py
+++ b/tests/test_mda.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock, patch
 import pytest
 from pymmcore_plus import CMMCorePlus
 from pymmcore_plus.mda.events import MDASignaler
+from pymmcore_plus.mda import MDARunner
 from useq import MDAEvent, MDASequence
 
 if TYPE_CHECKING:
@@ -128,3 +129,11 @@ def test_mda_iterable_of_events(
 
     assert start_mock.call_count == 1
     assert frame_mock.call_count == 2
+
+@pytest.mark.parametrize("seq", SEQS)
+def test_mda_replace_runner(core: CMMCorePlus, seq: Iterable[MDAEvent], qtbot: QtBot) -> None:
+    core.set_mda(MDARunner)
+    test_mda_iterable_of_events(core, seq, qtbot)
+    test_mda_failures(core, qtbot)
+    test_mda_waiting(core)
+    test_setting_position(core)


### PR DESCRIPTION
Hey everyone,

I would like to use pymmcore-plus with a slightly modified runner that allows for addition of acquisition events. For this I would have to register a different runner in the CMMCorePlus instance. Do you think it makes sense to add this functionality?
@tlambert03 

Thanks, Willi