### PR TITLE
fix: fix bug in sequencing

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -112,8 +112,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -U pip
-          python -m pip install -e ./pymmcore-plus[testing]
           python -m pip install -e ./napari-micromanager[testing]
+          python -m pip install -e ./pymmcore-plus[testing]
 
       - name: Install Micro-Manager
         run: mmcore install

--- a/src/pymmcore_plus/core/_sequencing.py
+++ b/src/pymmcore_plus/core/_sequencing.py
@@ -244,7 +244,7 @@ def can_sequence_events(
                 return _nope(f"'{dev}-{prop}' {max_len=} < {cur_length=}")
 
     # Z
-    if e1.z_pos and e2.z_pos and (e1.z_pos != e2.z_pos):
+    if (e1.z_pos or e2.z_pos) and (e1.z_pos != e2.z_pos):
         focus_dev = core.getFocusDevice()
         if not core.isStageSequenceable(focus_dev):
             return _nope(f"Focus device {focus_dev!r} is not sequenceable")
@@ -253,8 +253,8 @@ def can_sequence_events(
             return _nope(f"Focus device {focus_dev!r} {max_len=} < {cur_length=}")
 
     # XY
-    if (e1.x_pos and e2.x_pos and (e1.x_pos != e2.x_pos)) or (
-        e1.y_pos and e2.y_pos and (e1.y_pos != e2.y_pos)
+    if ((e1.x_pos or e2.x_pos) and (e1.x_pos != e2.x_pos)) or (
+        (e1.y_pos or e2.y_pos) and (e1.y_pos != e2.y_pos)
     ):
         stage = core.getXYStageDevice()
         if not core.isXYStageSequenceable(stage):

--- a/tests/test_sequencing.py
+++ b/tests/test_sequencing.py
@@ -51,6 +51,15 @@ def test_sequenced_mda(core: CMMCorePlus) -> None:
     assert core_mock.setXYPosition.call_args_list == expected_pos
 
 
+def test_sequenced_mda_with_zero_values() -> None:
+    # just testing a bug I found where if z, x, or y are 0, they accidentally
+    # get sequenced
+    mda = useq.MDASequence(z_plan=useq.ZRangeAround(range=3.0, step=0.5))
+    core = CMMCorePlus()
+    core.loadSystemConfiguration()
+    core.mda.run(mda)
+
+
 def test_fully_sequenceable_core():
     mda = useq.MDASequence(
         stage_positions=[(0, 0, 0), (1, 1, 1)],


### PR DESCRIPTION
This fixes a bug in `canSequenceEvents` when one of the two events has an x,y, or z position of 0