### PR TITLE
fix: fix payload for sequenced objects

### DIFF
--- a/src/pymmcore_plus/mda/_engine.py
+++ b/src/pymmcore_plus/mda/_engine.py
@@ -257,7 +257,7 @@ class MDAEngine(PMDAEngine):
                 len(images),
             )
 
-        return EventPayload(image_sequence=images)
+        return EventPayload(image_sequence=tuple(zip(images, event.events)))
 
     # ===================== EXTRA =====================
 
@@ -297,4 +297,4 @@ class MDAEngine(PMDAEngine):
 
 class EventPayload(NamedTuple):
     image: np.ndarray | None = None
-    image_sequence: Sequence[np.ndarray] | None = None
+    image_sequence: Sequence[tuple[np.ndarray, MDAEvent]] | None = None

--- a/src/pymmcore_plus/mda/_runner.py
+++ b/src/pymmcore_plus/mda/_runner.py
@@ -190,8 +190,8 @@ class MDARunner:
             # but we might not want to do this for sequences for performance reasons.s
             if (imgs := getattr(output, "image_sequence", None)) is not None:
                 with contextlib.suppress(EmitLoopError):
-                    for img in imgs:
-                        self._events.frameReady.emit(img, event)
+                    for img, sub_event in imgs:
+                        self._events.frameReady.emit(img, sub_event)
 
             teardown_event(event)
 


### PR DESCRIPTION
This makes sure that the `frameReady` signal emits (`np.ndarray`, `MDAEvent`) with the subevents inside of a sequenced event, (rather than the second item in the tuple always being   the combined `SequencedEvent`