### PR TITLE
refactor: remove loguru

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "appdirs",
-    "loguru >=0.5.0",
     "numpy",
     "psygnal >=0.4.2",
     "pymmcore >=10.1.1.70.4",

--- a/src/pymmcore_plus/_cli.py
+++ b/src/pymmcore_plus/_cli.py
@@ -84,7 +84,7 @@ def _list() -> None:
 @app.command()
 def find() -> None:
     """Show the location of Micro-Manager in use by pymmcore-plus."""
-    configure_logging(strerr_level="CRITICAL")
+    configure_logging(stderr_level="CRITICAL")
 
     found = None
     with suppress(Exception):

--- a/src/pymmcore_plus/_logger.py
+++ b/src/pymmcore_plus/_logger.py
@@ -4,9 +4,10 @@ import logging
 import os
 import sys
 import warnings
+from contextlib import contextmanager
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, ClassVar, Iterator
 
 __all__ = ["logger"]
 
@@ -150,6 +151,15 @@ def current_logfile(logger: logging.Logger) -> Path | None:
         if isinstance(handler, RotatingFileHandler):
             return Path(handler.baseFilename)
     return None
+
+
+@contextmanager
+def exceptions_logged() -> Iterator[None]:
+    """Context manager to log exceptions."""
+    try:
+        yield
+    except Exception as e:
+        logger.error(e)
 
 
 configure_logging()

--- a/src/pymmcore_plus/_logger.py
+++ b/src/pymmcore_plus/_logger.py
@@ -16,11 +16,11 @@ if TYPE_CHECKING:
     LogLvlStr = Literal["NOTSET", "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
     LogLvlInt = Literal[0, 10, 20, 30, 40, 50]
 
-logging.basicConfig(level=logging.NOTSET)  # Initialize the basic configuration
-logger = logging.getLogger("pymmcore-plus")
-
 
 DEFAULT_LOG_LEVEL: LogLvlStr = os.getenv("PYMM_LOG_LEVEL", "INFO").upper()  # type: ignore  # noqa: E501
+
+logging.basicConfig(level=DEFAULT_LOG_LEVEL)
+logger = logging.getLogger("pymmcore-plus")
 
 if any(x.endswith("pytest") for x in sys.argv):
     LOG_FILE = None
@@ -43,7 +43,7 @@ class CustomFormatter(logging.Formatter):
     bold_red = "\x1b[31;1m"
     reset = "\x1b[0m"
     _format: str = (
-        "%(asctime)s - %(name)s - %(levelname)s - %(message)s (%(filename)s:%(lineno)d)"
+        "%(asctime)s - %(name)s - %(levelname)s - (%(filename)s:%(lineno)d) %(message)s"
     )
 
     FORMATS: ClassVar[dict[int, str]] = {

--- a/src/pymmcore_plus/_logger.py
+++ b/src/pymmcore_plus/_logger.py
@@ -1,54 +1,24 @@
 from __future__ import annotations
 
-import atexit
-import contextlib
+import logging
 import os
 import sys
 import warnings
+from logging.handlers import RotatingFileHandler
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
-
-try:
-    from typing_extensions import deprecated
-except ImportError:
-
-    def deprecated(*args, **kwargs):  # type: ignore
-        def _decorator(func):  # type: ignore
-            return func
-
-        return _decorator
-
+from typing import TYPE_CHECKING, ClassVar
 
 __all__ = ["logger"]
 
 if TYPE_CHECKING:
-    from loguru import logger
     from typing_extensions import Literal
 
-    LogLvlStr = Literal["TRACE", "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
-    LogLvlInt = Literal[5, 10, 20, 30, 40, 50]
-else:
-    from loguru import __version__
-    from loguru._logger import Core, Logger
+    LogLvlStr = Literal["NOTSET", "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
+    LogLvlInt = Literal[0, 10, 20, 30, 40, 50]
 
-    PATCHERS = {"patchers": []}
-    with contextlib.suppress(Exception):
-        if tuple(int(x) for x in __version__.split("."))[:2] < (0, 7):
-            PATCHERS = {"patcher": None}
+logging.basicConfig(level=logging.NOTSET)  # Initialize the basic configuration
+logger = logging.getLogger("pymmcore-plus")
 
-    # avoid using the global loguru logger in case other packages are using it.
-    logger = Logger(
-        core=Core(),
-        exception=None,
-        depth=0,
-        record=False,
-        lazy=False,
-        colors=False,
-        raw=False,
-        capture=True,
-        extra={},
-        **PATCHERS,
-    )
 
 DEFAULT_LOG_LEVEL: LogLvlStr = os.getenv("PYMM_LOG_LEVEL", "INFO").upper()  # type: ignore  # noqa: E501
 
@@ -64,21 +34,38 @@ else:
 
     LOG_FILE = USER_DATA_DIR / "logs" / "pymmcore-plus.log"
 
-# this format helps to align the log messages with those from pymmcore
-LOGGER_FORMAT = (
-    "{time:YYYY-MM-DD HH:mm:ss.SSSSSS} | "
-    "<level>{level: <10}</level> | "
-    "<cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> | "
-    "<level>{message}</level>"
-)
+
+class CustomFormatter(logging.Formatter):
+    dark_grey = "\x1b[38;5;242m"
+    grey = "\x1b[38;20m"
+    yellow = "\x1b[33;20m"
+    red = "\x1b[31;20m"
+    bold_red = "\x1b[31;1m"
+    reset = "\x1b[0m"
+    _format: str = (
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s (%(filename)s:%(lineno)d)"
+    )
+
+    FORMATS: ClassVar[dict[int, str]] = {
+        logging.DEBUG: dark_grey + _format + reset,
+        logging.INFO: grey + _format + reset,
+        logging.WARNING: yellow + _format + reset,
+        logging.ERROR: red + _format + reset,
+        logging.CRITICAL: bold_red + _format + reset,
+    }
+
+    def format(self, record: logging.LogRecord) -> str:
+        log_fmt = self.FORMATS.get(record.levelno)
+        formatter = logging.Formatter(log_fmt)
+        return formatter.format(record)
 
 
 def configure_logging(
     file: str | Path | None = LOG_FILE,
-    strerr_level: LogLvlStr | LogLvlInt = DEFAULT_LOG_LEVEL,
-    file_level: LogLvlStr | LogLvlInt = "TRACE",
+    stderr_level: LogLvlStr | LogLvlInt = DEFAULT_LOG_LEVEL,
+    file_level: LogLvlStr | LogLvlInt = "DEBUG",
     log_to_stderr: bool = True,
-    file_rotation: str = "40MB",
+    file_rotation: int = 40,
     file_retention: int = 20,
 ) -> None:
     r"""Configure logging for pymmcore-plus.
@@ -108,7 +95,7 @@ def configure_logging(
         Mac OS X:   ~/Library/Application Support/pymmcore-plus/logs
         Unix:       ~/.local/share/pymmcore-plus/logs
         Win:        C:\Users\<username>\AppData\Local\pymmcore-plus\pymmcore-plus\logs
-    strerr_level : int | str
+    stderr_level : int | str
         Level for stderr logging.
         One of "TRACE", "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL",
         or 5, 10, 20, 30, 40, or 50, respectively.
@@ -117,59 +104,52 @@ def configure_logging(
         Level for logging to file, by default `"TRACE"`
     log_to_stderr : bool
         Whether to log to stderr, by default True
-    file_rotation : str
-        When to rollover to the next log file, by default `"40MB"`
+    file_rotation : int
+        When to rollover to the next log file, in MegaBytes, by default `40`.
     file_retention : int
         Maximum number of log files to retain, by default `20`
     """
-    logger.remove()
+    formatter = CustomFormatter()
+
+    for handler in logger.handlers:
+        logger.removeHandler(handler)
 
     # automatically log to stderr
     if log_to_stderr and sys.stderr:
-        logger.add(sys.stderr, level=strerr_level, backtrace=False)
+        stderr_handler = logging.StreamHandler(sys.stderr)
+        stderr_handler.setLevel(stderr_level)
+        stderr_handler.setFormatter(formatter)
+        logger.addHandler(stderr_handler)
 
     # automatically log to file
     if file:
         log_file = Path(file)
         log_file.parent.mkdir(parents=True, exist_ok=True)
-        logger.add(
-            log_file,
-            level=file_level,
-            format=LOGGER_FORMAT,
-            backtrace=False,
-            enqueue=True,
-            rotation=file_rotation,
-            retention=file_retention,
+
+        # Create a rotating file handler with a maximum file size and backup count.
+        file_handler = RotatingFileHandler(
+            log_file, maxBytes=file_rotation * 1_000_000, backupCount=file_retention
         )
+        file_handler.setLevel(file_level)
+        file_handler.setFormatter(formatter)
+        logger.addHandler(file_handler)
 
 
-@deprecated("Use configure_logging instead.")
 def set_log_level(level: LogLvlStr | LogLvlInt = DEFAULT_LOG_LEVEL) -> None:
-    import warnings
-
     warnings.warn(
         "set_log_level is deprecated. Use configure_logging instead.",
         FutureWarning,
         stacklevel=1,
     )
-    configure_logging(strerr_level=level)
+    configure_logging(stderr_level=level)
 
 
-def current_logfile(logger: Any) -> Path | None:
-    """Hacky way to return the current log file."""
-    # sourcery skip: use-next
-    try:
-        for h in logger._core.handlers.values():  # noqa: SLF001
-            if hasattr(h, "_sink") and getattr(h._sink, "_path", None):  # noqa: SLF001
-                return Path(h._sink._path)  # noqa: SLF001
-    except AttributeError as e:  # pragma: no cover
-        warnings.warn(
-            f"Error determining current log file {e}. Please check loguru version.",
-            RuntimeWarning,
-            stacklevel=1,
-        )
+def current_logfile(logger: logging.Logger) -> Path | None:
+    """Return the first RotatingFileHandler's baseFilename."""
+    for handler in logger.handlers:
+        if isinstance(handler, RotatingFileHandler):
+            return Path(handler.baseFilename)
     return None
 
 
 configure_logging()
-atexit.register(logger.remove)

--- a/src/pymmcore_plus/_util.py
+++ b/src/pymmcore_plus/_util.py
@@ -78,7 +78,7 @@ def find_micromanager(return_first: bool = True) -> str | None | list[str]:
     env_path = os.getenv("MICROMANAGER_PATH")
     if env_path and os.path.isdir(env_path):
         if return_first:
-            logger.debug(f"using MM path from env var: {env_path}")
+            logger.debug("using MM path from env var: %s", env_path)
             return env_path
         full_list.append(env_path)
 
@@ -86,7 +86,7 @@ def find_micromanager(return_first: bool = True) -> str | None | list[str]:
     user_install = sorted(USER_DATA_MM_PATH.glob("Micro-Manager*"), reverse=True)
     if user_install:
         if return_first:
-            logger.debug(f"using MM path from user install: {user_install[0]}")
+            logger.debug("using MM path from user install: %s", user_install[0])
             return str(user_install[0])
         full_list.extend([str(x) for x in user_install])
 
@@ -95,7 +95,7 @@ def find_micromanager(return_first: bool = True) -> str | None | list[str]:
     local_install = list(PYMMCORE_PLUS_PATH.glob(f"**/Micro-Manager*{sfx}"))
     if local_install:
         if return_first:
-            logger.debug(f"using MM path from local install: {local_install[0]}")
+            logger.debug("using MM path from local install: %s", local_install[0])
             return str(local_install[0])
         full_list.extend([str(x) for x in local_install])
 
@@ -112,9 +112,9 @@ def find_micromanager(return_first: bool = True) -> str | None | list[str]:
     pth = next(app_path.glob("[m,M]icro-[m,M]anager*"), None)
     if return_first:
         if pth is None:
-            logger.error(f"could not find micromanager directory in {app_path}")
+            logger.error("could not find micromanager directory in %s", app_path)
             return None
-        logger.debug(f"using MM path found in applications: {pth}")
+        logger.debug("using MM path found in applications: %s", pth)
         return str(pth)
     if pth is not None:
         full_list.append(str(pth))

--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -175,7 +175,7 @@ class CMMCorePlus(pymmcore.CMMCore):
 
         if logfile := current_logfile(logger):
             self.setPrimaryLogFile(str(logfile))
-            logger.debug("Initialized core {}", self)
+            logger.debug("Initialized core %s", self)
 
         self._mm_path = mm_path or find_micromanager()
         if not adapter_paths and self._mm_path:
@@ -280,7 +280,7 @@ class CMMCorePlus(pymmcore.CMMCore):
             if p not in env_path:
                 env_path = p + os.pathsep + env_path
         os.environ["PATH"] = env_path
-        logger.debug(f"setting adapter search paths: {paths}")
+        logger.debug("setting adapter search paths: %s", paths)
         super().setDeviceAdapterSearchPaths(paths)
 
     def loadDevice(self, label: str, moduleName: str, deviceName: str) -> None:
@@ -1907,7 +1907,7 @@ class CMMCorePlus(pymmcore.CMMCore):
                     orig_values[name] = getattr(self, f"get{name}")()
                     getattr(self, f"set{name}")(v)
                 except AttributeError:
-                    logger.warning(f"{name} is not a valid property, skipping.")
+                    logger.warning("%s is not a valid property, skipping.", name)
             yield
         finally:
             for k, v in orig_values.items():
@@ -2010,7 +2010,7 @@ class _MMCallbackRelay(pymmcore.MMEventCallback):
                 getattr(self._emitter, sig_name).emit(*args)
             except Exception as e:
                 logger.error(
-                    f"Exception occurred in MMCorePlus callback {sig_name!r}: {e}"
+                    "Exception occurred in MMCorePlus callback %r: %s", sig_name, e
                 )
 
         return reemit

--- a/src/pymmcore_plus/mda/_engine.py
+++ b/src/pymmcore_plus/mda/_engine.py
@@ -115,7 +115,7 @@ class MDAEngine(FullPMDAEngine):
                 # execute hardware autofocus
                 new_correction = self._execute_autofocus(action)
             except RuntimeError as e:
-                logger.warning("Hardware autofocus failed. {}", e)
+                logger.warning("Hardware autofocus failed. %s", e)
             else:
                 # store correction for this position index
                 p_idx = event.index.get("p", None)
@@ -175,12 +175,12 @@ class MDAEngine(FullPMDAEngine):
             try:
                 self._mmc.setConfig(event.channel.group, event.channel.config)
             except Exception as e:
-                logger.warning("Failed to set channel. {}", e)
+                logger.warning("Failed to set channel. %s", e)
         if event.exposure is not None:
             try:
                 self._mmc.setExposure(event.exposure)
             except Exception as e:
-                logger.warning("Failed to set exposure. {}", e)
+                logger.warning("Failed to set exposure. %s", e)
 
         if (
             # (if autoshutter wasn't set at the beginning of the sequence
@@ -205,7 +205,7 @@ class MDAEngine(FullPMDAEngine):
         try:
             self._mmc.snapImage()
         except Exception as e:
-            logger.warning("Failed to snap image. {}", e)
+            logger.warning("Failed to snap image. %s", e)
             return None
         if not event.keep_shutter_open:
             self._mmc.setShutterOpen(False)
@@ -306,7 +306,7 @@ class MDAEngine(FullPMDAEngine):
         if len(images) != n_events:
             logger.warning(
                 "Unexpected number of images returned from sequence. "
-                "Expected {}, got {}",
+                "Expected %s, got %s",
                 n_events,
                 len(images),
             )

--- a/src/pymmcore_plus/mda/_runner.py
+++ b/src/pymmcore_plus/mda/_runner.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
-import contextlib
 import time
 import warnings
 from typing import TYPE_CHECKING, Iterable, Iterator
 
-from psygnal import EmitLoopError
 from useq import MDASequence
 
-from pymmcore_plus._logger import logger
+from pymmcore_plus._logger import exceptions_logged, logger
 
 from ._protocol import PMDAEngine
 from .events import PMDASignaler, _get_auto_MDA_callback_class
@@ -167,7 +165,7 @@ class MDARunner:
             self._run(engine, events)
         except Exception as e:
             error = e
-        with contextlib.suppress(Exception):
+        with exceptions_logged():
             self._finish_run(sequence)
         if error is not None:
             raise error
@@ -189,13 +187,13 @@ class MDARunner:
             output = engine.exec_event(event)
 
             if (img := getattr(output, "image", None)) is not None:
-                with contextlib.suppress(EmitLoopError):
+                with exceptions_logged():
                     self._signals.frameReady.emit(img, event)
 
             # FIXME: this is here to make tests pass with sequenced events for now,
             # but we might not want to do this for sequences for performance reasons.s
             if (imgs := getattr(output, "image_sequence", None)) is not None:
-                with contextlib.suppress(EmitLoopError):
+                with exceptions_logged():
                     for img, sub_event in imgs:
                         self._signals.frameReady.emit(img, sub_event)
 

--- a/src/pymmcore_plus/mda/_runner.py
+++ b/src/pymmcore_plus/mda/_runner.py
@@ -183,7 +183,7 @@ class MDARunner:
             if self._wait_until_event(event) or not self._running:
                 break
 
-            logger.info(event)
+            logger.info("%s", event)
             engine.setup_event(event)
 
             output = engine.exec_event(event)
@@ -218,7 +218,7 @@ class MDARunner:
         self._sequence = sequence
 
         self._engine.setup_sequence(sequence)
-        logger.info("MDA Started: {}", sequence)
+        logger.info("MDA Started: %s", sequence)
 
         self._signals.sequenceStarted.emit(sequence)
         self._reset_timer()
@@ -242,7 +242,7 @@ class MDARunner:
             Whether the MDA has been canceled.
         """
         if self._canceled:
-            logger.warning("MDA Canceled: {}", self._sequence)
+            logger.warning("MDA Canceled: %s", self._sequence)
             self._signals.sequenceCanceled.emit(self._sequence)
             self._canceled = False
             return True
@@ -310,5 +310,5 @@ class MDARunner:
         if hasattr(self._engine, "teardown_sequence"):
             self._engine.teardown_sequence(sequence)  # type: ignore
 
-        logger.info("MDA Finished: {}", sequence)
+        logger.info("MDA Finished: %s", sequence)
         self._signals.sequenceFinished.emit(sequence)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import pymmcore_plus
 import pytest
+from pymmcore_plus._logger import logger
 from pymmcore_plus.core.events import CMMCoreSignaler, QCoreSignaler
 from pymmcore_plus.mda.events import MDASignaler, QMDASignaler
 
@@ -41,6 +42,15 @@ def mock_fullfocus_failure(core: pymmcore_plus.CMMCorePlus):
 
     with patch.object(core, "fullFocus", _fullfocus):
         yield
+
+
+@pytest.fixture
+def caplog(caplog: pytest.LogCaptureFixture):
+    logger.addHandler(caplog.handler)
+    try:
+        yield caplog
+    finally:
+        logger.removeHandler(caplog.handler)
 
 
 def pytest_collection_modifyitems(session, config, items: list[pytest.Function]):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,16 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pymmcore_plus
 import pytest
-from pymmcore_plus._logger import logger
 from pymmcore_plus.core.events import CMMCoreSignaler, QCoreSignaler
 from pymmcore_plus.mda.events import MDASignaler, QMDASignaler
-
-if TYPE_CHECKING:
-    from _pytest.logging import LogCaptureFixture
 
 
 @pytest.fixture(params=["QSignal", "psygnal"], scope="function")
@@ -28,15 +23,6 @@ def core(request):
         pytest.fail("To run tests, please install MM with `mmcore install`")
     core.loadSystemConfiguration()
     return core
-
-
-@pytest.fixture
-def caplog(caplog: LogCaptureFixture):
-    handler_id = logger.add(caplog.handler, format="{message}")
-    try:
-        yield caplog
-    finally:
-        logger.remove(handler_id)
 
 
 @pytest.fixture


### PR DESCRIPTION
closes #238 

we don't use many of the loguru features, and it brings on an unneeded extra dependency, and the possibility of conflict with stdlib logging