### PR TITLE
build: make cli dependencies (typer and rich) optional

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .[testing]
+          pip install -e .[testing,cli]
       
       - name: Downgrade pydantic
         if: ${{ matrix.pydantic }}
@@ -86,7 +86,7 @@ jobs:
         working-directory: pymmcore-widgets
 
       - name: Install core
-        run: python -m pip install -e .[testing] -U
+        run: python -m pip install -e .[testing,cli] -U
 
       - name: Install Micro-Manager
         run: mmcore install
@@ -124,7 +124,7 @@ jobs:
         run: |
           python -m pip install -U pip
           python -m pip install -e ./napari-micromanager[testing]
-          python -m pip install -e ./pymmcore-plus[testing]
+          python -m pip install -e ./pymmcore-plus[testing,cli]
 
       - name: Install Micro-Manager
         run: mmcore install

--- a/README.md
+++ b/README.md
@@ -78,15 +78,24 @@ Java in the loop.
 
 ### Install
 
+from pip
 ```sh
-# from pip
 pip install pymmcore-plus
 
-# from conda
-conda install -c conda-forge pymmcore-plus
+# or, add the [cli] extra if you wish to use the `mmcore` command line tool:
 
-# or from source tree
-pip install git+https://github.com/pymmcore-plus/pymmcore-plus.git
+pip install "pymmcore-plus[cli]"
+```
+
+from conda
+
+```sh
+conda install -c conda-forge pymmcore-plus
+```
+
+dev version from github
+```sh
+pip install 'pymmcore-plus[cli] @ git+https://github.com/pymmcore-plus/pymmcore-plus'
 ```
 
 Usually, you'll then want to install the device adapters (though

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Java in the loop.
 ### Install
 
 from pip
+
 ```sh
 pip install pymmcore-plus
 
@@ -94,16 +95,19 @@ conda install -c conda-forge pymmcore-plus
 ```
 
 dev version from github
+
 ```sh
 pip install 'pymmcore-plus[cli] @ git+https://github.com/pymmcore-plus/pymmcore-plus'
 ```
 
-Usually, you'll then want to install the device adapters (though
-you can also download these manually from [micro-manager.org](https://micro-manager.org/Micro-Manager_Nightly_Builds)):
+Usually, you'll then want to install the device adapters. Assuming you've
+installed with `pip install "pymmcore-plus[cli]"`, you can run:
 
 ```sh
 mmcore install
 ```
+
+(you can also download these manually from [micro-manager.org](https://micro-manager.org/Micro-Manager_Nightly_Builds))
 
 _See [installation documentation ](https://pymmcore-plus.github.io/pymmcore-plus/install/) for more details._
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,12 +63,17 @@ Install with `pip` or `conda`:
 
 ```bash
 pip install pymmcore-plus
+
+# OR, to include the `mmcore` command line tool
+pip install "pymmcore-plus[cli]"
+
 # OR
 conda install -c conda-forge pymmcore-plus
 ```
 
 You will also need the micro-manager device adapters on your system.
-To get them quickly, you can run:
+To get them quickly, assuming you have installed with `pymmcore-plus[cli]`,
+you can run:
 
 ```bash
 mmcore install

--- a/docs/install.md
+++ b/docs/install.md
@@ -6,6 +6,10 @@
 
 ```bash
 pip install pymmcore-plus
+
+# or, add the [cli] extra if you wish to use the `mmcore` command line tool:
+
+pip install "pymmcore-plus[cli]"
 ```
 
 ... as well as conda:
@@ -22,31 +26,32 @@ provided by
 [mmCoreAndDevices](https://github.com/micro-manager/mmCoreAndDevices#mmcoreanddevices).
 There are two ways to do this:
 
-1. **Use the `pymmcore_plus.install` module**
+1. **Use the `mmcore` command line tool**
 
-    This library provides a quick way to install the latest version of
-    micro-manager:
+    If you've installed with `pip install "pymmcore-plus[cli]"`,
+   this library provides a quick way to install the latest version of
+   micro-manager:
 
-    ```bash
-    mmcore install
-    ```
+   ```bash
+   mmcore install
+   ```
 
-    This will download the latest release of micro-manager and place it in the
-    pymmcore-plus folder.  If you would like to modify the location of the
-    installation, or the release of micro-manager to install, you can use the
-    `--dest` and `--release` flags respectively.
+   This will download the latest release of micro-manager and place it in the
+   pymmcore-plus folder. If you would like to modify the location of the
+   installation, or the release of micro-manager to install, you can use the
+   `--dest` and `--release` flags respectively.
 
-    For more information, run:
+   For more information, run:
 
-    ```bash
-    mmcore install --help
-    ```
+   ```bash
+   mmcore install --help
+   ```
 
 2. **Download manually from micro-manager.org**
 
-    Go to the [micro-manager
-    downloads](https://micro-manager.org/Micro-Manager_Nightly_Builds) page and
-    download the latest release for your Operating System.
+   Go to the [micro-manager
+   downloads](https://micro-manager.org/Micro-Manager_Nightly_Builds) page and
+   download the latest release for your Operating System.
 
 !!! danger "Critical"
 
@@ -79,7 +84,6 @@ There are two ways to do this:
     ```shell
     python -c "from pymmcore_plus import find_micromanager; print(find_micromanager())"
     ```
-
 
 ### On Linux
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,6 @@ dependencies = [
     "numpy",
     "psygnal >=0.4.2",
     "pymmcore >=10.1.1.70.4",
-    "rich >=10.2.0",
-    "typer >=0.4.2",
     "typing-extensions",
     "useq-schema >=0.4.0",
     "wrapt",
@@ -48,6 +46,7 @@ dependencies = [
 # extras
 # https://peps.python.org/pep-0621/#dependencies-optional-dependencies
 [project.optional-dependencies]
+cli = ["typer >=0.4.2", "rich >=10.2.0"]
 docs = [
     "mkdocs >=1.4",
     "mkdocs-material",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,15 @@ docs = [
     "mkdocstrings-python ==1.1.2",
     # "griffe @ git+https://github.com/tlambert03/griffe@recursion"
 ]
-testing = ["PyQt6", "pytest", "pytest-cov", "pytest-qt", "qtpy"]
+testing = [
+    "PyQt6",
+    "pytest",
+    "pytest-cov",
+    "pytest-qt",
+    "qtpy",
+    "typer",
+    "rich",
+]
 dev = [
     "black",
     "ipython",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,8 @@ dependencies = [
     "numpy",
     "psygnal >=0.4.2",
     "pymmcore >=10.1.1.70.4",
+    "rich >=10.2.0",
+    "typer >=0.4.2",
     "typing-extensions",
     "useq-schema >=0.4.0",
     "wrapt",
@@ -46,7 +48,6 @@ dependencies = [
 # extras
 # https://peps.python.org/pep-0621/#dependencies-optional-dependencies
 [project.optional-dependencies]
-cli = ["typer >=0.4.2", "rich >=10.2.0"]
 docs = [
     "mkdocs >=1.4",
     "mkdocs-material",
@@ -54,15 +55,7 @@ docs = [
     "mkdocstrings-python ==1.1.2",
     # "griffe @ git+https://github.com/tlambert03/griffe@recursion"
 ]
-testing = [
-    "PyQt6",
-    "pytest",
-    "pytest-cov",
-    "pytest-qt",
-    "qtpy",
-    "typer",
-    "rich",
-]
+testing = ["PyQt6", "pytest", "pytest-cov", "pytest-qt", "qtpy"]
 dev = [
     "black",
     "ipython",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
 # extras
 # https://peps.python.org/pep-0621/#dependencies-optional-dependencies
 [project.optional-dependencies]
+cli = ["typer >=0.4.2", "rich >=10.2.0"]
 docs = [
     "mkdocs >=1.4",
     "mkdocs-material",
@@ -55,7 +56,7 @@ docs = [
     "mkdocstrings-python ==1.1.2",
     # "griffe @ git+https://github.com/tlambert03/griffe@recursion"
 ]
-testing = ["PyQt6", "pytest", "pytest-cov", "pytest-qt", "qtpy"]
+testing = ["PyQt6", "pytest", "pytest-cov", "pytest-qt", "qtpy", "typer", "rich"]
 dev = [
     "black",
     "ipython",

--- a/src/pymmcore_plus/_cli.py
+++ b/src/pymmcore_plus/_cli.py
@@ -13,8 +13,8 @@ try:
     from rich import print
 except ImportError:  # pragma: no cover
     raise ImportError(
-        "please install with `pip install pymmcore-plus[cli]` to use the pymmcore-plus"
-        " command line interface."
+        'Please install with `pip install "pymmcore-plus[cli]"` to use the '
+        "pymmcore-plus command line interface."
     ) from None
 
 import pymmcore_plus

--- a/src/pymmcore_plus/_cli.py
+++ b/src/pymmcore_plus/_cli.py
@@ -8,8 +8,14 @@ from contextlib import suppress
 from pathlib import Path
 from typing import List, Optional, Union, cast
 
-import typer
-from rich import print
+try:
+    import typer
+    from rich import print
+except ImportError:  # pragma: no cover
+    raise ImportError(
+        "please install with `pip install pymmcore-plus[cli]` to use the pymmcore-plus"
+        " command line interface."
+    ) from None
 
 import pymmcore_plus
 from pymmcore_plus._logger import configure_logging

--- a/src/pymmcore_plus/install.py
+++ b/src/pymmcore_plus/install.py
@@ -14,7 +14,15 @@ from typing import Iterator
 from urllib.request import urlopen, urlretrieve
 
 import typer
-from rich import print, progress
+
+try:
+    from rich import print, progress
+except ImportError:  # pragma: no cover
+    raise ImportError(
+        "please install with `pip install pymmcore-plus[cli]` to use the pymmcore-plus "
+        "command line tools."
+    ) from None
+
 
 from pymmcore_plus._util import USER_DATA_MM_PATH
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,9 +11,14 @@ from typing import TYPE_CHECKING, Any, Callable, cast
 from unittest.mock import patch
 
 import pytest
+
+try:
+    from pymmcore_plus._cli import app
+    from typer.testing import CliRunner
+except ImportError:
+    pytest.skip("cli extras not available", allow_module_level=True)
+
 from pymmcore_plus import CMMCorePlus, __version__, _cli, _logger, install
-from pymmcore_plus._cli import app
-from typer.testing import CliRunner
 from useq import MDASequence
 
 if TYPE_CHECKING:


### PR DESCRIPTION
This follows on #239 to make Typer and rich (cli dependencies) only necessary when using the `mmcore` CLI.

now, use `pip install pymmcore-plus[cli]` to get that functionality

cc @wl-stepp