### PR TITLE
feat: add metadata to frameready signal, add getTaggedImage

### DIFF
--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -17,6 +17,7 @@ from typing import (
     Callable,
     Iterable,
     Iterator,
+    NamedTuple,
     Pattern,
     Sequence,
     TypeVar,
@@ -109,6 +110,10 @@ STATE = pymmcore.g_Keyword_State
 LABEL = pymmcore.g_Keyword_Label
 STATE_PROPS = (STATE, LABEL)
 UNNAMED_PRESET = "NewPreset"
+
+class TaggedImage(NamedTuple):
+    pix: np.ndarray
+    tags: dict[str, Any]
 
 
 @contextmanager
@@ -1432,6 +1437,13 @@ class CMMCorePlus(pymmcore.CMMCore):
             img = img.view(dtype=f"u{img.dtype.itemsize//4}")
             img = img.reshape(new_shape)[:, :, (2, 1, 0, 3)]  # mmcore gives bgra
         return img
+
+    def getTaggedImage(self, channel_index: int = 0) -> TaggedImage:
+        return self._createTaggedImage(self.getImage(channel_index), {})
+
+    def _createTaggedImage(self, img: np.ndarray, md: dict) -> TaggedImage:
+        tags = md
+        config = 
 
     def snap(self, numChannel: int | None = None, *, fix: bool = True) -> np.ndarray:
         """Snap and return an image.

--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -1447,7 +1447,7 @@ class CMMCorePlus(pymmcore.CMMCore):
         similar to MMCoreJ.getTaggedImage().
         """
         img = self.getImage(channel_index)
-        return self._createTaggedImage(img, None, channel_index)
+        return TaggedImage(img, self.getTags(None, channel_index))
 
     def popNextTaggedImage(self, channel_index: int = 0) -> TaggedImage:
         """Return popNextImageAndMD as named tuple with metadata.
@@ -1456,14 +1456,6 @@ class CMMCorePlus(pymmcore.CMMCore):
         similar to MMCoreJ.popNextTaggedImage().
         """
         img, meta = self.popNextImageAndMD(channel_index, 0)
-        return self._createTaggedImage(img, meta, channel_index)
-
-    def _createTaggedImage(
-        self,
-        img: np.ndarray,
-        meta: Metadata | None = None,
-        channel_index: int | None = None,
-    ) -> TaggedImage:
         return TaggedImage(img, self.getTags(meta, channel_index))
 
     # this matches the MMCoreJ implementation ... which we may or may not want to do?

--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import atexit
 import os
 import re
+import time
 import warnings
 import weakref
 from collections import defaultdict
@@ -110,6 +111,7 @@ STATE = pymmcore.g_Keyword_State
 LABEL = pymmcore.g_Keyword_Label
 STATE_PROPS = (STATE, LABEL)
 UNNAMED_PRESET = "NewPreset"
+
 
 class TaggedImage(NamedTuple):
     pix: np.ndarray
@@ -1439,11 +1441,105 @@ class CMMCorePlus(pymmcore.CMMCore):
         return img
 
     def getTaggedImage(self, channel_index: int = 0) -> TaggedImage:
-        return self._createTaggedImage(self.getImage(channel_index), {})
+        """Return getImage as named tuple with metadata.
 
-    def _createTaggedImage(self, img: np.ndarray, md: dict) -> TaggedImage:
-        tags = md
-        config = 
+        :sparkles: *This method is new in `CMMCorePlus`.* It returns an object
+        similar to MMCoreJ.getTaggedImage().
+        """
+        img = self.getImage(channel_index)
+        return self._createTaggedImage(img, None, channel_index)
+
+    def popNextTaggedImage(self, channel_index: int = 0) -> TaggedImage:
+        """Return popNextImageAndMD as named tuple with metadata.
+
+        :sparkles: *This method is new in `CMMCorePlus`.* It returns an object
+        similar to MMCoreJ.popNextTaggedImage().
+        """
+        img, meta = self.popNextImageAndMD(channel_index, 0)
+        return self._createTaggedImage(img, meta, channel_index)
+
+    def _createTaggedImage(
+        self,
+        img: np.ndarray,
+        meta: Metadata | None = None,
+        channel_index: int | None = None,
+    ) -> TaggedImage:
+        return TaggedImage(img, self.getTags(meta, channel_index))
+
+    # this matches the MMCoreJ implementation ... which we may or may not want to do?
+    def getTags(
+        self, meta: Metadata | None = None, channel_index: int | None = None
+    ) -> dict[str, Any]:
+        """Return a dict of metadata tags for the state of the core.
+
+        NOTE: this function is pretty slow, and is potentially called on every frame
+        of an acquisition. It would be nice to determine what is absolutely necessary,
+        and possible allow the user to specify what they want to include.
+
+        :sparkles: *This method is new in `CMMCorePlus`.* It returns only the `.tags`
+        attribute of what you would get with `getTaggedImage()` or
+        `popNextTaggedImage()`.
+        """
+        # TODO: make these keys into an enum or something somewhere...
+        # you shouldn't have to search the code to find out what keys are available
+
+        tags = dict(meta) if meta else {}
+        for dev, label, val in self.getSystemStateCache():  # type: ignore
+            tags[f"{dev}-{label}"] = val
+
+        tags["BitDepth"] = self.getImageBitDepth()
+
+        # NOTE: AcqEngJ appears to also add this as PixelSize_um
+        # while MMCoreJ uses PixelSizeUm?  not sure why both are needed
+        tags["PixelSizeUm"] = self.getPixelSizeUm(True)  # true == cached
+
+        affine = self.getPixelSizeAffine(True)  # true == cached
+        tags["PixelSizeAffine"] = ";".join(str(x) for x in affine)
+        tags["ROI"] = "-".join(str(x) for x in self.getROI())
+        tags["Width"] = self.getImageWidth()
+        tags["Height"] = self.getImageHeight()
+        if (depth := self.getBytesPerPixel()) == 4:
+            ncomp = self.getNumberOfComponents()
+            pix_type = "GRAY32" if ncomp == 1 else "RGB32"
+        else:
+            pix_type = {1: "GRAY8", 2: "GRAY16", 8: "RGB64"}[depth]
+        tags["PixelType"] = pix_type
+        tags["Frame"] = 0
+        tags["FrameIndex"] = 0
+        tags["Position"] = "Default"
+        tags["PositionIndex"] = 0
+        tags["Slice"] = 0
+        tags["SliceIndex"] = 0
+
+        try:
+            channel_group = self.getPropertyFromCache("Core", "ChannelGroup")
+            channel = self.getCurrentConfigFromCache(channel_group)
+        except Exception:
+            channel = "Default"
+        tags["Channel"] = channel
+        tags["ChannelIndex"] = 0
+
+        with suppress(Exception):
+            tags["Binning"] = self.getProperty(self.getCameraDevice(), "Binning")
+
+        if channel_index is not None:
+            if "CameraChannelIndex" not in tags:
+                tags["CameraChannelIndex"] = channel_index
+                tags["ChannelIndex"] = channel_index
+            if "Camera" not in tags:
+                core_cam = tags.get("Core-Camera")
+                phys_cam_key = f"{core_cam}-Physical Camera {channel_index+1}"
+                if phys_cam_key in tags:
+                    tags["Camera"] = tags[phys_cam_key]
+                    # tags["Channel"] = tags[phys_cam_key] # ?? why did MMCoreJ do this?
+
+        # these are added by AcqEngJ
+        # yyyy-MM-dd HH:mm:ss.mmmmmm  # NOTE AcqEngJ omits microseconds
+        tags["Time"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")
+
+        # used by Runner
+        tags["PerfCounter"] = time.perf_counter()
+        return tags
 
     def snap(self, numChannel: int | None = None, *, fix: bool = True) -> np.ndarray:
         """Snap and return an image.

--- a/src/pymmcore_plus/mda/_engine.py
+++ b/src/pymmcore_plus/mda/_engine.py
@@ -12,9 +12,11 @@ from pymmcore_plus.core._sequencing import SequencedEvent
 from ._protocol import PMDAEngine
 
 if TYPE_CHECKING:
-    import numpy as np
+    from numpy.typing import NDArray
 
     from pymmcore_plus.core import CMMCorePlus
+
+    from ._protocol import PImagePayload
 
 
 class MDAEngine(PMDAEngine):
@@ -102,14 +104,14 @@ class MDAEngine(PMDAEngine):
             self.setup_single_event(event)
         self._mmc.waitForSystem()
 
-    def exec_event(self, event: MDAEvent) -> EventPayload | None:
+    def exec_event(self, event: MDAEvent) -> Sequence[PImagePayload]:
         """Execute an individual event and return the image data."""
         action = getattr(event, "action", None)
         if isinstance(action, HardwareAutofocus):
             # skip if no autofocus device is found
             if not self._mmc.getAutoFocusDevice():
                 logger.warning("No autofocus device found. Cannot execute autofocus.")
-                return None
+                return ()
 
             try:
                 # execute hardware autofocus
@@ -120,7 +122,7 @@ class MDAEngine(PMDAEngine):
                 # store correction for this position index
                 p_idx = event.index.get("p", None)
                 self._z_correction[p_idx] = new_correction
-            return None
+            return ()
 
         if isinstance(event, SequencedEvent):
             return self.exec_sequenced_event(event)
@@ -195,7 +197,7 @@ class MDAEngine(PMDAEngine):
             self._mmc.setAutoShutter(False)
             self._mmc.setShutterOpen(True)
 
-    def exec_single_event(self, event: MDAEvent) -> EventPayload | None:
+    def exec_single_event(self, event: MDAEvent) -> Sequence[PImagePayload]:
         """Execute a single (non-triggered) event and return the image data.
 
         This method is not part of the PMDAEngine protocol (it is called by
@@ -206,10 +208,10 @@ class MDAEngine(PMDAEngine):
             self._mmc.snapImage()
         except Exception as e:
             logger.warning("Failed to snap image. %s", e)
-            return None
+            return ()
         if not event.keep_shutter_open:
             self._mmc.setShutterOpen(False)
-        return EventPayload(image=self._mmc.getImage())
+        return ((self._mmc.getImage(), event, {}),)
 
     def teardown_event(self, event: MDAEvent) -> None:
         """Teardown state of system (hardware, etc.) after `event`."""
@@ -271,7 +273,7 @@ class MDAEngine(PMDAEngine):
         elif event.channel is not None:
             core.setConfig(event.channel.group, event.channel.config)
 
-    def exec_sequenced_event(self, event: SequencedEvent) -> EventPayload:
+    def exec_sequenced_event(self, event: SequencedEvent) -> Sequence[PImagePayload]:
         """Execute a sequenced (triggered) event and return the image data.
 
         This method is not part of the PMDAEngine protocol (it is called by
@@ -314,8 +316,7 @@ class MDAEngine(PMDAEngine):
                 n_events,
                 len(images),
             )
-
-        return EventPayload(image_sequence=tuple(zip(images, event.events)))
+        return tuple(ImagePayload(img, e, {}) for img, e in zip(images, event.events))
 
     # ===================== EXTRA =====================
 
@@ -363,6 +364,7 @@ class MDAEngine(PMDAEngine):
         self._mmc.setZPosition(cast("float", event.z_pos) + correction)
 
 
-class EventPayload(NamedTuple):
-    image: np.ndarray | None = None
-    image_sequence: Sequence[tuple[np.ndarray, MDAEvent]] | None = None
+class ImagePayload(NamedTuple):
+    image: NDArray
+    event: MDAEvent
+    metadata: dict

--- a/src/pymmcore_plus/mda/_protocol.py
+++ b/src/pymmcore_plus/mda/_protocol.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Protocol, Sequence, Union, runtime_checkable
 
 if TYPE_CHECKING:
     from typing import Iterable, Iterator
 
+    from numpy.typing import NDArray
     from useq import MDAEvent, MDASequence
+
+    PImagePayload = Union[
+        tuple[NDArray], tuple[NDArray, MDAEvent], tuple[NDArray, MDAEvent, dict]
+    ]
 
 
 # NOTE: This whole thing could potentially go in useq-schema
@@ -37,7 +42,7 @@ class PMDAEngine(Protocol):
         """
 
     @abstractmethod
-    def exec_event(self, event: MDAEvent) -> object:
+    def exec_event(self, event: MDAEvent) -> Sequence[PImagePayload]:
         """Execute `event`.
 
         This method is called after `setup_event` and is responsible for
@@ -82,3 +87,14 @@ class PMDAEngine(Protocol):
         If the engine provides this function, it will be called after the
         last event in the sequence has been executed.
         """
+
+
+class PDataHandler(Protocol):
+    def start(self) -> None:
+        ...
+
+    def put(self, payload: PImagePayload) -> None:
+        ...
+
+    def finish(self) -> None:
+        ...

--- a/src/pymmcore_plus/mda/_protocol.py
+++ b/src/pymmcore_plus/mda/_protocol.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import TYPE_CHECKING, Protocol, Sequence, Union, runtime_checkable
+from typing import TYPE_CHECKING, Protocol, Sequence, runtime_checkable
 
 if TYPE_CHECKING:
     from typing import Iterable, Iterator
@@ -9,9 +9,7 @@ if TYPE_CHECKING:
     from numpy.typing import NDArray
     from useq import MDAEvent, MDASequence
 
-    PImagePayload = Union[
-        tuple[NDArray], tuple[NDArray, MDAEvent], tuple[NDArray, MDAEvent, dict]
-    ]
+    PImagePayload = tuple[NDArray, MDAEvent, dict]
 
 
 # NOTE: This whole thing could potentially go in useq-schema
@@ -87,14 +85,3 @@ class PMDAEngine(Protocol):
         If the engine provides this function, it will be called after the
         last event in the sequence has been executed.
         """
-
-
-class PDataHandler(Protocol):
-    def start(self) -> None:
-        ...
-
-    def put(self, payload: PImagePayload) -> None:
-        ...
-
-    def finish(self) -> None:
-        ...

--- a/src/pymmcore_plus/mda/events/_protocol.py
+++ b/src/pymmcore_plus/mda/events/_protocol.py
@@ -16,4 +16,4 @@ class PMDASignaler(Protocol):
     sequenceFinished: PSignal
     """Emits `(sequence: MDASequence)` when an acquisition sequence is finished."""
     frameReady: PSignal
-    """Emits `(image: np.ndarray, event: MDAEvent)` after an image is acquired during an acquisition sequence."""  # noqa: E501
+    """Emits `(img, MDAEvent, metadata)` after an image is acquired during an acquisition sequence."""  # noqa: E501

--- a/src/pymmcore_plus/mda/events/_psygnal.py
+++ b/src/pymmcore_plus/mda/events/_psygnal.py
@@ -8,4 +8,4 @@ class MDASignaler:
     sequencePauseToggled = Signal(bool)  # when MDA is paused/unpaused
     sequenceCanceled = Signal(MDASequence)  # when mda is canceled
     sequenceFinished = Signal(MDASequence)  # when mda is done (whether canceled or not)
-    frameReady = Signal(np.ndarray, MDAEvent)  # after each event in the sequence
+    frameReady = Signal(np.ndarray, MDAEvent, dict)  # img, MDAEvent, metadata

--- a/src/pymmcore_plus/mda/events/_qsignals.py
+++ b/src/pymmcore_plus/mda/events/_qsignals.py
@@ -6,4 +6,4 @@ class QMDASignaler(QObject):
     sequencePauseToggled = Signal(bool)  # when MDA is paused/unpaused
     sequenceCanceled = Signal(object)  # when mda is canceled
     sequenceFinished = Signal(object)  # when mda is done (whether canceled or not)
-    frameReady = Signal(object, object)  # after each event in the sequence
+    frameReady = Signal(object, object, dict)  # img, MDAEvent, metadata


### PR DESCRIPTION
This emits a (currently-unstructured) metadata dict as the third value of frameReady.  This would be an important component for a proper writer spec (#29) 

It also adds `getTaggedImage` to mimic the Java API.
i should note that I don't really like the `getTaggedImage` API (the "tags" themselves are constructed in a way that makes them hard to disambiguate).  But for now, this uses it in case it helps with cross-compatibility

side-note: because both psygnal and qt let you connect a slot that accepts less values than the signal emits, we can always add positional arguments to signals without breaking any APIs.

closes #220 
