### PR TITLE
fix: fix a bug in saveSystemConfiguration method

### DIFF
--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -1728,28 +1728,29 @@ class CMMCorePlus(pymmcore.CMMCore):
             super().setFocusDevice(focusLabel)
             self.events.propertyChanged.emit("Core", "Focus", focusLabel)
 
-    def saveSystemConfiguration(
-        self, filename: str, objective_device: str | None = None
-    ) -> None:
+    def saveSystemConfiguration(self, filename: str) -> None:
         """Saves the current system configuration to a text file.
 
         **Why Override?** To also save pixel size configurations.
         """
         super().saveSystemConfiguration(filename)
         px_configs = self.getAvailablePixelSizeConfigs()
-        if not px_configs or objective_device is None:
+        if not px_configs:
             return
         # saveSystemConfiguration does not save the pixel size config so here
         # we add to the saved file also any pixel size config.
         with open(filename, "a") as f:
             f.write("# PixelSize settings")
             for px_config in px_configs:
-                data = self.getPixelSizeConfigData(px_config)
-                obj = data.dict()[objective_device]["Label"]
+                data = self.getPixelSizeConfigData(px_config).dict()
+                obj_device = next(iter(data.keys()))
+                obj_label = data[obj_device].get("Label")
+                if obj_label is None:
+                    continue
                 px_size = self.getPixelSizeUmByID(px_config)
                 px_affine = self.getPixelSizeAffineByID(px_config)
                 cfg = (
-                    f"\nConfigPixelSize,{px_config},Objective,Label,{obj}\n"
+                    f"\nConfigPixelSize,{px_config},{obj_device},Label,{obj_label}\n"
                     f"PixelSize_um,{px_config},{px_size}\n"
                     f"PixelSizeAffine,{px_config},{','.join(map(str, px_affine))}"
                 )

--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -1728,14 +1728,16 @@ class CMMCorePlus(pymmcore.CMMCore):
             super().setFocusDevice(focusLabel)
             self.events.propertyChanged.emit("Core", "Focus", focusLabel)
 
-    def saveSystemConfiguration(self, filename: str) -> None:
+    def saveSystemConfiguration(
+        self, filename: str, objective_device: str | None = None
+    ) -> None:
         """Saves the current system configuration to a text file.
 
         **Why Override?** To also save pixel size configurations.
         """
         super().saveSystemConfiguration(filename)
         px_configs = self.getAvailablePixelSizeConfigs()
-        if not px_configs:
+        if not px_configs or objective_device is None:
             return
         # saveSystemConfiguration does not save the pixel size config so here
         # we add to the saved file also any pixel size config.
@@ -1743,7 +1745,7 @@ class CMMCorePlus(pymmcore.CMMCore):
             f.write("# PixelSize settings")
             for px_config in px_configs:
                 data = self.getPixelSizeConfigData(px_config)
-                obj = data.dict()["Objective"]["Label"]
+                obj = data.dict()[objective_device]["Label"]
                 px_size = self.getPixelSizeUmByID(px_config)
                 px_affine = self.getPixelSizeAffineByID(px_config)
                 cfg = (

--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -1750,7 +1750,7 @@ class CMMCorePlus(pymmcore.CMMCore):
             cfg.extend(
                 f"ConfigPixelSize,{px_config},{device},{prop},{val}"
                 for device, prop, val in self.getPixelSizeConfigData(px_config)
-                )
+            )
             px_size = self.getPixelSizeUmByID(px_config)
             px_affine = self.getPixelSizeAffineByID(px_config)
             cfg.extend(

--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -42,8 +42,6 @@ from ._sequencing import can_sequence_events
 from .events import CMMCoreSignaler, PCoreSignaler, _get_auto_core_callback_class
 
 if TYPE_CHECKING:
-    from io import TextIOBase
-
     import numpy as np
     from typing_extensions import Literal, TypedDict
     from useq import MDAEvent
@@ -1738,28 +1736,28 @@ class CMMCorePlus(pymmcore.CMMCore):
         super().saveSystemConfiguration(filename)
         # saveSystemConfiguration does not save the pixel size config so here
         # we add to the saved file also any pixel size config.
-        with open(filename, "a") as f:
-            self._save_pixel_configurations(f)
+        self._save_pixel_configurations(filename)
 
-    def _save_pixel_configurations(self, f: TextIOBase) -> None:
-        px_configs = self.getAvailablePixelSizeConfigs()
-        if not px_configs:
-            return
-        cfg = ["# PixelSize settings"]
-        for px_config in px_configs:
-            cfg.extend(
-                f"ConfigPixelSize,{px_config},{device},{prop},{val}"
-                for device, prop, val in self.getPixelSizeConfigData(px_config)
-            )
-            px_size = self.getPixelSizeUmByID(px_config)
-            px_affine = self.getPixelSizeAffineByID(px_config)
-            cfg.extend(
-                (
-                    f"PixelSize_um,{px_config},{px_size}",
-                    f"PixelSizeAffine,{px_config},{','.join(map(str, px_affine))}",
+    def _save_pixel_configurations(self, filename: str) -> None:
+        with open(filename, "a") as f:
+            px_configs = self.getAvailablePixelSizeConfigs()
+            if not px_configs:
+                return
+            cfg = ["# PixelSize settings"]
+            for px_config in px_configs:
+                cfg.extend(
+                    f"ConfigPixelSize,{px_config},{device},{prop},{val}"
+                    for device, prop, val in self.getPixelSizeConfigData(px_config)
                 )
-            )
-        f.write("\n".join(cfg))
+                px_size = self.getPixelSizeUmByID(px_config)
+                px_affine = self.getPixelSizeAffineByID(px_config)
+                cfg.extend(
+                    (
+                        f"PixelSize_um,{px_config},{px_size}",
+                        f"PixelSizeAffine,{px_config},{','.join(map(str, px_affine))}",
+                    )
+                )
+            f.write("\n".join(cfg))
 
     def describe(self, sort: str | None = None) -> None:
         """Print information table with the current configuration.

--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -1747,11 +1747,9 @@ class CMMCorePlus(pymmcore.CMMCore):
             return
         cfg = ["# PixelSize settings"]
         for px_config in px_configs:
-            data = self.getPixelSizeConfigData(px_config).dict()
-            for device, prop in data.items():
-                cfg.extend(
-                    f"ConfigPixelSize,{px_config},{device},{k},{v}"
-                    for k, v in prop.items()
+            cfg.extend(
+                f"ConfigPixelSize,{px_config},{device},{prop},{val}"
+                for device, prop, val in self.getPixelSizeConfigData(px_config)
                 )
             px_size = self.getPixelSizeUmByID(px_config)
             px_affine = self.getPixelSizeAffineByID(px_config)

--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -1739,24 +1739,24 @@ class CMMCorePlus(pymmcore.CMMCore):
         self._save_pixel_configurations(filename)
 
     def _save_pixel_configurations(self, filename: str) -> None:
+        px_configs = self.getAvailablePixelSizeConfigs()
+        if not px_configs:
+            return
+        cfg = ["# PixelSize settings"]
+        for px_config in px_configs:
+            cfg.extend(
+                f"ConfigPixelSize,{px_config},{device},{prop},{val}"
+                for device, prop, val in self.getPixelSizeConfigData(px_config)
+            )
+            px_size = self.getPixelSizeUmByID(px_config)
+            px_affine = self.getPixelSizeAffineByID(px_config)
+            cfg.extend(
+                (
+                    f"PixelSize_um,{px_config},{px_size}",
+                    f"PixelSizeAffine,{px_config},{','.join(map(str, px_affine))}",
+                )
+            )
         with open(filename, "a") as f:
-            px_configs = self.getAvailablePixelSizeConfigs()
-            if not px_configs:
-                return
-            cfg = ["# PixelSize settings"]
-            for px_config in px_configs:
-                cfg.extend(
-                    f"ConfigPixelSize,{px_config},{device},{prop},{val}"
-                    for device, prop, val in self.getPixelSizeConfigData(px_config)
-                )
-                px_size = self.getPixelSizeUmByID(px_config)
-                px_affine = self.getPixelSizeAffineByID(px_config)
-                cfg.extend(
-                    (
-                        f"PixelSize_um,{px_config},{px_size}",
-                        f"PixelSizeAffine,{px_config},{','.join(map(str, px_affine))}",
-                    )
-                )
             f.write("\n".join(cfg))
 
     def describe(self, sort: str | None = None) -> None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -526,7 +526,7 @@ def test_save_config(core: CMMCorePlus, tmp_path: Path) -> None:
     assert "r10x" in core.getAvailablePixelSizeConfigs()
 
     test_cfg = str(tmp_path / "test.cfg")
-    core.saveSystemConfiguration(test_cfg, "Objective")
+    core.saveSystemConfiguration(test_cfg)
 
     core.loadSystemConfiguration()
     assert "r10x" not in core.getAvailablePixelSizeConfigs()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -10,6 +10,10 @@ import psygnal
 import pymmcore
 import pytest
 from pymmcore import CMMCore, PropertySetting
+from qtpy.QtCore import QObject
+from qtpy.QtCore import SignalInstance as QSignalInstance
+from useq import MDASequence
+
 from pymmcore_plus import (
     CMMCorePlus,
     Configuration,
@@ -20,9 +24,6 @@ from pymmcore_plus import (
 )
 from pymmcore_plus.core.events import CMMCoreSignaler
 from pymmcore_plus.mda import MDAEngine
-from qtpy.QtCore import QObject
-from qtpy.QtCore import SignalInstance as QSignalInstance
-from useq import MDASequence
 
 if TYPE_CHECKING:
     from pytestqt.qtbot import QtBot
@@ -522,6 +523,7 @@ def test_save_config(core: CMMCorePlus, tmp_path: Path) -> None:
     assert "Res10x" not in core.getAvailablePixelSizeConfigs()
 
     core.definePixelSizeConfig("r10x", "Objective", "Label", "Nikon 10X S Fluor")
+    core.definePixelSizeConfig("r10x", "Core", "XYStage", "XY")
     core.setPixelSizeUm("r10x", 2)
     assert "r10x" in core.getAvailablePixelSizeConfigs()
 
@@ -532,6 +534,12 @@ def test_save_config(core: CMMCorePlus, tmp_path: Path) -> None:
     assert "r10x" not in core.getAvailablePixelSizeConfigs()
     core.loadSystemConfiguration(test_cfg)
     assert "r10x" in core.getAvailablePixelSizeConfigs()
+
+    items = list(core.getPixelSizeConfigData("r10x"))
+    assert items == [
+        ("Objective", "Label", "Nikon 10X S Fluor"),
+        ("Core", "XYStage", "XY"),
+    ]
 
 
 @pytest.mark.parametrize("use_rich", [True, False])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -10,10 +10,6 @@ import psygnal
 import pymmcore
 import pytest
 from pymmcore import CMMCore, PropertySetting
-from qtpy.QtCore import QObject
-from qtpy.QtCore import SignalInstance as QSignalInstance
-from useq import MDASequence
-
 from pymmcore_plus import (
     CMMCorePlus,
     Configuration,
@@ -24,6 +20,9 @@ from pymmcore_plus import (
 )
 from pymmcore_plus.core.events import CMMCoreSignaler
 from pymmcore_plus.mda import MDAEngine
+from qtpy.QtCore import QObject
+from qtpy.QtCore import SignalInstance as QSignalInstance
+from useq import MDASequence
 
 if TYPE_CHECKING:
     from pytestqt.qtbot import QtBot

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -10,6 +10,10 @@ import psygnal
 import pymmcore
 import pytest
 from pymmcore import CMMCore, PropertySetting
+from qtpy.QtCore import QObject
+from qtpy.QtCore import SignalInstance as QSignalInstance
+from useq import MDASequence
+
 from pymmcore_plus import (
     CMMCorePlus,
     Configuration,
@@ -20,9 +24,6 @@ from pymmcore_plus import (
 )
 from pymmcore_plus.core.events import CMMCoreSignaler
 from pymmcore_plus.mda import MDAEngine
-from qtpy.QtCore import QObject
-from qtpy.QtCore import SignalInstance as QSignalInstance
-from useq import MDASequence
 
 if TYPE_CHECKING:
     from pytestqt.qtbot import QtBot
@@ -525,7 +526,7 @@ def test_save_config(core: CMMCorePlus, tmp_path: Path) -> None:
     assert "r10x" in core.getAvailablePixelSizeConfigs()
 
     test_cfg = str(tmp_path / "test.cfg")
-    core.saveSystemConfiguration(test_cfg)
+    core.saveSystemConfiguration(test_cfg, "Objective")
 
     core.loadSystemConfiguration()
     assert "r10x" not in core.getAvailablePixelSizeConfigs()


### PR DESCRIPTION
in #214 we  updated the original `pymmcore` `saveSystemConfiguration` method so that it also saves any pixel size configuration if are set. 

However it is not done properly, it assumes that the objective device e is called "Objective" and it does not take into account any other possible device-property that might be added to the pixel size configuration.

This PR fixes this issue and saves any `device-property-value` that are added to the pixel size `configuration.

---
For example, if we have a px config that is called `cfg1` and we call:
```py
getPixelSizeConfigData(cfg1).dict()
```
we might get something like this: 
``` py
{'Core': {'XYStage': 'XY'}, 'Objective': {'Label': 'Nikon 10X S Fluor'}}
```
Since in the px configuration we have two devices (`Core` and `Objective`), we need to make sure that both will be added to the saved configuration like below:
```
PixelSize,Res10x,Core,XYStage,XY
ConfigPixelSize,Res10x,Objective,Label,Nikon 10X S Fluor
PixelSize_um,Res10x,1.0
PixelSizeAffine,Res10x,1.0,0.0,0.0,0.0,1.0,0.0
```