### PR TITLE
refactor: remove AvailableDevice

### DIFF
--- a/src/pymmcore_plus/core/_adapter.py
+++ b/src/pymmcore_plus/core/_adapter.py
@@ -1,26 +1,12 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING
 
 from pymmcore_plus.core._constants import DeviceType
+from pymmcore_plus.core._device import Device
 
 if TYPE_CHECKING:
-    from pymmcore_plus.core._device import Device
-
     from ._mmcore_plus import CMMCorePlus
-
-
-class AvailableDevice(NamedTuple):
-    adapter_name: str
-    device_name: str
-    type: DeviceType
-    description: str
-    core: CMMCorePlus
-
-    def load(self, label: str) -> Device:
-        """Load the device under the label `label`."""
-        self.core.loadDevice(label, self.adapter_name, self.device_name)
-        return self.core.getDeviceObject(label)
 
 
 class DeviceAdapter:
@@ -53,13 +39,13 @@ class DeviceAdapter:
         return self._mmc
 
     @property
-    def available_devices(self) -> tuple[AvailableDevice, ...]:
+    def available_devices(self) -> tuple[Device, ...]:
         """Get available devices offered by this device adapter.
 
         Returns
         -------
-        tuple[AvailableDevice, ...]
-            Tuple of `AvailableDevice` objects, with the name, type, and description
+        tuple[Device, ...]
+            Tuple of `Device` objects, with the name, type, and description
             of each device.  These objects also have a `load` method that can be used
             to load the device under a given label.
         """
@@ -71,8 +57,14 @@ class DeviceAdapter:
         types = self._mmc.getAvailableDeviceTypes(self.name)
         descriptions = self._mmc.getAvailableDeviceDescriptions(self.name)
         return tuple(
-            AvailableDevice(self.name, label, DeviceType(dt), desc, self._mmc)
-            for label, dt, desc in zip(devs, types, descriptions)
+            Device(
+                mmcore=self._mmc,
+                adapter_name=self.name,
+                device_name=dev_name,
+                type=DeviceType(dt),
+                description=desc,
+            )
+            for dev_name, dt, desc in zip(devs, types, descriptions)
         )
 
     @property

--- a/src/pymmcore_plus/core/events/_device_signal_view.py
+++ b/src/pymmcore_plus/core/events/_device_signal_view.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 if TYPE_CHECKING:
     from pymmcore_plus.core import CMMCorePlus
@@ -21,6 +21,10 @@ class _DevicePropValueSignal:
     def disconnect(self, callback: _C) -> None:
         sig = self._mmc.events.devicePropertyChanged(self._dev, self._prop)
         return sig.disconnect(callback)  # type: ignore
+
+    def emit(self, *args: Any) -> Any:
+        """Emits the signal with the given arguments."""
+        self._mmc.events.devicePropertyChanged(self._dev, self._prop).emit(*args)
 
     def __call__(self, property: str) -> "_DevicePropValueSignal":
         return _DevicePropValueSignal(self._dev, property, self._mmc)

--- a/tests/test_adapter_class.py
+++ b/tests/test_adapter_class.py
@@ -1,16 +1,19 @@
-from pymmcore_plus import CMMCorePlus, DeviceAdapter
-from pymmcore_plus.core._adapter import AvailableDevice
+from pymmcore_plus import CMMCorePlus, Device, DeviceAdapter, DeviceType
 
 
 def test_adapter_object(core: CMMCorePlus) -> None:
-    core.unloadAllDevices()
+    # core.unloadAllDevices()
     for adapter in core.iterDeviceAdapters(as_object=True):
         assert adapter.name in repr(adapter)
         assert isinstance(adapter, DeviceAdapter)
         assert adapter.name
         assert adapter.core == core
         for ad in adapter.available_devices:
-            assert isinstance(ad, AvailableDevice)
+            assert isinstance(ad, Device)
+            assert ad.type() is not DeviceType.Unknown
+            assert ad.label == Device.UNASIGNED
+            assert ad.description()
+            assert ad.library() == adapter.name
             assert ad.core == core
         # the load method and other stuff is hard to test without exceptions
         # need more specific tests


### PR DESCRIPTION
this removes the AvailableDevice NamedTuple used in iterAdapters and replaces it with the Device class (that we already had)