### PR TITLE
fix: don't check is_busy when updating device in model

### DIFF
--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -2133,7 +2133,7 @@ class _MMCallbackRelay(pymmcore.MMEventCallback):
         super().__init__()
 
     @staticmethod
-    def _make_reemitter(name: str) -> Callable[..., None]:
+    def make_reemitter(name: str) -> Callable[..., None]:
         sig_name = name[2].lower() + name[3:]
 
         def reemit(self: _MMCallbackRelay, *args: Any) -> None:
@@ -2151,7 +2151,7 @@ MMCallbackRelay = type(
     "MMCallbackRelay",
     (_MMCallbackRelay,),
     {
-        n: _MMCallbackRelay._make_reemitter(n)
+        n: _MMCallbackRelay.make_reemitter(n)
         for n in dir(pymmcore.MMEventCallback)
         if n.startswith("on")
     },

--- a/src/pymmcore_plus/model/_device.py
+++ b/src/pymmcore_plus/model/_device.py
@@ -30,11 +30,11 @@ DEVICE_GETTERS: dict[str, DeviceGetter] = {
     "adapter_name": CMMCorePlus.getDeviceName,
     "description": CMMCorePlus.getDeviceDescription,
     "device_type": CMMCorePlus.getDeviceType,
-    "is_busy": CMMCorePlus.deviceBusy,
     "delay_ms": CMMCorePlus.getDeviceDelayMs,
     "uses_delay": CMMCorePlus.usesDeviceDelay,
     "parent_label": CMMCorePlus.getParentLabel,
     "property_names": CMMCorePlus.getDevicePropertyNames,
+    # "is_busy": CMMCorePlus.deviceBusy,  # Leave this out... it can crash when checking
 }
 STATE_DEVICE_GETTERS: dict[str, DeviceGetter] = {
     **DEVICE_GETTERS,


### PR DESCRIPTION
fixes a bug @fdrgsp  found in the config wizard on a real device