### PR TITLE
feat: add mda thread relay

### DIFF
--- a/src/pymmcore_plus/_util.py
+++ b/src/pymmcore_plus/_util.py
@@ -334,9 +334,9 @@ def listeners_connected(
     listeners : Any
         Object(s) that has methods matching the name of signals on `emitter`.
     name_map : dict[str, str] | None
-        Optionally map signal names on `emitter` to signal names on `listener`.  This
-        can be used to connect signals with different names. By default, the signal
-        names must match exactly.
+        Optionally map signal names on `emitter` to different method names on
+        `listener`.  This can be used to connect callbacks with different names. By
+        default, callbacks names must match the signal names exactly.
 
     Examples
     --------

--- a/src/pymmcore_plus/_util.py
+++ b/src/pymmcore_plus/_util.py
@@ -15,6 +15,8 @@ import appdirs
 if TYPE_CHECKING:
     from typing import Any, Callable, Iterator, Literal, TypeVar
 
+    QtConnectionType = Literal["AutoConnection", "DirectConnection", "QueuedConnection"]
+
     from typing_extensions import ParamSpec, TypeGuard
 
     from .core.events._protocol import PSignalInstance
@@ -315,7 +317,10 @@ def _sorted_rows(data: dict, sort: str | None) -> list[tuple]:
 
 @contextmanager
 def listeners_connected(
-    emitter: Any, *listeners: Any, name_map: dict[str, str] | None = None
+    emitter: Any,
+    *listeners: Any,
+    name_map: dict[str, str] | None = None,
+    qt_connection_type: QtConnectionType | None = None,
 ) -> Iterator[None]:
     """Context manager for listening to signals.
 
@@ -337,6 +342,12 @@ def listeners_connected(
         Optionally map signal names on `emitter` to different method names on
         `listener`.  This can be used to connect callbacks with different names. By
         default, callbacks names must match the signal names exactly.
+    qt_connection_type: str | None
+        ADVANCED: Optionally specify the Qt connection type to use when connecting
+        signals, in the case where `emitter` is a Qt object.  This is useful for
+        connecting to Qt signals in a thread-safe way. Must be one of
+        `"AutoConnection"`, `"DirectConnection"`, `"QueuedConnection"`.
+        If `None` (the default), `Qt.ConnectionType.AutoConnection` will be used.
 
     Examples
     --------
@@ -380,8 +391,13 @@ def listeners_connected(
         for attr_name in common_names:
             if _is_signal_instance(signal := getattr(emitter, attr_name)):
                 slot_name = name_map.get(attr_name, attr_name)
+                args: tuple[Any, ...] = ()
                 if callable(slot := getattr(listener, slot_name)):
-                    tokens[attr_name].add(signal.connect(slot))
+                    if qt_connection_type and "Qt" in type(signal).__module__:
+                        from qtpy.QtCore import Qt
+
+                        args = (getattr(Qt.ConnectionType, qt_connection_type),)
+                    tokens[attr_name].add(signal.connect(slot, *args))
 
     try:
         yield

--- a/src/pymmcore_plus/_util.py
+++ b/src/pymmcore_plus/_util.py
@@ -391,13 +391,15 @@ def listeners_connected(
         for attr_name in common_names:
             if _is_signal_instance(signal := getattr(emitter, attr_name)):
                 slot_name = name_map.get(attr_name, attr_name)
-                args: tuple[Any, ...] = ()
                 if callable(slot := getattr(listener, slot_name)):
                     if qt_connection_type and "Qt" in type(signal).__module__:
                         from qtpy.QtCore import Qt
 
-                        args = (getattr(Qt.ConnectionType, qt_connection_type),)
-                    tokens[attr_name].add(signal.connect(slot, *args))
+                        ctype = getattr(Qt.ConnectionType, qt_connection_type)
+                        token = signal.connect(slot, ctype)  # type: ignore
+                        tokens[attr_name].add(token)
+                    else:
+                        tokens[attr_name].add(signal.connect(slot))
 
     try:
         yield

--- a/src/pymmcore_plus/_util.py
+++ b/src/pymmcore_plus/_util.py
@@ -389,10 +389,12 @@ def listeners_connected(
         common_names: set[str] = set(dir(emitter)).intersection(listener_names)
 
         for attr_name in common_names:
+            if attr_name.startswith("__"):
+                continue
             if _is_signal_instance(signal := getattr(emitter, attr_name)):
                 slot_name = name_map.get(attr_name, attr_name)
                 if callable(slot := getattr(listener, slot_name)):
-                    if qt_connection_type and "Qt" in type(signal).__module__:
+                    if qt_connection_type and _is_qt_signal(signal):
                         from qtpy.QtCore import Qt
 
                         ctype = getattr(Qt.ConnectionType, qt_connection_type)
@@ -415,3 +417,8 @@ def _is_signal_instance(obj: Any) -> TypeGuard[PSignalInstance]:
     return (
         hasattr(obj, "connect") and callable(obj.connect) and hasattr(obj, "disconnect")
     )
+
+
+def _is_qt_signal(obj: Any) -> TypeGuard[PSignalInstance]:
+    modname = getattr(type(obj), "__module__", "")
+    return "Qt" in modname or "Shiboken" in modname

--- a/src/pymmcore_plus/mda/__init__.py
+++ b/src/pymmcore_plus/mda/__init__.py
@@ -1,6 +1,13 @@
 from ._engine import MDAEngine
 from ._protocol import PMDAEngine
 from ._runner import MDARunner
+from ._thread_relay import mda_listeners_connected
 from .events import PMDASignaler
 
-__all__ = ["MDAEngine", "PMDAEngine", "MDARunner", "PMDASignaler"]
+__all__ = [
+    "MDAEngine",
+    "PMDAEngine",
+    "MDARunner",
+    "PMDASignaler",
+    "mda_listeners_connected",
+]

--- a/src/pymmcore_plus/mda/_thread_relay.py
+++ b/src/pymmcore_plus/mda/_thread_relay.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import threading
+import time
+from collections import deque
+from contextlib import contextmanager, suppress
+from typing import TYPE_CHECKING, Literal, overload
+
+from pymmcore_plus._util import listeners_connected
+
+from .events import _get_auto_MDA_callback_class
+
+if TYPE_CHECKING:
+    from typing import Any, ContextManager, Iterator
+
+    from pymmcore_plus.core.events._protocol import PSignalInstance
+    from pymmcore_plus.mda import PMDASignaler
+
+
+@overload
+def mda_listeners_connected(
+    *listeners: Any,
+    mda_events: PMDASignaler | None = ...,
+    name_map: dict[str, str] | None = ...,
+    asynchronous: Literal[False],
+    wait_on_exit: bool = ...,
+) -> ContextManager[None]:
+    ...
+
+
+@overload
+def mda_listeners_connected(
+    *listeners: Any,
+    mda_events: PMDASignaler | None = ...,
+    name_map: dict[str, str] | None = ...,
+    asynchronous: Literal[True] = ...,
+    wait_on_exit: bool = ...,
+) -> ContextManager[MDARelayThread]:
+    ...
+
+
+@contextmanager
+def mda_listeners_connected(
+    *listeners: Any,
+    mda_events: PMDASignaler | None = None,
+    name_map: dict[str, str] | None = None,
+    asynchronous: bool = True,
+    wait_on_exit: bool = True,
+) -> Iterator:
+    """Context in which MDA events are connected to listeners, in a thread by default.
+
+    Parameters
+    ----------
+    listeners : Any
+        Object(s) that has methods matching the name of signals on `mda_events`.
+        (Namely: `sequenceStarted`, `frameReady`, `sequenceFinished`, etc...)
+    mda_events : PMDASignaler | None, optional
+        The MDA events to connect to.  If not provided, the `mda.events` attribute on
+        the global `CMMCorePlus.instance()` will be used, by default None.
+    name_map : dict[str, str] | None
+        Optionally map signal names to different method names on `listener`.  This
+        can be used to connect callbacks with different names. By default, the
+        callbacks names must match the signal names exactly.
+    asynchronous : bool, optional
+        Whether to execute callbacks on `listeners` in another thread.  If True,
+        the MDA will proceed without waiting for the callbacks to finish.  A deque will
+        collect events and pass them to handlers as they become ready (FIFO),
+        by default True.
+    wait_on_exit : bool, optional
+        Whether to wait for all callbacks on listeners to finish before exiting the
+        context, by default True.
+    """
+    if mda_events is None:
+        from pymmcore_plus import CMMCorePlus
+
+        mda_events = CMMCorePlus.instance().mda.events
+
+    if not asynchronous:
+        # Just collapse to a regular synchronous listeners_connected
+        with listeners_connected(mda_events, *listeners, name_map=name_map):
+            yield None
+        return
+
+    # create a relay thread and start/stop it when the sequence starts/finishes
+    relay = MDARelayThread()
+    mda_events.sequenceStarted.connect(relay.start)
+    mda_events.sequenceFinished.connect(relay.stop)
+
+    try:
+        # connect the actual core.mda.events to methods on the relay
+        with listeners_connected(mda_events, relay):
+            # connect the signals on the relay to the listeners
+            with listeners_connected(relay.signals, *listeners, name_map=name_map):
+                yield relay
+
+                if wait_on_exit:
+                    # wait for the relay to finish
+                    if relay.is_alive():
+                        relay.join()
+                elif relay.remaining():
+                    ...  # TODO: log reminaing events
+    finally:
+        # disconnect the relay
+        with suppress(Exception):
+            mda_events.sequenceStarted.disconnect(relay.start)
+            mda_events.sequenceFinished.disconnect(relay.stop)
+
+
+class MDARelayThread(threading.Thread):
+    """A thread that relays MDA events to a signaler.
+
+    Meant to be used with `mda_listeners_connected` to connect MDA events to
+    listeners that don't implement asynchronous callbacks.
+
+    Parameters
+    ----------
+    sleep_interval : float, optional
+        The interval in seconds to sleep between processing events, by default 0.001
+    """
+
+    def __init__(self, sleep_interval: float = 0.001) -> None:
+        super().__init__()
+
+        self.signals = _get_auto_MDA_callback_class()()
+
+        self._sleep_interval = sleep_interval
+        self._deque: deque[tuple[str, tuple[Any, ...]]] = deque()
+        self._stop_event = threading.Event()
+
+    def run(self) -> None:
+        """Block until the stop event is set and the deque is empty."""
+        while self._deque or not self._stop_event.is_set():
+            if self._deque:
+                signal_name, args = self._deque.popleft()
+                emitter: PSignalInstance = getattr(self.signals, signal_name)
+                emitter.emit(*args)
+            else:
+                time.sleep(self._sleep_interval)
+
+    def remaining(self) -> int:
+        """Return the number of events remaining to be processed."""
+        return len(self._deque)
+
+    def stop(self) -> None:
+        """Set the stop event to stop the thread."""
+        self._stop_event.set()
+
+    # MDA callbacks
+    # These may be connected to core.mda.events using `listeners_connected`
+    # as done above in `mda_listeners_connected`
+
+    def sequenceStarted(self, *args: Any) -> None:
+        self._deque.append(("sequenceStarted", args))
+
+    def frameReady(self, *args: Any) -> None:
+        self._deque.append(("frameReady", args))
+
+    def sequencePauseToggled(self, *args: Any) -> None:
+        self._deque.append(("sequencePauseToggled", args))
+
+    def sequenceCanceled(self, *args: Any) -> None:
+        self._deque.append(("sequenceCanceled", args))
+
+    def sequenceFinished(self, *args: Any) -> None:
+        self._deque.append(("sequenceFinished", args))

--- a/tests/test_thread_relay.py
+++ b/tests/test_thread_relay.py
@@ -7,7 +7,7 @@ from pymmcore_plus import CMMCorePlus
 from pymmcore_plus.mda import mda_listeners_connected
 
 
-def test_runner_cancel(core: CMMCorePlus) -> None:
+def test_mda_listeners_connected(core: CMMCorePlus) -> None:
     mock = Mock()
 
     class SlowHandler:

--- a/tests/test_thread_relay.py
+++ b/tests/test_thread_relay.py
@@ -1,0 +1,43 @@
+import time
+from unittest.mock import Mock, call
+
+import numpy as np
+import useq
+from pymmcore_plus import CMMCorePlus
+from pymmcore_plus.mda import mda_listeners_connected
+
+
+def test_runner_cancel(core: CMMCorePlus) -> None:
+    mock = Mock()
+
+    class SlowHandler:
+        def frameReady(self, ary, event):
+            mock(event.index.get("t"))
+            time.sleep(0.1)
+
+    LOOPS = 4
+    seq = useq.MDASequence(time_plan=useq.TIntervalLoops(loops=LOOPS, interval=0))
+
+    handler = SlowHandler()
+
+    # by default, we wait for the relay to finish
+    # so the mock should be called LOOPS times
+    with mda_listeners_connected(handler, mda_events=core.mda.events):
+        core.mda.run(seq)
+    assert mock.call_count == LOOPS
+    mock.assert_has_calls([call(t) for t in range(LOOPS)])
+
+    # with wait_on_exit=False, the mock should be called less than LOOPS times
+    # because the relay is stopped before SlowHandler finishes
+    mock.reset_mock()
+    with mda_listeners_connected(
+        handler, mda_events=core.mda.events, wait_on_exit=False
+    ):
+        core.mda.run(seq)
+
+    assert mock.call_count < LOOPS
+
+    # make sure it got disconnected
+    mock.reset_mock()
+    core.mda.events.frameReady.emit(np.empty((10, 10)), useq.MDAEvent(), {})
+    mock.assert_not_called()

--- a/tests/test_thread_relay.py
+++ b/tests/test_thread_relay.py
@@ -1,22 +1,24 @@
-import time
-from unittest.mock import Mock, call
+from typing import TYPE_CHECKING
+from unittest.mock import Mock
 
-import numpy as np
 import useq
 from pymmcore_plus import CMMCorePlus
 from pymmcore_plus.mda import mda_listeners_connected
 
+if TYPE_CHECKING:
+    from pytestqt.qtbot import QtBot
 
-def test_mda_listeners_connected(core: CMMCorePlus) -> None:
+
+def test_mda_listeners_connected(core: CMMCorePlus, qtbot: "QtBot") -> None:
     mock = Mock()
 
     class SlowHandler:
         def frameReady(self, ary, event):
             mock(event.index.get("t"))
-            time.sleep(0.1)
+            # time.sleep(0.1)
 
     LOOPS = 4
-    seq = useq.MDASequence(time_plan=useq.TIntervalLoops(loops=LOOPS, interval=0))
+    seq = useq.MDASequence(time_plan=useq.TIntervalLoops(loops=LOOPS, interval=0.01))
 
     handler = SlowHandler()
 
@@ -24,20 +26,21 @@ def test_mda_listeners_connected(core: CMMCorePlus) -> None:
     # so the mock should be called LOOPS times
     with mda_listeners_connected(handler, mda_events=core.mda.events):
         core.mda.run(seq)
+
     assert mock.call_count == LOOPS
-    mock.assert_has_calls([call(t) for t in range(LOOPS)])
+    # mock.assert_has_calls([call(t) for t in range(LOOPS)])
 
-    # with wait_on_exit=False, the mock should be called less than LOOPS times
-    # because the relay is stopped before SlowHandler finishes
-    mock.reset_mock()
-    with mda_listeners_connected(
-        handler, mda_events=core.mda.events, wait_on_exit=False
-    ):
-        core.mda.run(seq)
+    # # with wait_on_exit=False, the mock should be called less than LOOPS times
+    # # because the relay is stopped before SlowHandler finishes
+    # mock.reset_mock()
+    # with mda_listeners_connected(
+    #     handler, mda_events=core.mda.events, wait_on_exit=False
+    # ):
+    #     with qtbot.waitSignal(core.mda.events.sequenceFinished):
+    #         core.mda.run(seq)
+    # assert mock.call_count < LOOPS
 
-    assert mock.call_count < LOOPS
-
-    # make sure it got disconnected
-    mock.reset_mock()
-    core.mda.events.frameReady.emit(np.empty((10, 10)), useq.MDAEvent(), {})
-    mock.assert_not_called()
+    # # make sure it got disconnected
+    # mock.reset_mock()
+    # core.mda.events.frameReady.emit(np.empty((10, 10)), useq.MDAEvent(), {})
+    # mock.assert_not_called()

--- a/tests/test_thread_relay.py
+++ b/tests/test_thread_relay.py
@@ -1,24 +1,22 @@
-from typing import TYPE_CHECKING
-from unittest.mock import Mock
+import time
+from unittest.mock import Mock, call
 
+import numpy as np
 import useq
 from pymmcore_plus import CMMCorePlus
 from pymmcore_plus.mda import mda_listeners_connected
 
-if TYPE_CHECKING:
-    from pytestqt.qtbot import QtBot
 
-
-def test_mda_listeners_connected(core: CMMCorePlus, qtbot: "QtBot") -> None:
+def test_mda_listeners_connected(core: CMMCorePlus) -> None:
     mock = Mock()
 
     class SlowHandler:
-        def frameReady(self, ary, event):
+        def frameReady(self, ary: np.ndarray, event: useq.MDAEvent):
             mock(event.index.get("t"))
-            # time.sleep(0.1)
+            time.sleep(0.05)
 
     LOOPS = 4
-    seq = useq.MDASequence(time_plan=useq.TIntervalLoops(loops=LOOPS, interval=0.01))
+    seq = useq.MDASequence(time_plan=useq.TIntervalLoops(loops=LOOPS, interval=0))
 
     handler = SlowHandler()
 
@@ -28,19 +26,26 @@ def test_mda_listeners_connected(core: CMMCorePlus, qtbot: "QtBot") -> None:
         core.mda.run(seq)
 
     assert mock.call_count == LOOPS
-    # mock.assert_has_calls([call(t) for t in range(LOOPS)])
+    mock.assert_has_calls([call(t) for t in range(LOOPS)])
 
-    # # with wait_on_exit=False, the mock should be called less than LOOPS times
-    # # because the relay is stopped before SlowHandler finishes
-    # mock.reset_mock()
-    # with mda_listeners_connected(
-    #     handler, mda_events=core.mda.events, wait_on_exit=False
-    # ):
-    #     with qtbot.waitSignal(core.mda.events.sequenceFinished):
-    #         core.mda.run(seq)
-    # assert mock.call_count < LOOPS
+    # with wait_on_exit=False, the mock should be called less than LOOPS times
+    # because the relay is stopped before SlowHandler finishes
+    mock.reset_mock()
+    with mda_listeners_connected(
+        handler, mda_events=core.mda.events, wait_on_exit=False
+    ):
+        core.mda.run(seq)
+    assert mock.call_count < LOOPS
 
-    # # make sure it got disconnected
-    # mock.reset_mock()
-    # core.mda.events.frameReady.emit(np.empty((10, 10)), useq.MDAEvent(), {})
-    # mock.assert_not_called()
+    # make sure it got disconnected
+    mock.reset_mock()
+    core.mda.events.frameReady.emit(np.empty((10, 10)), useq.MDAEvent(), {})
+    mock.assert_not_called()
+
+    # with asynchronous=False, it reduces to a synchronous listeners_connected context
+    mock.reset_mock()
+    with mda_listeners_connected(
+        handler, mda_events=core.mda.events, asynchronous=False
+    ):
+        core.mda.run(seq)
+    assert mock.call_count == LOOPS


### PR DESCRIPTION
This implements a general pattern similar to what we're doing in napari-micromanager to pass data to handlers (such as writers) asynchronously as it comes off the MDA.

- a new `MDARelayThread` object has a deque
- it collects signals as they come off the `core.mda.events` (such as a `frameReady`) signal
- it runs in another thread and *synchronously* calls anything connected to it
- before the context manager exits, it (by default) makes sure the dequeue is 

This means that anyone can implement a performant data handler such as what @ianhi  and @fdrgsp  did in https://github.com/pymmcore-plus/napari-micromanager/pull/272 without having to worry about implementing the threading.  And multiple handlers can share the same handler thread.  (note: this assumes that the callback doesn't need to update the MDA itself, which is the case for writers, etc...)

so it's:

```mermaid
graph LR;
    core.mda.events -->|frameReady| ThreadRelay;
    ThreadRelay --> Handler1;
    ThreadRelay --> Handler2;
    ThreadRelay --> Handler3;
```

```python
import time

import useq
from pymmcore_plus import CMMCorePlus
from pymmcore_plus.mda import mda_listeners_connected

core = CMMCorePlus.instance()
core.loadSystemConfiguration()


class SlowHandler:
    def frameReady(self, ary, event):
        time.sleep(0.12)
        print("slowly processing frame:", event.index)


seq = useq.MDASequence(time_plan=useq.TIntervalLoops(loops=4, interval=0.1))
with mda_listeners_connected(SlowHandler()):
    core.mda.run(seq)
```

outputs:
```
2023-09-21 09:11:40,484 - pymmcore-plus - INFO - (_runner.py:216) MDA Started: Multi-Dimensional Acquisition with: nt=4
2023-09-21 09:11:40,485 - pymmcore-plus - INFO - (_runner.py:184) index=mappingproxy({'t': 0}) min_start_time=0.0
2023-09-21 09:11:40,586 - pymmcore-plus - INFO - (_runner.py:184) index=mappingproxy({'t': 1}) min_start_time=0.1
slowly processing frame: {'t': 0}
2023-09-21 09:11:40,685 - pymmcore-plus - INFO - (_runner.py:184) index=mappingproxy({'t': 2}) min_start_time=0.2
slowly processing frame: {'t': 1}
2023-09-21 09:11:40,789 - pymmcore-plus - INFO - (_runner.py:184) index=mappingproxy({'t': 3}) min_start_time=0.3
2023-09-21 09:11:40,801 - pymmcore-plus - INFO - (_runner.py:308) MDA Finished: Multi-Dimensional Acquisition with: nt=4
slowly processing frame: {'t': 2}
slowly processing frame: {'t': 3}
```

(note that the slow handler didn't hold up the MDA...).

closes #189 

cc @ianhi 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added an optional parameter `qt_connection_type` to the `listeners_connected` function in `src/pymmcore_plus/_util.py`. This allows users to specify the Qt connection type when connecting signals, enhancing flexibility.
- New Feature: Introduced a new module `mda_listeners_connected` in `src/pymmcore_plus/mda/_thread_relay.py`. This provides a context manager for connecting MDA events to listeners and supports both synchronous and asynchronous execution of callbacks, improving performance and usability.
- Test: Added a new test function `test_mda_listeners_connected` in `tests/test_thread_relay.py` to ensure the correct behavior of the new context manager.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->