### PR TITLE
feat: emit metadata as second argument of `sequenceStarted` 

### DIFF
--- a/src/pymmcore_plus/core/_constants.py
+++ b/src/pymmcore_plus/core/_constants.py
@@ -227,5 +227,7 @@ class PixelType(str, Enum):
     @classmethod
     def for_bytes(cls, depth: int, n_comp: int = 1) -> PixelType:
         if depth != 4:
-            return {1: cls.GRAY8, 2: cls.GRAY16, 8: cls.RGB64, 0: cls.UNKNOWN}[depth]
+            return {1: cls.GRAY8, 2: cls.GRAY16, 8: cls.RGB64, 0: cls.UNKNOWN}.get(
+                depth, cls.UNKNOWN
+            )
         return cls.GRAY32 if n_comp == 1 else cls.RGB32

--- a/src/pymmcore_plus/core/_constants.py
+++ b/src/pymmcore_plus/core/_constants.py
@@ -211,3 +211,21 @@ class DeviceDetectionStatus(IntEnum):
     """Communication attributes are valid, but the device does not respond."""
     CanCommunicate = pymmcore.CanCommunicate
     """Communication verified, parameters have been set to valid values."""
+
+
+class PixelType(str, Enum):
+    UNKNOWN = ""
+    GRAY8 = "GRAY8"
+    GRAY16 = "GRAY16"
+    GRAY32 = "GRAY32"
+    RGB32 = "RGB32"
+    RGB64 = "RGB64"
+
+    def __str__(self) -> str:
+        return self.value
+
+    @classmethod
+    def for_bytes(cls, depth: int, n_comp: int = 1) -> PixelType:
+        if depth != 4:
+            return {1: cls.GRAY8, 2: cls.GRAY16, 8: cls.RGB64, 0: cls.UNKNOWN}[depth]
+        return cls.GRAY32 if n_comp == 1 else cls.RGB32

--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -36,7 +36,7 @@ from pymmcore_plus.mda import MDAEngine, MDARunner, PMDAEngine
 from ._adapter import DeviceAdapter
 from ._config import Configuration
 from ._config_group import ConfigGroup
-from ._constants import DeviceDetectionStatus, DeviceType, PropertyType
+from ._constants import DeviceDetectionStatus, DeviceType, PixelType, PropertyType
 from ._device import Device
 from ._metadata import Metadata
 from ._property import DeviceProperty
@@ -1496,12 +1496,9 @@ class CMMCorePlus(pymmcore.CMMCore):
         tags["ROI"] = "-".join(str(x) for x in self.getROI())
         tags["Width"] = self.getImageWidth()
         tags["Height"] = self.getImageHeight()
-        if (depth := self.getBytesPerPixel()) == 4:
-            ncomp = self.getNumberOfComponents()
-            pix_type = "GRAY32" if ncomp == 1 else "RGB32"
-        else:
-            pix_type = {1: "GRAY8", 2: "GRAY16", 8: "RGB64"}[depth]
-        tags["PixelType"] = pix_type
+        tags["PixelType"] = str(
+            PixelType.for_bytes(self.getBytesPerPixel(), self.getNumberOfComponents())
+        )
         tags["Frame"] = 0
         tags["FrameIndex"] = 0
         tags["Position"] = "Default"

--- a/src/pymmcore_plus/mda/_protocol.py
+++ b/src/pymmcore_plus/mda/_protocol.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import TYPE_CHECKING, Protocol, Sequence, runtime_checkable
+from typing import TYPE_CHECKING, Any, Mapping, Protocol, Sequence, runtime_checkable
 
 if TYPE_CHECKING:
     from typing import Iterable, Iterator
@@ -21,7 +21,7 @@ class PMDAEngine(Protocol):
     """Protocol that all MDA engines must implement."""
 
     @abstractmethod
-    def setup_sequence(self, sequence: MDASequence) -> None:
+    def setup_sequence(self, sequence: MDASequence) -> None | Mapping[str, Any]:
         """Setup state of system (hardware, etc.) before an MDA is run.
 
         This method is called once at the beginning of a sequence.

--- a/src/pymmcore_plus/mda/_runner.py
+++ b/src/pymmcore_plus/mda/_runner.py
@@ -212,10 +212,10 @@ class MDARunner:
         self._paused_time = 0.0
         self._sequence = sequence
 
-        self._engine.setup_sequence(sequence)
+        meta = self._engine.setup_sequence(sequence)
         logger.info("MDA Started: %s", sequence)
 
-        self._signals.sequenceStarted.emit(sequence)
+        self._signals.sequenceStarted.emit(sequence, meta or {})
         self._reset_timer()
         return self._engine
 

--- a/src/pymmcore_plus/mda/events/_protocol.py
+++ b/src/pymmcore_plus/mda/events/_protocol.py
@@ -8,7 +8,7 @@ class PMDASignaler(Protocol):
     """Declares the protocol for all signals that will be emitted from [`pymmcore_plus.mda.MDARunner`][]."""  # noqa: E501
 
     sequenceStarted: PSignal
-    """Emits `(sequence: MDASequence)` when an acquisition sequence is started."""
+    """Emits `(sequence: MDASequence, metadata: dict)` when an acquisition sequence is started."""  # noqa: E501
     sequencePauseToggled: PSignal
     """Emits `(paused: bool)` when an acquisition sequence is paused or unpaused."""
     sequenceCanceled: PSignal
@@ -16,4 +16,4 @@ class PMDASignaler(Protocol):
     sequenceFinished: PSignal
     """Emits `(sequence: MDASequence)` when an acquisition sequence is finished."""
     frameReady: PSignal
-    """Emits `(img, MDAEvent, metadata)` after an image is acquired during an acquisition sequence."""  # noqa: E501
+    """Emits `(img: np.ndarray, event: MDAEvent, metadata: dict)` after an image is acquired during an acquisition sequence."""  # noqa: E501

--- a/src/pymmcore_plus/mda/events/_psygnal.py
+++ b/src/pymmcore_plus/mda/events/_psygnal.py
@@ -4,7 +4,7 @@ from useq import MDAEvent, MDASequence
 
 
 class MDASignaler:
-    sequenceStarted = Signal(MDASequence)  # at the start of an MDA sequence
+    sequenceStarted = Signal(MDASequence, dict)  # at the start of an MDA sequence
     sequencePauseToggled = Signal(bool)  # when MDA is paused/unpaused
     sequenceCanceled = Signal(MDASequence)  # when mda is canceled
     sequenceFinished = Signal(MDASequence)  # when mda is done (whether canceled or not)

--- a/src/pymmcore_plus/mda/events/_qsignals.py
+++ b/src/pymmcore_plus/mda/events/_qsignals.py
@@ -2,7 +2,7 @@ from qtpy.QtCore import QObject, Signal
 
 
 class QMDASignaler(QObject):
-    sequenceStarted = Signal(object)  # at the start of an MDA sequence
+    sequenceStarted = Signal(object, dict)  # at the start of an MDA sequence
     sequencePauseToggled = Signal(bool)  # when MDA is paused/unpaused
     sequenceCanceled = Signal(object)  # when mda is canceled
     sequenceFinished = Signal(object)  # when mda is done (whether canceled or not)


### PR DESCRIPTION
this adds an additional parameter to the sequenceStarted callback, to let the engine pass additional metadata to handlers at the beginning of the experiment.

Note: the specification on both the summary metadata and the frame metadata isn't nailed down
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Introduced a `PixelType` enum class in `src/pymmcore_plus/core/_constants.py` for better representation and handling of different pixel types.
- Refactor: Simplified the logic for determining pixel type in `src/pymmcore_plus/core/_mmcore_plus.py` by using the new `PixelType.for_bytes` method.
- New Feature: Enhanced the `setup_sequence` method in `src/pymmcore_plus/mda/_engine.py` to return a mapping of summary metadata.
- Refactor: Updated the `PMDAEngine` protocol in `src/pymmcore_plus/mda/_protocol.py` to reflect changes in the `setup_sequence` method's return type.
- New Feature: Modified the `sequenceStarted` signal in `src/pymmcore_plus/mda/events/_protocol.py`, `src/pymmcore_plus/mda/events/_psygnal.py`, and `src/pymmcore_plus/mda/events/_qsignals.py` to include additional metadata.
- Test: Updated tests in `tests/test_core.py` to validate the new features and changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->