### PR TITLE
docs: clarify get/setZPosition in docs and update call

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -4,8 +4,14 @@
   border-left-width: 4px;
 }
 
-.md-typeset .doc-children{
+.md-typeset .doc-children {
   font-size: 0.7rem;
+}
+
+/* Wrap long functions */
+.md-typeset {
+  overflow-x: auto;
+  column-width: 1800px;
 }
 
 /* name of a method */
@@ -19,14 +25,14 @@ code.highlight span.n:not(:first-child) {
 /* Indentation. */
 div.doc-contents:not(.first) {
   padding-left: 25px;
-  border-left: .05rem solid var(--md-typeset-table-color);
+  border-left: 0.05rem solid var(--md-typeset-table-color);
 }
 
 /* Mark external links as such. */
 a.autorefs-external::after {
   /* https://primer.style/octicons/arrow-up-right-24 */
   background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="rgb(0, 0, 0)" d="M18.25 15.5a.75.75 0 00.75-.75v-9a.75.75 0 00-.75-.75h-9a.75.75 0 000 1.5h7.19L6.22 16.72a.75.75 0 101.06 1.06L17.5 7.56v7.19c0 .414.336.75.75.75z"></path></svg>');
-  content: ' ';
+  content: " ";
 
   display: inline-block;
   position: relative;

--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -1289,9 +1289,8 @@ class CMMCorePlus(pymmcore.CMMCore):
         added to complement `getXPosition` and `getYPosition`*
 
         !!! note
-            This is simply an alias for [`pymmcore.CMMCore.getPosition`][], which
-            returns the position of the current focus device when called without
-            arguments.
+            This is simply an alias for `getPosition`], which returns the position of
+            the current focus device when called without arguments.
         """
         return self.getPosition()
 
@@ -1302,9 +1301,8 @@ class CMMCorePlus(pymmcore.CMMCore):
         added to complement `setXYPosition`*
 
         !!! note
-            This is simply an alias for [`pymmcore.CMMCore.setPosition`][], which
-            returns the position of the current focus device when called with a single
-            argument.
+            This is simply an alias for `setPosition`, which returns the position of the
+            current focus device when called with a single argument.
         """
         return self.setPosition(val)
 

--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -1287,16 +1287,26 @@ class CMMCorePlus(pymmcore.CMMCore):
 
         :sparkles: *This method is new in `CMMCorePlus`:
         added to complement `getXPosition` and `getYPosition`*
+
+        !!! note
+            This is simply an alias for [`pymmcore.CMMCore.getPosition`][], which
+            returns the position of the current focus device when called without
+            arguments.
         """
-        return self.getPosition(self.getFocusDevice())
+        return self.getPosition()
 
     def setZPosition(self, val: float) -> None:
         """Set the position of the current focus device in microns.
 
         :sparkles: *This method is new in `CMMCorePlus`:
         added to complement `setXYPosition`*
+
+        !!! note
+            This is simply an alias for [`pymmcore.CMMCore.setPosition`][], which
+            returns the position of the current focus device when called with a single
+            argument.
         """
-        return self.setPosition(self.getFocusDevice(), val)
+        return self.setPosition(val)
 
     @overload
     def setPosition(self, position: float) -> None:


### PR DESCRIPTION
looks like the get/setZPosition functions were extraneous.  Looking at the source code of MMCore.cpp, it appears that `get/setPosition` called without arguments control the `currentFocusDevice` already.  This doesn't deprecate those functions (since it was obviously confusing in the first place), just leaves them as aliases, updates the docs, and updates the parent call

see also https://github.com/micro-manager/pymmcore/pull/85


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added `getZPosition` and `setZPosition` methods to the `CMMCorePlus` class in `pymmcore_plus/core/_mmcore_plus.py`. These methods provide a more intuitive way to get and set the position of the current focus device.
- Refactor: Updated `getZPosition` and `setZPosition` methods in `pymmcore_plus/core/_mmcore_plus.py` to remove dependency on the focus device, simplifying the code.
- Style: Updated `docs/stylesheets/extra.css` with a new CSS rule for wrapping long functions in an overflow-x container and adjusted border-left-width value.
- Bug Fix: Corrected a typo in the content property of the autorefs-external class in `docs/stylesheets/extra.css`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->