### PR TITLE
feat: autofind autofocus offset devices

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
       - id: mypy
         additional_dependencies:
           - pymmcore >=10.4.0.71.0
-          - useq-schema >= 0.4.0
+          - useq-schema >= 0.4.7
           - psygnal
           - typer
         files: "^src/"

--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -1661,6 +1661,69 @@ class CMMCorePlus(pymmcore.CMMCore):
         cameraLabel = cameraLabel or super().getCameraDevice()
         self.events.sequenceAcquisitionStopped.emit(cameraLabel)
 
+    def setAutoFocusOffset(self, offset: float) -> None:
+        """Applies offset the one-shot focusing device.
+
+        In micro-manager, there is some variability in the way that autofocus devices
+        are implemented.  Some have a separate offset device, while others can directly
+        set the offset of an associated device.  As a result, calling
+        `setAutoFocusOffset`, may or may not do anything depending on the current
+        autofocus device.
+
+        This method attempts to detect known autofocus devices and
+        """
+        if offset_dev := self._getAutoFocusOffsetDevice():
+            self.setPosition(offset_dev, offset)
+        super().setAutoFocusOffset(offset)
+
+    def _getAutoFocusOffsetDevice(self, af_dev: str | None = None) -> str | None:
+        """Return label of offset device for `af_dev` or the current autofocus device.
+
+        This method matches the device library and name of the provided or autofocus
+        device against a list of known autofocus devices that have an offset device
+        that must be manually managed.  If a match is found, the label of a currently
+        loaded stage device is returned (which may be used in a call to `setPosition`).
+
+        If no match is found, `None` is returned.
+        """
+        # these are devices for which setAutoFocusOffset is known to have no effect
+        # maps (device_library, device_name) -> offset_device_name
+        _OFFSET_DEVS: dict[tuple[str, str], str] = {
+            ("NikonTE2000", "PerfectFocus"): "PFS-Offset",
+            ("NikonTI", "TIPFSStatus"): "TIPFSOffset",
+            # --------------------------
+            # these devices have an apparent offset device
+            # but may implicitly/privately control it just fine with the setOffset API
+            # need testing to see whether setAutoFocusOffset works as is.
+            # ("ZeissCAN29", "ZeissDefiniteFocus"): "ZeissDefiniteFocusOffset",
+            # ("Olympus", "AutoFocusZDC"): "ZDC2OffsetDrive",
+            # ("OlympusIX83", "Autofocus"): "AutofocusDrive",
+            # ("LeicaDMI", "Adaptive Focus Control"): "Adaptive Focus Control Offset",
+            # --------------------------
+            # these devices have a known no-op for setOffset()
+            # but have no apparent offset device
+            # ("DemoCamera", "DAutoFocus"): "",
+            # ("AmScope", ""): "",
+            # ("ASIStage", "CRIF"): "",
+            # ("FocalPoint", "FocalPoint"): "",
+        }
+        if af_dev is None:
+            af_dev = self.getAutoFocusDevice()
+
+        if af_dev:
+            try:
+                lib_name = self.getDeviceLibrary(af_dev)
+            except RuntimeError:
+                return None
+            dev_name = self.getDeviceName(af_dev)
+            if offset_dev := _OFFSET_DEVS.get((lib_name, dev_name)):
+                # a match was found,
+                # find the label of currently loaded device with the same name
+                for dev in self.getLoadedDevicesOfType(DeviceType.StageDevice):
+                    if self.getDeviceName(dev) == offset_dev:
+                        return dev
+        return None
+
     def setAutoShutter(self, state: bool) -> None:
         """Set shutter to automatically open and close when an image is acquired.
 

--- a/src/pymmcore_plus/mda/_engine.py
+++ b/src/pymmcore_plus/mda/_engine.py
@@ -358,12 +358,15 @@ class MDAEngine(PMDAEngine):
         # switch off autofocus device if it is on
         self._mmc.enableContinuousFocus(False)
 
-        # setup the autofocus device
-        if name := getattr(action, "autofocus_device_name", None):
-            self._mmc.setPosition(name, action.autofocus_motor_offset)
-        else:
-            self._mmc.setAutoFocusOffset(action.autofocus_motor_offset)
-        self._mmc.waitForSystem()
+        if action.autofocus_motor_offset is not None:
+            # set the autofocus device offset
+            # if name is given explicitly, use it, otherwise use setAutoFocusOffset
+            # (see docs for setAutoFocusOffset for additional details)
+            if name := getattr(action, "autofocus_device_name", None):
+                self._mmc.setPosition(name, action.autofocus_motor_offset)
+            else:
+                self._mmc.setAutoFocusOffset(action.autofocus_motor_offset)
+            self._mmc.waitForSystem()
 
         @retry(exceptions=RuntimeError, tries=action.max_retries, logger=logger.warning)
         def _perform_full_focus(previous_z: float) -> float:

--- a/src/pymmcore_plus/mda/_engine.py
+++ b/src/pymmcore_plus/mda/_engine.py
@@ -359,10 +359,10 @@ class MDAEngine(PMDAEngine):
         self._mmc.enableContinuousFocus(False)
 
         # setup the autofocus device
-        self._mmc.setPosition(
-            action.autofocus_device_name,
-            action.autofocus_motor_offset,
-        )
+        if name := getattr(action, "autofocus_device_name", None):
+            self._mmc.setPosition(name, action.autofocus_motor_offset)
+        else:
+            self._mmc.setAutoFocusOffset(action.autofocus_motor_offset)
         self._mmc.waitForSystem()
 
         @retry(exceptions=RuntimeError, tries=action.max_retries, logger=logger.warning)

--- a/src/pymmcore_plus/mda/_runner.py
+++ b/src/pymmcore_plus/mda/_runner.py
@@ -23,7 +23,7 @@ MSG = (
 
 
 class GeneratorMDASequence(MDASequence):
-    axis_order: str = ""
+    axis_order: tuple[str, ...] = ()
 
     @property
     def sizes(self) -> dict[str, int]:  # pragma: no cover

--- a/src/pymmcore_plus/mda/_runner.py
+++ b/src/pymmcore_plus/mda/_runner.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import time
 import warnings
-from typing import TYPE_CHECKING, Any, Iterable, Iterator
+from typing import TYPE_CHECKING, Any, Iterable, Iterator, Tuple
 
 from useq import MDASequence
 
@@ -23,7 +23,7 @@ MSG = (
 
 
 class GeneratorMDASequence(MDASequence):
-    axis_order: tuple[str, ...] = ()
+    axis_order: Tuple[str, ...] = ()  # noqa: UP006
 
     @property
     def sizes(self) -> dict[str, int]:  # pragma: no cover

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -576,3 +576,15 @@ def test_multi_roi(core: CMMCorePlus) -> None:
     roi = ([0, 0], [10, 10], [20, 20], [30, 30])
     core.setMultiROI(*roi)
     assert core.getMultiROI() == roi
+
+
+def test_set_autofocus_offset(
+    core: CMMCorePlus, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from pymmcore_plus.core import _mmcore_plus
+
+    monkeypatch.setitem(
+        _mmcore_plus._OFFSET_DEVICES, ("DemoCamera", "DAutoFocus"), "DStage"
+    )
+    core.setAutoFocusOffset(1.0)
+    assert core.getAutoFocusOffset() == 1.0


### PR DESCRIPTION
In micro-manager, there is some variability in the way that autofocus devices are implemented.  Some have a separate offset device, while others can directly set the offset of an associated device.  As a result, calling `setAutoFocusOffset`, may or may not do anything depending on the current autofocus device, and the way to set the offset of these devices is to call `setPosition` on a corresponding Stage Device (see https://github.com/micro-manager/micro-manager/issues/858).

For many devices adapters (such as the NikonTI), it is possible to know *a priori* what the corresponding offset device name would be.  This PR adds a map of known device lookups to offset device names, and sets the corresponding position accordingly.  The goal is to make `setAutoFocusOffset` be *the* way to update the autofocus device offset (rather than sometimes having to call `setPosition`.  Currently, it only adds NikonTE2000 and NikonTI ... but there are a number of commented out offset devices that may or may not be useful to uncomment eventually.

It's a little magical, but it's also unlikely to affect anything but a couple devices like Nikon at the moment.

@marktsuchida curious if you think this is a terrible idea :)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Introduced `setAutoFocusOffset` method in the core class to apply an offset to the one-shot focusing device, enhancing flexibility in configuring autofocus devices.
- Refactor: Updated `_execute_autofocus` method in the MDA engine to handle cases when `autofocus_motor_offset` is not None, improving the setup of autofocus devices.
- Refactor: Modified `axis_order` attribute in the `GeneratorMDASequence` class from a string to a tuple of strings, allowing for multiple axis orders to be specified.
- Test: Added new test function `test_set_autofocus_offset` to validate the functionality of the newly introduced `setAutoFocusOffset` method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->