### PR TITLE
feat: allow engine to modify sequence

### DIFF
--- a/docs/guides/mda_engine.md
+++ b/docs/guides/mda_engine.md
@@ -140,12 +140,12 @@ mmc.run_mda(mda_sequence)
     that look something like this:
 
     ```log
-    2023-08-12 16:37:50,694 - INFO - MDA Started: GeneratorMDASequence()
+    2023-08-12 16:37:50,694 - INFO - MDA Started: EventIterable()
     2023-08-12 16:37:50,695 - INFO - channel=Channel(config='DAPI') x_pos=1100.0 y_pos=1240.0
     2023-08-12 16:37:50,881 - INFO - channel=Channel(config='FITC') x_pos=1100.0 y_pos=1240.0
     2023-08-12 16:37:50,891 - INFO - channel=Channel(config='DAPI') x_pos=1442.0 y_pos=1099.0
     2023-08-12 16:37:50,947 - INFO - channel=Channel(config='FITC') x_pos=1442.0 y_pos=1099.0
-    2023-08-12 16:37:50,958 - INFO - MDA Finished: GeneratorMDASequence()
+    2023-08-12 16:37:50,958 - INFO - MDA Finished: EventIterable()
     ```
 
     See [logging](logging.md) for more details on how to configure and review logs.

--- a/src/pymmcore_plus/__init__.py
+++ b/src/pymmcore_plus/__init__.py
@@ -27,7 +27,7 @@ from .core import (
     PropertyType,
 )
 from .core.events import CMMCoreSignaler, PCoreSignaler
-from .mda._runner import GeneratorMDASequence
+from .mda._runner import EventIterable
 
 __all__ = [
     "__version__",
@@ -47,7 +47,7 @@ __all__ = [
     "DeviceType",
     "find_micromanager",
     "FocusDirection",
-    "GeneratorMDASequence",
+    "EventIterable",
     "Keyword",
     "Metadata",
     "PCoreSignaler",

--- a/src/pymmcore_plus/mda/_engine.py
+++ b/src/pymmcore_plus/mda/_engine.py
@@ -91,7 +91,7 @@ class MDAEngine(PMDAEngine):
 
     # ===================== Protocol Implementation =====================
 
-    def setup_sequence(self, sequence: MDASequence) -> Mapping[str, Any]:
+    def setup_sequence(self, sequence: MDASequence) -> tuple[Mapping[str, Any]]:
         """Setup the hardware for the entire sequence."""
         if not self._mmc:  # pragma: no cover
             from pymmcore_plus.core import CMMCorePlus
@@ -102,7 +102,7 @@ class MDAEngine(PMDAEngine):
             self._update_grid_fov_sizes(px_size, sequence)
 
         self._autoshutter_was_set = self._mmc.getAutoShutter()
-        return _summary_meta(self._mmc)
+        return (_summary_meta(self._mmc),)
 
     def _update_grid_fov_sizes(self, px_size: float, sequence: MDASequence) -> None:
         *_, x_size, y_size = self._mmc.getROI()

--- a/src/pymmcore_plus/mda/_protocol.py
+++ b/src/pymmcore_plus/mda/_protocol.py
@@ -21,10 +21,18 @@ class PMDAEngine(Protocol):
     """Protocol that all MDA engines must implement."""
 
     @abstractmethod
-    def setup_sequence(self, sequence: MDASequence) -> None | Mapping[str, Any]:
+    def setup_sequence(
+        self, sequence: MDASequence
+    ) -> None | tuple[Mapping[str, Any]] | tuple[Mapping[str, Any], MDASequence]:
         """Setup state of system (hardware, etc.) before an MDA is run.
 
         This method is called once at the beginning of a sequence.
+        It should prepare the state of the system for the sequence and return one of:
+        - None: no summary metadata or modified sequence
+        - (meta,): 1-tuple containing summary metadata dict
+        - (meta, sequence): 2-tuple containing summary metadata dict and modified
+          MDASequence.  If the sequence is modified, the modified sequence will be
+          used for the rest of the sequence.
         """
 
     @abstractmethod


### PR DESCRIPTION
This PR would modify the engine protocol to allow `setup_sequence` to return a modified sequence.

Related to https://github.com/pymmcore-plus/pymmcore-widgets/pull/213 and other times when we found the engine needs to weigh in on the Sequence.

It has a possibly bad result though: if we're _not_ running an MDASequence, but rather a generic event iterable, and the engine tries to modify it, then we have a conflict (those objects should not be modified).  One possibilitiy here is to change the input arguments to `setup_sequence` to be `MDASequence | None` ... in which case it's obvious to the engine that it's not allowed to modify `None`, but that's a breaking change (things like @ianhi's engines would break in the rare case that a non-MDAsequence was passed to the runner).

so, need to think about this one for a moment and gather opinions