### PR TITLE
refactor: update state method on MMCorePlus

### DIFF
--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -22,7 +22,6 @@ from typing import (
     Pattern,
     Sequence,
     TypeVar,
-    cast,
     overload,
 )
 
@@ -41,6 +40,7 @@ from ._device import Device
 from ._metadata import Metadata
 from ._property import DeviceProperty
 from ._sequencing import can_sequence_events
+from ._state import core_state
 from .events import CMMCoreSignaler, PCoreSignaler, _get_auto_core_callback_class
 
 if TYPE_CHECKING:
@@ -48,34 +48,11 @@ if TYPE_CHECKING:
     from typing_extensions import Literal, TypedDict
     from useq import MDAEvent
 
+    from ._state import StateDict
+
     _T = TypeVar("_T")
     _F = TypeVar("_F", bound=Callable[..., Any])
     ListOrTuple = list[_T] | tuple[_T, ...]
-
-    class StateDict(TypedDict, total=False):
-        """Dictionary of state values for a device.
-
-        This object should only be imported inside a `TYPE_CHECKING` block.
-        """
-
-        AutoFocusDevice: str
-        BytesPerPixel: int
-        CameraChannelNames: tuple[str, ...]
-        CameraDevice: str
-        Datetime: str
-        Exposure: float
-        FocusDevice: str
-        GalvoDevice: str
-        ImageBitDepth: int
-        ImageHeight: int
-        ImageProcessorDevice: str
-        ImageWidth: int
-        PixelSizeUm: float
-        ShutterDevice: str
-        SLMDevice: str
-        XYPosition: tuple[float, float]
-        XYStageDevice: str
-        ZPosition: float
 
     class PropertySchema(TypedDict, total=False):
         """JSON schema `dict` describing a device property."""
@@ -2011,58 +1988,36 @@ class CMMCorePlus(pymmcore.CMMCore):
         print("Adapter path:", ",".join(self.getDeviceAdapterSearchPaths()))
         print_tabular_data(data, sort=sort)
 
-    def state(self, exclude: Iterable[str] = ()) -> StateDict:
-        """Return `StateDict` with commonly accessed state values.
-
-        :sparkles: *This method is new in `CMMCorePlus`. It is a bit faster
-        than [`getSystemState`][pymmcore_plus.CMMCorePlus.getSystemState].*
-
-        Parameters
-        ----------
-        exclude : Iterable[str]
-            List of properties to exclude when gathering state (may speed things up).
-            See [`StateDict`][pymmcore_plus.core._mmcore_plus.StateDict] for a list of
-            keys that can be excluded.
-
-        Returns
-        -------
-        StateDict
-            A dictionary of commonly accessed state values.
-        """
-        # approx retrieval cost in comment (for demoCam)
-        exclude = set(exclude)
-        state: dict = {}
-        for attr in (
-            "AutoFocusDevice",  # 150 ns
-            "BytesPerPixel",  # 149 ns
-            "CameraChannelNames",  # 1 µs
-            "CameraDevice",  # 159 ns
-            "Datetime",
-            "Exposure",  # 726 ns
-            "FocusDevice",  # 112 ns
-            "GalvoDevice",  # 109 ns
-            "ImageBitDepth",  # 147 ns
-            "ImageHeight",  # 164 ns
-            "ImageProcessorDevice",  # 110 ns
-            "ImageWidth",  # 172 ns
-            "PixelSizeUm",  # 2.2 µs
-            "ShutterDevice",  # 152 ns
-            "SLMDevice",  # 110 ns
-            "XYPosition",  # 1.1 µs
-            "XYStageDevice",  # 156 ns
-            "ZPosition",  # 1.03 µs
-        ):
-            if attr not in exclude:
-                if attr == "Datetime":
-                    state[attr] = str(datetime.now())
-                elif attr == "PixelSizeUm":
-                    state[attr] = self.getPixelSizeUm(True)  # True==cached
-                else:
-                    try:
-                        state[attr] = getattr(self, f"get{attr}")()
-                    except RuntimeError:
-                        continue
-        return cast("StateDict", state)
+    def state(
+        self,
+        *,
+        devices: bool = True,
+        image: bool = True,
+        system_info: bool = False,
+        system_status: bool = False,
+        config_groups: bool | Sequence[str] = True,
+        position: bool = False,
+        autofocus: bool = False,
+        pixel_size_configs: bool = False,
+        device_types: bool = False,
+        cached: bool = True,
+        error_value: Any = None,
+    ) -> StateDict:
+        """Return info on the current state of the core."""
+        return core_state(
+            self,
+            devices=devices,
+            image=image,
+            system_info=system_info,
+            system_status=system_status,
+            config_groups=config_groups,
+            position=position,
+            autofocus=autofocus,
+            pixel_size_configs=pixel_size_configs,
+            device_types=device_types,
+            cached=cached,
+            error_value=error_value,
+        )
 
     @contextmanager
     def _property_change_emission_ensured(

--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -498,6 +498,18 @@ class CMMCorePlus(pymmcore.CMMCore):
         cfg = super().getConfigGroupState(group)
         return cfg if native else Configuration.from_configuration(cfg)
 
+    @overload
+    def getConfigGroupStateFromCache(
+        self, group: str, *, native: Literal[True]
+    ) -> pymmcore.Configuration:
+        ...
+
+    @overload
+    def getConfigGroupStateFromCache(
+        self, group: str, *, native: Literal[False] = False
+    ) -> Configuration:
+        ...
+
     def getConfigGroupStateFromCache(
         self, group: str, *, native: bool = False
     ) -> Configuration | pymmcore.Configuration:

--- a/src/pymmcore_plus/core/_state.py
+++ b/src/pymmcore_plus/core/_state.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+from contextlib import suppress
+from typing import TYPE_CHECKING, Any, Sequence, TypedDict, cast
+
+if TYPE_CHECKING:
+    from typing_extensions import Literal
+
+    from pymmcore_plus import CMMCorePlus
+
+
+class SystemInfoDict(TypedDict):
+    APIVersionInfo: str
+    BufferFreeCapacity: int
+    BufferTotalCapacity: int
+    CircularBufferMemoryFootprint: int
+    DeviceAdapterSearchPaths: tuple[str, ...]
+    HostName: str
+    MACAddresses: tuple[str, ...]
+    PrimaryLogFile: str
+    RemainingImageCount: int
+    TimeoutMs: int  # rarely needed for metadata
+    UserId: str
+    VersionInfo: str
+
+
+class ImageDict(TypedDict):
+    BytesPerPixel: int
+    CurrentPixelSizeConfig: str
+    Exposure: float
+    ImageBitDepth: int
+    ImageBufferSize: int
+    ImageHeight: int
+    ImageWidth: int
+    MagnificationFactor: float
+    MultiROI: tuple[list[int], list[int], list[int], list[int]] | None
+    NumberOfCameraChannels: int
+    NumberOfComponents: int
+    PixelSizeAffine: tuple[float, float, float, float, float, float]
+    PixelSizeUm: int
+    ROI: list[int]
+
+
+class PositionDict(TypedDict):
+    X: float | None
+    Y: float | None
+    Focus: float | None
+
+
+class AutoFocusDict(TypedDict):
+    CurrentFocusScore: float
+    LastFocusScore: float
+    AutoFocusOffset: float | None
+
+
+class PixelSizeConfigDict(TypedDict):
+    Objective: dict[str, str]
+    PixelSizeUm: float
+    PixelSizeAffine: tuple[float, float, float, float, float, float]
+
+
+class DeviceTypeDict(TypedDict):
+    Type: str
+    Description: str
+    Adapter: str
+
+
+class SystemStatusDict(TypedDict):
+    debugLogEnabled: bool
+    isBufferOverflowed: bool
+    isContinuousFocusEnabled: bool
+    isContinuousFocusLocked: bool
+    isSequenceRunning: bool
+    stderrLogEnabled: bool
+    systemBusy: bool
+    autoShutter: bool
+    shutterOpen: bool
+
+
+class StateDict(TypedDict, total=False):
+    Devices: dict[str, dict[str, str]]
+    SystemInfo: SystemInfoDict
+    SystemStatus: SystemStatusDict
+    ConfigGroups: dict[str, dict[str, Any]]
+    Image: ImageDict
+    Position: PositionDict
+    AutoFocus: AutoFocusDict
+    PixelSizeConfig: dict[str, str | PixelSizeConfigDict]
+    DeviceTypes: dict[str, DeviceTypeDict]
+
+
+def core_state(
+    core: CMMCorePlus,
+    *,
+    devices: bool = True,
+    image: bool = True,
+    system_info: bool = False,
+    system_status: bool = False,
+    config_groups: bool | Sequence[str] = True,
+    position: bool = False,
+    autofocus: bool = False,
+    pixel_size_configs: bool = False,
+    device_types: bool = False,
+    cached: bool = True,
+    error_value: Any = None,
+) -> StateDict:
+    out: StateDict = {}
+    if devices:
+        out["Devices"] = get_device_state(core, error_value)
+    if system_info:
+        out["SystemInfo"] = get_system_info(core)
+    if system_status:
+        out["SystemStatus"] = get_system_status(core)
+    if config_groups:
+        out["ConfigGroups"] = get_config_groups(core, config_groups, cached)
+    if image:
+        out["Image"] = get_image_info(core, error_value)
+    if position:
+        out["Position"] = get_position(core, error_value)
+    if autofocus:
+        out["AutoFocus"] = get_autofocus(core, error_value)
+    if pixel_size_configs:
+        out["PixelSizeConfig"] = get_pix_size_config(core)
+    if device_types:
+        out["DeviceTypes"] = get_device_types(core)
+    return out
+
+
+def get_device_state(
+    core: CMMCorePlus, cached: bool = True, error_value: Any = None
+) -> dict[str, dict[str, Any]]:
+    # this actually appears to be faster than getSystemStateCache
+    getProp = core.getPropertyFromCache if cached else core.getProperty
+    device_state: dict = {}
+    for dev in core.getLoadedDevices():
+        dd = device_state.setdefault(dev, {})
+        for prop in core.getDevicePropertyNames(dev):
+            try:
+                val = getProp(dev, prop)
+            except Exception:
+                val = error_value
+            dd[prop] = val
+    return device_state
+
+
+def get_system_info(core: CMMCorePlus) -> SystemInfoDict:
+    return {  # type: ignore
+        key: getattr(core, f"get{key}")()
+        for key in sorted(SystemInfoDict.__annotations__)
+    }
+
+
+def get_system_status(core: CMMCorePlus) -> SystemStatusDict:
+    out = {
+        "autoShutter": core.getAutoShutter(),
+        "shutterOpen": core.getShutterOpen(),
+    }
+    out.update(
+        {
+            key: getattr(core, key)()
+            for key in sorted(SystemStatusDict.__annotations__)
+            if key not in {"autoShutter", "shutterOpen"}
+        }
+    )
+    return cast("SystemStatusDict", out)
+
+
+def get_config_groups(
+    core: CMMCorePlus,
+    config_groups: bool | Sequence[str | Literal["[Channel]"]],
+    cached: bool = True,
+) -> dict[str, dict[str, Any]]:
+    if not isinstance(config_groups, (list, tuple, set)):
+        config_groups = core.getAvailableConfigGroups()
+
+    getState = core.getConfigGroupStateFromCache if cached else core.getConfigGroupState
+    curGrp = core.getCurrentConfigFromCache if cached else core.getCurrentConfig
+    cfg_group_dict: dict = {}
+    for grp in config_groups:
+        if grp == "[Channel]":
+            # special case for accessing channel group
+            grp = core.getChannelGroup()
+
+        grp_dict = cfg_group_dict.setdefault(grp, {})
+        grp_dict["Current"] = curGrp(grp)
+
+        for dev, prop, val in getState(grp):
+            grp_dict.setdefault(dev, {})[prop] = val
+    return cfg_group_dict
+
+
+def get_image_info(core: CMMCorePlus, error_value: Any = None) -> ImageDict:
+    img_dict = {}
+    for key in sorted(ImageDict.__annotations__):
+        try:
+            val = getattr(core, f"get{key}")()
+        except Exception:
+            val = error_value
+        img_dict[key] = val
+    return cast("ImageDict", img_dict)
+
+
+def get_position(core: CMMCorePlus, error_value: Any = None) -> PositionDict:
+    pos: PositionDict = {"X": error_value, "Y": error_value, "Focus": error_value}
+    with suppress(Exception):
+        pos["X"] = core.getXPosition()
+        pos["Y"] = core.getYPosition()
+    with suppress(Exception):
+        pos["Focus"] = core.getPosition()
+    return pos
+
+
+def get_autofocus(core: CMMCorePlus, error_value: Any = None) -> AutoFocusDict:
+    out: AutoFocusDict = {
+        "CurrentFocusScore": core.getCurrentFocusScore(),
+        "LastFocusScore": core.getLastFocusScore(),
+        "AutoFocusOffset": error_value,
+    }
+    with suppress(Exception):
+        out["AutoFocusOffset"] = core.getAutoFocusOffset()
+    return out
+
+
+def get_pix_size_config(core: CMMCorePlus) -> dict[str, str | PixelSizeConfigDict]:
+    # the Current value is a string, all the rest are PixelSizeConfigDict
+    px: dict = {"Current": core.getCurrentPixelSizeConfig()}
+    for px_cfg_name in core.getAvailablePixelSizeConfigs():
+        px_cfg_info: dict = {}
+        for dev, prop, val in core.getPixelSizeConfigData(px_cfg_name):
+            px_cfg_info.setdefault(dev, {})[prop] = val
+        px_cfg_info["PixelSizeUm"] = core.getPixelSizeUmByID(px_cfg_name)
+        px_cfg_info["PixelSizeAffine"] = core.getPixelSizeAffineByID(px_cfg_name)
+        px[px_cfg_name] = px_cfg_info
+    return px
+
+
+def get_device_types(core: CMMCorePlus) -> dict[str, DeviceTypeDict]:
+    return {
+        dev_name: {
+            "Type": core.getDeviceType(dev_name).name,
+            "Description": core.getDeviceDescription(dev_name),
+            "Adapter": core.getDeviceName(dev_name),
+        }
+        for dev_name in core.getLoadedDevices()
+    }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -618,3 +618,7 @@ def test_core_state(core: CMMCorePlus) -> None:
     }:
         if val := state["Devices"]["Core"][key]:
             assert val in state["Devices"]
+
+    core.unloadAllDevices()
+    # should still work without error
+    state = core.state()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -588,3 +588,33 @@ def test_set_autofocus_offset(
     )
     core.setAutoFocusOffset(1.0)
     assert core.getAutoFocusOffset() == 1.0
+
+
+def test_core_state(core: CMMCorePlus) -> None:
+    state = core.state(
+        devices=True,
+        image=True,
+        system_info=True,
+        system_status=True,
+        config_groups=True,
+        position=True,
+        autofocus=True,
+        pixel_size_configs=True,
+        device_types=True,
+    )
+    assert isinstance(state, dict)
+    assert "Devices" in state
+    assert "Core" in state["Devices"]
+
+    for key in {
+        "AutoFocus",
+        "Camera",
+        "Focus",
+        "Galvo",
+        "ImageProcessor",
+        "SLM",
+        "Shutter",
+        "XYStage",
+    }:
+        if val := state["Devices"]["Core"][key]:
+            assert val in state["Devices"]


### PR DESCRIPTION
this is a better implementation of `CMMCorePlus.state`.  it could be used instead of `getTags` for metadata during acquisitions.  The output is typed by `TypedDicts` so it's easy to tell what keys are available in downstream usage, and the presence of each key is toggleable for performance reasons.

It adheres pretty tightly to the naming conventions in Core itself, and avoids coming up with new keys/conventions/capitalizations whenever possible

<details>

<summary>example output</summary>

```python
{
    'Devices': {
        'DHub': {},
        'Camera': {
            'AllowMultiROI': '0',
            'AsyncPropertyDelayMS': '2000',
            'AsyncPropertyFollower': '',
            'AsyncPropertyLeader': '',
            'Binning': '1',
            'BitDepth': '16',
            'CCDTemperature': '0.0000',
            'CCDTemperature RO': '0.0000',
            'CameraID': 'V1.0',
            'CameraName': 'DemoCamera-MultiMode',
            'Description': 'Demo Camera Device Adapter',
            'DisplayImageNumber': '0',
            'DropPixels': '0',
            'Exposure': '10.0000',
            'FastImage': '0',
            'FractionOfPixelsToDropOrSaturate': '0.0020',
            'Gain': '0',
            'HubID': '',
            'MaximumExposureMs': '10000.0000',
            'Mode': 'Artificial Waves',
            'MultiROIFillValue': '0',
            'Name': 'DCam',
            'Offset': '0',
            'OnCameraCCDXSize': '512',
            'OnCameraCCDYSize': '512',
            'Photon Conversion Factor': '1.0000',
            'Photon Flux': '50.0000',
            'PixelType': '16bit',
            'ReadNoise (electrons)': '2.5000',
            'ReadoutTime': '0.0000',
            'RotateImages': '0',
            'SaturatePixels': '0',
            'ScanMode': '1',
            'SimulateCrash': '',
            'StripeWidth': '1.0000',
            'TestProperty1': '0.0000',
            'TestProperty2': '0.0000',
            'TestProperty3': '0.0000',
            'TestProperty4': '0.0000',
            'TestProperty5': '0.0000',
            'TestProperty6': '0.0000',
            'TransposeCorrection': '0',
            'TransposeMirrorX': '0',
            'TransposeMirrorY': '0',
            'TransposeXY': '0',
            'TriggerDevice': '',
            'UseExposureSequences': 'No'
        },
        'Dichroic': {
            'ClosedPosition': '0',
            'Description': 'Demo filter wheel driver',
            'HubID': '',
            'Label': '400DCLP',
            'Name': 'DWheel',
            'State': '0'
        },
        'Emission': {
            'ClosedPosition': '0',
            'Description': 'Demo filter wheel driver',
            'HubID': '',
            'Label': 'Chroma-HQ620',
            'Name': 'DWheel',
            'State': '0'
        },
        'Excitation': {
            'ClosedPosition': '0',
            'Description': 'Demo filter wheel driver',
            'HubID': '',
            'Label': 'Chroma-D360',
            'Name': 'DWheel',
            'State': '0'
        },
        'Objective': {
            'Description': 'Demo objective turret driver',
            'HubID': '',
            'Label': 'Nikon 10X S Fluor',
            'Name': 'DObjective',
            'State': '1',
            'Trigger': '-'
        },
        'Z': {
            'Description': 'Demo stage driver',
            'HubID': '',
            'Name': 'DStage',
            'Position': '0.0000',
            'UseSequences': 'No'
        },
        'Path': {
            'Description': 'Demo light-path driver',
            'HubID': '',
            'Label': 'State-0',
            'Name': 'DLightPath',
            'State': '0'
        },
        'XY': {
            'Description': 'Demo XY stage driver',
            'HubID': '',
            'Name': 'DXYStage',
            'TransposeMirrorX': '0',
            'TransposeMirrorY': '0'
        },
        'White Light Shutter': {
            'Description': 'Demo shutter driver',
            'HubID': '',
            'Name': 'DShutter',
            'State': '1'
        },
        'Autofocus': {'Description': 'Demo auto-focus adapter', 'HubID': '', 'Name': 'DAutoFocus'},
        'LED': {
            'ClosedPosition': '0',
            'Description': 'Demo state device driver',
            'HubID': '',
            'Label': 'Closed',
            'Name': 'DStateDevice',
            'Number of positions': '10',
            'Sequence': 'Off',
            'State': '0'
        },
        'LED Shutter': {
            'Description': 'State device that is used as a shutter',
            'Name': 'State Device Shutter',
            'State Device': 'LED'
        },
        'Core': {
            'AutoFocus': 'Autofocus',
            'AutoShutter': '1',
            'Camera': 'Camera',
            'ChannelGroup': 'Channel',
            'Focus': 'Z',
            'Galvo': '',
            'ImageProcessor': '',
            'Initialize': '1',
            'SLM': '',
            'Shutter': 'White Light Shutter',
            'TimeoutMs': '5000',
            'XYStage': 'XY'
        }
    },
    'SystemInfo': {
        'APIVersionInfo': 'Device API version 71, Module API version 10',
        'BufferFreeCapacity': 0,
        'BufferTotalCapacity': 0,
        'CircularBufferMemoryFootprint': 250,
        'DeviceAdapterSearchPaths': (
            '/Users/talley/Library/Application Support/pymmcore-plus/mm/Micro-Manager-2.0.2-20230810',
        ),
        'HostName': 'Talleys-iMac.local',
        'MACAddresses': ('1c-1b-0d-65-d9-10',),
        'PrimaryLogFile': '',
        'RemainingImageCount': 0,
        'TimeoutMs': 5000,
        'UserId': 'talley',
        'VersionInfo': 'MMCore version 10.4.0'
    },
    'SystemStatus': {
        'autoShutter': True,
        'shutterOpen': True,
        'debugLogEnabled': False,
        'isBufferOverflowed': False,
        'isContinuousFocusEnabled': False,
        'isContinuousFocusLocked': False,
        'isSequenceRunning': False,
        'stderrLogEnabled': False,
        'systemBusy': False
    },
    'ConfigGroups': {
        'Camera': {'Current': '', 'Camera': {'Binning': '1', 'BitDepth': '16'}},
        'Channel': {
            'Current': 'DAPI',
            'Dichroic': {'Label': '400DCLP'},
            'Emission': {'Label': 'Chroma-HQ620'},
            'Excitation': {'Label': 'Chroma-D360'},
            'Core': {'Shutter': 'White Light Shutter'}
        },
        'Channel-Multiband': {
            'Current': '',
            'Dichroic': {'Label': '400DCLP'},
            'Emission': {'Label': 'Chroma-HQ620'},
            'Excitation': {'Label': 'Chroma-D360'},
            'LED': {'Label': 'Closed'},
            'Core': {'Shutter': 'White Light Shutter'}
        },
        'LightPath': {'Current': 'Eyepiece', 'Path': {'State': '0'}},
        'Objective': {'Current': '10X', 'Objective': {'State': '1'}},
        'System': {
            'Current': 'Startup',
            'Camera': {'BitDepth': '16', 'ScanMode': '1', 'Binning': '1'},
            'Objective': {'Label': 'Nikon 10X S Fluor'},
            'LED Shutter': {'State Device': 'LED'},
            'Core': {'ChannelGroup': 'Channel'}
        }
    },
    'Image': {
        'BytesPerPixel': 2,
        'CurrentPixelSizeConfig': 'Res10x',
        'Exposure': 10.0,
        'ImageBitDepth': 16,
        'ImageBufferSize': 524288,
        'ImageHeight': 512,
        'ImageWidth': 512,
        'MagnificationFactor': 1.0,
        'MultiROI': ([], [], [], []),
        'NumberOfCameraChannels': 1,
        'NumberOfComponents': 1,
        'PixelSizeAffine': (1.0, 0.0, 0.0, 0.0, 1.0, 0.0),
        'PixelSizeUm': 1.0,
        'ROI': [0, 0, 512, 512]
    },
    'Position': {'X': -0.0, 'Y': -0.0, 'Focus': 0.0},
    'AutoFocus': {'CurrentFocusScore': 1.0, 'LastFocusScore': 0.0, 'AutoFocusOffset': 2.2459860707e-314},
    'PixelSizeConfig': {
        'Current': 'Res10x',
        'Res10x': {
            'Objective': {'Label': 'Nikon 10X S Fluor'},
            'PixelSizeUm': 1.0,
            'PixelSizeAffine': (1.0, 0.0, 0.0, 0.0, 1.0, 0.0)
        },
        'Res20x': {
            'Objective': {'Label': 'Nikon 20X Plan Fluor ELWD'},
            'PixelSizeUm': 0.5,
            'PixelSizeAffine': (1.0, 0.0, 0.0, 0.0, 1.0, 0.0)
        },
        'Res40x': {
            'Objective': {'Label': 'Nikon 40X Plan Fluor ELWD'},
            'PixelSizeUm': 0.25,
            'PixelSizeAffine': (1.0, 0.0, 0.0, 0.0, 1.0, 0.0)
        }
    },
    'DeviceTypes': {
        'DHub': {'Type': 'HubDevice', 'Description': 'DHub', 'Adapter': 'DHub'},
        'Camera': {'Type': 'CameraDevice', 'Description': 'Demo camera', 'Adapter': 'DCam'},
        'Dichroic': {'Type': 'StateDevice', 'Description': 'Demo filter wheel', 'Adapter': 'DWheel'},
        'Emission': {'Type': 'StateDevice', 'Description': 'Demo filter wheel', 'Adapter': 'DWheel'},
        'Excitation': {'Type': 'StateDevice', 'Description': 'Demo filter wheel', 'Adapter': 'DWheel'},
        'Objective': {'Type': 'StateDevice', 'Description': 'Demo objective turret', 'Adapter': 'DObjective'},
        'Z': {'Type': 'StageDevice', 'Description': 'Demo stage', 'Adapter': 'DStage'},
        'Path': {'Type': 'StateDevice', 'Description': 'Demo light path', 'Adapter': 'DLightPath'},
        'XY': {'Type': 'XYStageDevice', 'Description': 'Demo XY stage', 'Adapter': 'DXYStage'},
        'White Light Shutter': {'Type': 'ShutterDevice', 'Description': 'Demo shutter', 'Adapter': 'DShutter'},
        'Autofocus': {'Type': 'AutoFocusDevice', 'Description': 'Demo auto focus', 'Adapter': 'DAutoFocus'},
        'LED': {'Type': 'StateDevice', 'Description': 'Demo State Device', 'Adapter': 'DStateDevice'},
        'LED Shutter': {
            'Type': 'ShutterDevice',
            'Description': 'State device used as a shutter',
            'Adapter': 'State Device Shutter'
        },
        'Core': {'Type': 'CoreDevice', 'Description': 'Core device', 'Adapter': 'Core'}
    }
}
```

</details>

The design is partially based on @marktsuchida's comments in https://github.com/micro-manager/pymmcore/issues/17#issuecomment-690512630

>  it would be good to learn also from a few more design mistakes that TaggedImage made: it puts metadata from different sources into a single bag, and string-concatenates device and property names with "-", so that unambiguous parsing is not possible.

