### PR TITLE
feat: store last config path

### DIFF
--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -195,6 +195,7 @@ class CMMCorePlus(pymmcore.CMMCore):
             self.setPrimaryLogFile(str(logfile))
             logger.debug("Initialized core %s", self)
 
+        self._last_config: str | None = None  # last loaded config file
         self._mm_path = mm_path or find_micromanager()
         if not adapter_paths and self._mm_path:
             adapter_paths = [self._mm_path]
@@ -369,7 +370,15 @@ class CMMCorePlus(pymmcore.CMMCore):
             fpath = Path(self._mm_path) / fileName
         if not fpath.exists():
             raise FileNotFoundError(f"Path does not exist: {fpath}")
-        super().loadSystemConfiguration(str(fpath.resolve()))
+        self._last_config = str(fpath.resolve())
+        super().loadSystemConfiguration(self._last_config)
+
+    def systemConfigurationFile(self) -> str | None:
+        """Return the path to the last loaded system configuration file, or `None`.
+
+        :sparkles: *This method is new in `CMMCorePlus`.*
+        """
+        return self._last_config
 
     def unloadAllDevices(self) -> None:
         """Unload all devices from the core and reset all configuration data.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -64,6 +64,7 @@ def test_load_system_config(core: CMMCorePlus):
 
     config_path = Path(__file__).parent / "local_config.cfg"
     core.loadSystemConfiguration(str(config_path))
+    assert core.systemConfigurationFile() == str(config_path)
     assert core.getLoadedDevices() == (
         "DHub",
         "Camera",


### PR DESCRIPTION
This adds a `systemConfigurationFile` method.
There are many places in MMStudio where it would be nice to have a central place to look for the currently loaded config file.  This offers that.