### PR TITLE
refactor: change exec_events to iterable

### DIFF
--- a/src/pymmcore_plus/mda/_engine.py
+++ b/src/pymmcore_plus/mda/_engine.py
@@ -27,7 +27,6 @@ if TYPE_CHECKING:
     from typing_extensions import TypedDict
 
     from pymmcore_plus.core import CMMCorePlus
-    from pymmcore_plus.core._mmcore_plus import TaggedImage
 
     from ._protocol import PImagePayload
 

--- a/src/pymmcore_plus/mda/_engine.py
+++ b/src/pymmcore_plus/mda/_engine.py
@@ -133,7 +133,7 @@ class MDAEngine(PMDAEngine):
             self.setup_single_event(event)
         self._mmc.waitForSystem()
 
-    def exec_event(self, event: MDAEvent) -> Sequence[PImagePayload]:
+    def exec_event(self, event: MDAEvent) -> Iterable[PImagePayload]:
         """Execute an individual event and return the image data."""
         action = getattr(event, "action", None)
         if isinstance(action, HardwareAutofocus):
@@ -154,9 +154,9 @@ class MDAEngine(PMDAEngine):
             return ()
 
         if isinstance(event, SequencedEvent):
-            return self.exec_sequenced_event(event)
+            yield from self.exec_sequenced_event(event)
         else:
-            return self.exec_single_event(event)
+            yield from self.exec_single_event(event)
 
     def event_iterator(self, events: Iterable[MDAEvent]) -> Iterator[MDAEvent]:
         """Event iterator that merges events for hardware sequencing if possible.
@@ -240,7 +240,7 @@ class MDAEngine(PMDAEngine):
             return ()
         if not event.keep_shutter_open:
             self._mmc.setShutterOpen(False)
-        return ((self._mmc.getImage(), event, self._mmc.getTags()),)
+        yield (self._mmc.getImage(), event, self._mmc.getTags())
 
     def teardown_event(self, event: MDAEvent) -> None:
         """Teardown state of system (hardware, etc.) after `event`."""
@@ -322,11 +322,15 @@ class MDAEngine(PMDAEngine):
             True,  # stopOnOverflow
         )
 
+        count = 0
+        iter_events = iter(event.events)
         # block until the sequence is done, popping images in the meantime
-        images: list[TaggedImage] = []
         while self._mmc.isSequenceRunning():
             if self._mmc.getRemainingImageCount():
-                images.append(self._mmc.popNextTaggedImage())
+                img = self._mmc.popNextTaggedImage()
+                e = next(iter_events)
+                yield (ImagePayload(img.pix, e, img.tags), e)
+                count += 1
             else:
                 time.sleep(0.001)
 
@@ -334,19 +338,18 @@ class MDAEngine(PMDAEngine):
             raise MemoryError("Buffer overflowed")
 
         while self._mmc.getRemainingImageCount():
-            images.append(self._mmc.popNextTaggedImage())
+            img = self._mmc.popNextTaggedImage()
+            e = next(iter_events)
+            yield (ImagePayload(img.pix, e, img.tags), e)
+            count += 1
 
-        if len(images) != n_events:
+        if count != n_events:
             logger.warning(
                 "Unexpected number of images returned from sequence. "
                 "Expected %s, got %s",
                 n_events,
-                len(images),
+                count,
             )
-
-        return tuple(
-            ImagePayload(img.pix, e, img.tags) for img, e in zip(images, event.events)
-        )
 
     # ===================== EXTRA =====================
 

--- a/src/pymmcore_plus/mda/_protocol.py
+++ b/src/pymmcore_plus/mda/_protocol.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import TYPE_CHECKING, Any, Mapping, Protocol, Sequence, runtime_checkable
+from typing import TYPE_CHECKING, Any, Mapping, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
     from typing import Iterable, Iterator

--- a/src/pymmcore_plus/mda/_protocol.py
+++ b/src/pymmcore_plus/mda/_protocol.py
@@ -40,7 +40,7 @@ class PMDAEngine(Protocol):
         """
 
     @abstractmethod
-    def exec_event(self, event: MDAEvent) -> Sequence[PImagePayload]:
+    def exec_event(self, event: MDAEvent) -> Iterable[PImagePayload]:
         """Execute `event`.
 
         This method is called after `setup_event` and is responsible for

--- a/tests/test_mda.py
+++ b/tests/test_mda.py
@@ -224,14 +224,16 @@ DEVICE_ERRORS: dict[str, list[str]] = {
     "Autofocus": ["No autofocus device found. Cannot execute autofocus"],
     "Camera": [
         "Failed to set exposure.",
-        "Failed to snap image. Camera not loaded or initialized",
+        "Camera not loaded or initialized",
     ],
     "Dichroic": ['No device with label "Dichroic"'],
 }
 
 
 @pytest.mark.parametrize("device", DEVICE_ERRORS)
-def test_mda_no_device(device: str, core: CMMCorePlus, caplog: LogCaptureFixture):
+def test_mda_no_device(
+    device: str, core: CMMCorePlus, caplog: LogCaptureFixture
+) -> None:
     core.unloadDevice(device)
 
     if device == "Autofocus":
@@ -242,8 +244,9 @@ def test_mda_no_device(device: str, core: CMMCorePlus, caplog: LogCaptureFixture
         )
     else:
         event = MDAEvent(x_pos=1, z_pos=1, exposure=1, channel={"config": "FITC"})
-    core.mda.engine.setup_event(event)  # type: ignore
-    core.mda.engine.exec_event(event)  # type: ignore
+    engine = cast("MDAEngine", core.mda.engine)
+    engine.setup_event(event)
+    list(engine.exec_event(event))
 
     for e in DEVICE_ERRORS[device]:
         assert e in caplog.text


### PR DESCRIPTION
This relaxes the engine `exec_event` protocol slightly to `(self, event: MDAEvent) -> Iterable[PImagePayload]:` (from `-> Sequence:`.  This allows frames to be yielded immediately as they are popped from the buffer

helps with #289 