### PR TITLE
feat: Add basic msgpack decoding for images from SequenceTester 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ testing = [
     "rich",
     "tiffile",
     "typer",
+    "msgpack",
 ]
 dev = [
     "black",

--- a/src/pymmcore_plus/seq_tester.py
+++ b/src/pymmcore_plus/seq_tester.py
@@ -1,0 +1,88 @@
+from dataclasses import dataclass
+from typing import Any, Self
+
+import numpy as np
+
+
+@dataclass
+class CameraInfo:
+    name: str
+    serial_img_num: int
+    is_sequence: bool
+    cumulative_img_num: int
+    frame_num: int
+
+    @classmethod
+    def validate(cls, val: Any) -> "CameraInfo":
+        if isinstance(val, cls):
+            return val
+        if isinstance(val, dict):
+            return cls(**val)
+        if isinstance(val, (list, tuple)):
+            return cls(*val)
+        raise TypeError(f"Cannot convert {val} to CameraInfo")
+
+
+@dataclass
+class Setting:
+    device: str
+    property: str
+    type_: type
+    value: Any
+
+    @classmethod
+    def validate(cls, val: Any) -> Self:
+        if isinstance(val, cls):
+            return val
+        if isinstance(val, dict):
+            return cls(**val)
+        if isinstance(val, list):
+            return cls.from_list(val)
+        raise TypeError(f"Cannot convert {val} to Setting")
+
+    @classmethod
+    def from_list(cls, val: list) -> Self:
+        (dev, prop), (typ, val) = val
+        return cls(dev, prop, typ, val)
+
+
+@dataclass
+class SettingEvent(Setting):
+    count: int
+
+    @classmethod
+    def from_list(cls, val: list) -> Self:
+        (dev, prop), (typ, val), count = val
+        return cls(dev, prop, typ, val, count)
+
+
+@dataclass
+class InfoPacket:
+    hub_global_packet_nr: int
+    camera: CameraInfo
+    start_counter: int
+    current_counter: int
+    start_state: list[Setting]
+    current_state: list[Setting]
+    history: list[SettingEvent]
+
+    def __post_init__(self) -> None:
+        self.camera = CameraInfo.validate(self.camera)
+        self.start_state = [Setting.validate(s) for s in self.start_state]
+        self.current_state = [Setting.validate(s) for s in self.current_state]
+        self.history = [SettingEvent.validate(h) for h in self.history]
+
+
+def decode_image(img: np.ndarray) -> InfoPacket:
+    """Extract data produced by a SequenceTester camera."""
+    try:
+        import msgpack
+    except ImportError as e:
+        raise ImportError(
+            "msgpack is required to decode image metadata from SequenceTester. "
+            "Try `pip install msgpack`."
+        ) from e
+
+    unpacker = msgpack.Unpacker()
+    unpacker.feed(img.ravel())
+    return InfoPacket(*next(unpacker))

--- a/tests/test_sequencing.py
+++ b/tests/test_sequencing.py
@@ -1,8 +1,10 @@
 from math import prod
-from typing import cast
+from typing import Any, Self, cast
 from unittest.mock import MagicMock, call
 
+import pytest
 import useq
+from attr import dataclass
 from pymmcore_plus import CMMCorePlus
 from pymmcore_plus.core._sequencing import SequencedEvent, get_all_sequenceable
 from pymmcore_plus.mda import MDAEngine, MDARunner
@@ -65,7 +67,7 @@ def test_sequenced_mda_with_zero_values() -> None:
     core.mda.run(mda)
 
 
-def test_fully_sequenceable_core():
+def test_fully_sequenceable_core() -> None:
     mda = useq.MDASequence(
         stage_positions=[(0, 0, 0), (1, 1, 1)],
         z_plan=useq.ZRangeAround(range=3, step=1),
@@ -110,7 +112,7 @@ def test_fully_sequenceable_core():
     )
 
 
-def test_sequenced_circular_buffer(core: CMMCorePlus):
+def test_sequenced_circular_buffer(core: CMMCorePlus) -> None:
     core.initializeCircularBuffer()
     core.setCircularBufferMemoryFootprint(20)
     max_imgs = core.getBufferFreeCapacity()
@@ -120,3 +122,23 @@ def test_sequenced_circular_buffer(core: CMMCorePlus):
     )
     core.mda.engine.use_hardware_sequencing = True
     core.mda.run(mda)
+
+
+@pytest.fixture
+def sequence_tester() -> CMMCorePlus:
+    core = CMMCorePlus()
+    core.loadDevice("THub", "SequenceTester", "THub")
+    core.initializeDevice("THub")
+
+    core.loadDevice("TCamera", "SequenceTester", "TCamera")
+    core.setParentLabel("TCamera", "THub")
+    core.setProperty("TCamera", "ImageMode", "MachineReadable")
+    core.setProperty("TCamera", "ImageWidth", 128)
+    core.setProperty("TCamera", "ImageHeight", 128)
+    core.initializeDevice("TCamera")
+    core.setCameraDevice("TCamera")
+    yield core
+
+
+def test_sequence_tester(sequence_tester: CMMCorePlus) -> None:
+    pass

--- a/tests/test_sequencing.py
+++ b/tests/test_sequencing.py
@@ -143,6 +143,7 @@ def test_sequence_tester_decoding(sequence_tester: CMMCorePlus) -> None:
     core = sequence_tester
     core.startContinuousSequenceAcquisition(3)
     core.waitForSystem()
+    core.stopSequenceAcquisition()
 
     for i in range(3):
         info = decode_image(core.popNextImage())


### PR DESCRIPTION
This PR just adds some code to be able to decode SequenceTester images, similar to what @marktsuchida added in https://github.com/micro-manager/micro-manager/blob/main/systemtest/SequenceTests/test/org/micromanager/testing/TestImageDecoder.java

