### PR TITLE
fix: fix excess reading of frame metadata in OMEZarrWriter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,4 @@ Micro-Manager-*
 docs/_includes/_cmmcore_members.md
 docs/_includes/_cmmcore_table.md
 docs/_includes/_cmmcoreplus_members.md
+file.zarr/

--- a/src/pymmcore_plus/mda/handlers/_ome_zarr_writer.py
+++ b/src/pymmcore_plus/mda/handlers/_ome_zarr_writer.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-
+import time
 import atexit
 import json
 import os.path
@@ -161,6 +161,7 @@ class OMEZarrWriter:
         # (the group will have a dataset for each position)
         self._arrays: dict[str, zarr.Array] = {}
         self._sizes: list[dict[str, int]] = []
+        self._frame_metas: dict[str, list[dict[str, Any]]] = {}
 
         # set during sequenceStarted and cleared during sequenceFinished
         self._current_sequence: useq.MDASequence | None = None
@@ -226,6 +227,8 @@ class OMEZarrWriter:
         """On sequence finished, clear the current sequence."""
         self._current_sequence = None
         self._sizes = []
+        self._write_frame_meta(seq)
+        print("FRAME META WRITTEN")
 
         if self._minify_metadata:
             self._minify_zattrs_metadata()
@@ -261,11 +264,11 @@ class OMEZarrWriter:
             # create the array in the group, store sequence metadata in attrs
             self._arrays[key] = ary = self._new_array(key, frame.dtype, sizes)
             ary.attrs["useq_MDASequence"] = json.loads(seq.json(exclude_unset=True))
+            self._frame_metas[key] = []
 
         # WRITE DATA TO DISK
         index = tuple(event.index.get(k) for k in ary.attrs["_ARRAY_DIMENSIONS"][:-2])
         ary[index] = frame  # for zarr, this immediately writes to disk
-
         # write frame metadata
         if meta:
             # fix serialization MDAEvent
@@ -273,11 +276,15 @@ class OMEZarrWriter:
             meta["Event"] = json.loads(
                 event.json(exclude={"sequence"}, exclude_defaults=True)
             )
-        frame_meta = ary.attrs.get("frame_meta", [])
-        frame_meta.append(meta or {})
-        ary.attrs["frame_meta"] = frame_meta
+        self._frame_metas[key].append(meta or {})
+
 
     # ------------------------------- private --------------------------------
+    def _write_frame_meta(self, seq: MDASequence):
+        for i in range(seq.sizes.get("p", 1)):
+            key = f'{POS_PREFIX}{i}'
+            ary = self._arrays[key]
+            ary.attrs["frame_meta"] = self._frame_metas.get(key, [])
 
     def _set_sequence(self, seq: useq.MDASequence | None) -> None:
         """Set the current sequence, and update the used axes."""

--- a/src/pymmcore_plus/mda/handlers/_ome_zarr_writer.py
+++ b/src/pymmcore_plus/mda/handlers/_ome_zarr_writer.py
@@ -230,7 +230,8 @@ class OMEZarrWriter:
         # flush frame metadata to disk
         while self._frame_metas:
             key, metas = self._frame_metas.popitem()
-            self._arrays[key].attrs["frame_meta"] = metas
+            if key in self._arrays:
+                self._arrays[key].attrs["frame_meta"] = metas
 
         self._current_sequence = None
         self._sizes = []

--- a/src/pymmcore_plus/mda/handlers/_ome_zarr_writer.py
+++ b/src/pymmcore_plus/mda/handlers/_ome_zarr_writer.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import atexit
 import json
 import os.path
@@ -9,13 +10,14 @@ from typing import TYPE_CHECKING, Any, Literal, MutableMapping, Protocol
 if TYPE_CHECKING:
     from os import PathLike
     from typing import ContextManager, Sequence
-    from useq import MDASequence
+
     import numpy as np
     import useq
     import zarr
     from fsspec import FSMap
     from numcodecs.abc import Codec
     from typing_extensions import TypedDict
+    from useq import MDASequence
 
     class ZarrSynchronizer(Protocol):
         def __getitem__(self, key: str) -> ContextManager:
@@ -276,11 +278,10 @@ class OMEZarrWriter:
             )
         self._frame_metas[key].append(meta or {})
 
-
     # ------------------------------- private --------------------------------
     def _write_frame_meta(self, seq: MDASequence) -> None:
         for i in range(seq.sizes.get("p", 1)):
-            key = f'{POS_PREFIX}{i}'
+            key = f"{POS_PREFIX}{i}"
             ary = self._arrays[key]
             ary.attrs["frame_meta"] = self._frame_metas.get(key, [])
 

--- a/src/pymmcore_plus/mda/handlers/_ome_zarr_writer.py
+++ b/src/pymmcore_plus/mda/handlers/_ome_zarr_writer.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import atexit
 import json
 import os.path
@@ -9,13 +10,14 @@ from typing import TYPE_CHECKING, Any, Literal, MutableMapping, Protocol
 if TYPE_CHECKING:
     from os import PathLike
     from typing import ContextManager, Sequence
-    from useq import MDASequence
+
     import numpy as np
     import useq
     import zarr
     from fsspec import FSMap
     from numcodecs.abc import Codec
     from typing_extensions import TypedDict
+    from useq import MDASequence
 
     class ZarrSynchronizer(Protocol):
         def __getitem__(self, key: str) -> ContextManager:
@@ -277,11 +279,10 @@ class OMEZarrWriter:
             )
         self._frame_metas[key].append(meta or {})
 
-
     # ------------------------------- private --------------------------------
     def _write_frame_meta(self, seq: MDASequence):
         for i in range(seq.sizes.get("p", 1)):
-            key = f'{POS_PREFIX}{i}'
+            key = f"{POS_PREFIX}{i}"
             ary = self._arrays[key]
             ary.attrs["frame_meta"] = self._frame_metas.get(key, [])
 

--- a/src/pymmcore_plus/mda/handlers/_ome_zarr_writer.py
+++ b/src/pymmcore_plus/mda/handlers/_ome_zarr_writer.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import time
 import atexit
 import json
 import os.path
@@ -10,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Literal, MutableMapping, Protocol
 if TYPE_CHECKING:
     from os import PathLike
     from typing import ContextManager, Sequence
-
+    from useq import MDASequence
     import numpy as np
     import useq
     import zarr

--- a/src/pymmcore_plus/mda/handlers/_ome_zarr_writer.py
+++ b/src/pymmcore_plus/mda/handlers/_ome_zarr_writer.py
@@ -234,6 +234,7 @@ class OMEZarrWriter:
 
         self._current_sequence = None
         self._sizes = []
+
         if self._minify_metadata:
             self._minify_zattrs_metadata()
 

--- a/src/pymmcore_plus/mda/handlers/_ome_zarr_writer.py
+++ b/src/pymmcore_plus/mda/handlers/_ome_zarr_writer.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-
 import atexit
 import json
 import os.path
@@ -10,14 +9,13 @@ from typing import TYPE_CHECKING, Any, Literal, MutableMapping, Protocol
 if TYPE_CHECKING:
     from os import PathLike
     from typing import ContextManager, Sequence
-
+    from useq import MDASequence
     import numpy as np
     import useq
     import zarr
     from fsspec import FSMap
     from numcodecs.abc import Codec
     from typing_extensions import TypedDict
-    from useq import MDASequence
 
     class ZarrSynchronizer(Protocol):
         def __getitem__(self, key: str) -> ContextManager:
@@ -229,7 +227,6 @@ class OMEZarrWriter:
         self._current_sequence = None
         self._sizes = []
         self._write_frame_meta(seq)
-        print("FRAME META WRITTEN")
 
         if self._minify_metadata:
             self._minify_zattrs_metadata()
@@ -279,10 +276,11 @@ class OMEZarrWriter:
             )
         self._frame_metas[key].append(meta or {})
 
+
     # ------------------------------- private --------------------------------
-    def _write_frame_meta(self, seq: MDASequence):
+    def _write_frame_meta(self, seq: MDASequence) -> None:
         for i in range(seq.sizes.get("p", 1)):
-            key = f"{POS_PREFIX}{i}"
+            key = f'{POS_PREFIX}{i}'
             ary = self._arrays[key]
             ary.attrs["frame_meta"] = self._frame_metas.get(key, [])
 


### PR DESCRIPTION
I had the problem that reading appending and re-writing the frame meta data become pretty slow for long acquisitions. First simple approach here to gather the metadata during the acqusition and write it on sequenceFinished.
Tests passing locally, not sure if frame metadata is tested though. Can have a look next week.