### PR TITLE
fix: fix available_peripherals for loaded hub devices

### DIFF
--- a/src/pymmcore_plus/_util.py
+++ b/src/pymmcore_plus/_util.py
@@ -142,7 +142,12 @@ def find_micromanager(return_first: bool = True) -> str | None | list[str]:
 def _qt_app_is_running() -> bool:
     for modname in {"PyQt5", "PySide2", "PyQt6", "PySide6"}:
         if modname in sys.modules:
-            QtWidgets = importlib.import_module(".QtWidgets", modname)
+            try:
+                # in broken environments modname can be a namespace package...
+                # and QtWidgets will still be unavailable
+                QtWidgets = importlib.import_module(".QtWidgets", modname)
+            except ImportError:  # pragma: no cover
+                continue
             return QtWidgets.QApplication.instance() is not None
     return False  # pragma: no cover
 

--- a/src/pymmcore_plus/model/_device.py
+++ b/src/pymmcore_plus/model/_device.py
@@ -365,14 +365,17 @@ def get_available_devices(core: CMMCorePlus) -> list[AvailableDevice]:
                 available_devices.append(dev)
                 if dev.device_type == DeviceType.Hub:
                     library_to_hub[lib_name] = dev
-    breakpoint()
 
+    # We also need to check for child devices of loaded hubs
+    # which will not visible via `core.getAvailableDevices`, and will only be
+    # visible after a hub device has been loaded.
+    # HACK: this is a bit of a hack, but it's due to the (multiple) ways that
+    # hub devices and child devices work in MMCore
     for hub in core.getLoadedDevicesOfType(DeviceType.Hub):
+        lib_name = core.getDeviceLibrary(hub)
         for child in core.getInstalledDevices(hub):
-            dev = AvailableDevice(
-                
-            )
-
+            dev = AvailableDevice(library=lib_name, adapter_name=child)
+            available_devices.append(dev)
 
     # now associate devices with their hubs
     for d in available_devices:

--- a/src/pymmcore_plus/model/_device.py
+++ b/src/pymmcore_plus/model/_device.py
@@ -365,6 +365,14 @@ def get_available_devices(core: CMMCorePlus) -> list[AvailableDevice]:
                 available_devices.append(dev)
                 if dev.device_type == DeviceType.Hub:
                     library_to_hub[lib_name] = dev
+    breakpoint()
+
+    for hub in core.getLoadedDevicesOfType(DeviceType.Hub):
+        for child in core.getInstalledDevices(hub):
+            dev = AvailableDevice(
+                
+            )
+
 
     # now associate devices with their hubs
     for d in available_devices:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -227,12 +227,13 @@ def test_dirty():
 
 
 def test_hubs():
-    from pymmcore_plus import CMMCorePlus
-    from pymmcore_plus.model import Device, Microscope
-
+    """Make sure that calling load_available_devices() on a model after loading
+    a hub device will find all peripherals when using dev.available_peripherals."""
     core = CMMCorePlus()
     model = Microscope()
 
+    # SequenceTester is a good example of a device library that only shows a Hub,
+    # but has peripherals that are visible only after calling initializeDevice
     core.loadDevice("THub", "SequenceTester", "THub")
     core.initializeDevice("THub")
 
@@ -240,4 +241,6 @@ def test_hubs():
     dev = Device.create_from_core(core, name="THub")
 
     model.load_available_devices(core)
-    # assert list(dev.available_peripherals(model))
+    assert model.available_devices
+    peripherals = list(dev.available_peripherals(model))
+    assert peripherals

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -224,3 +224,20 @@ def test_dirty():
     assert scope.is_dirty()
     scope.mark_clean()
     assert not scope.is_dirty()
+
+
+def test_hubs():
+    from pymmcore_plus import CMMCorePlus
+    from pymmcore_plus.model import Device, Microscope
+
+    core = CMMCorePlus()
+    model = Microscope()
+
+    core.loadDevice("THub", "SequenceTester", "THub")
+    core.initializeDevice("THub")
+
+    # successful closing of the dialog will have loaded and initialized the device.
+    dev = Device.create_from_core(core, name="THub")
+
+    model.load_available_devices(core)
+    # assert list(dev.available_peripherals(model))


### PR DESCRIPTION
This is a partial fix to a bug in the pymmcore-widgets ConfigWizard that results in some hub devices (like SequenceTester) not showing any peripherals.

The problem is that some hub devices reveal their peripherals as top level library devices, while others may wait until after device initialization to reveal them.

What this PR does is to make sure that calling `Microscope.load_available_devices()` will not only check `getAvailableDevices` for all `getDeviceAdapterNames` ... but will *also* check `getInstalledDevices` for all `getLoadedDevicesOfType(DeviceType.Hub)`.  

it's not a complete for for widgets though, since the ConfigWizard will still need to call `model.load_available_devices()` after successfully initializing a hub device (which will happen over in that repo)