### PR TITLE
fix: fix available peripherals for libraries with multiple hubs

### DIFF
--- a/src/pymmcore_plus/model/_device.py
+++ b/src/pymmcore_plus/model/_device.py
@@ -380,7 +380,9 @@ def get_available_devices(core: CMMCorePlus) -> list[AvailableDevice]:
         lib_name = core.getDeviceLibrary(hub)
         hub_dev = library_to_hub.get((lib_name, hub))
         for child in core.getInstalledDevices(hub):
-            dev = AvailableDevice(library=lib_name, adapter_name=child, library_hub=hub_dev)
+            dev = AvailableDevice(
+                library=lib_name, adapter_name=child, library_hub=hub_dev
+            )
             available_devices.append(dev)
 
     return available_devices

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -226,19 +226,28 @@ def test_dirty():
     assert not scope.is_dirty()
 
 
-def test_hubs():
+# SequenceTester is a good example of a device library that only shows a Hub,
+# but has peripherals that are visible only after calling initializeDevice
+#Ti2 is an example of a library that has multiple hubs... are there better ones?
+@pytest.mark.parametrize('lib, hub', [('SequenceTester', 'THub'), ('NikonTi2', 'Ti2-E__0')])
+def test_hubs(lib: str, hub: str) -> None:
     """Make sure that calling load_available_devices() on a model after loading
     a hub device will find all peripherals when using dev.available_peripherals."""
     core = CMMCorePlus()
     model = Microscope()
 
-    # SequenceTester is a good example of a device library that only shows a Hub,
-    # but has peripherals that are visible only after calling initializeDevice
-    core.loadDevice("THub", "SequenceTester", "THub")
-    core.initializeDevice("THub")
+    try:
+        core.loadDevice(hub, lib, hub)
+    except RuntimeError:
+        if lib == 'SequenceTester':
+            raise
+        pytest.skip(reason=f'{lib}, {hub} Not Available')
+        return
+    
+    core.initializeDevice(hub)
 
     # successful closing of the dialog will have loaded and initialized the device.
-    dev = Device.create_from_core(core, name="THub")
+    dev = Device.create_from_core(core, name=hub)
 
     model.load_available_devices(core)
     assert model.available_devices

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -228,8 +228,10 @@ def test_dirty():
 
 # SequenceTester is a good example of a device library that only shows a Hub,
 # but has peripherals that are visible only after calling initializeDevice
-#Ti2 is an example of a library that has multiple hubs... are there better ones?
-@pytest.mark.parametrize('lib, hub', [('SequenceTester', 'THub'), ('NikonTi2', 'Ti2-E__0')])
+# Ti2 is an example of a library that has multiple hubs... are there better ones?
+@pytest.mark.parametrize(
+    "lib, hub", [("SequenceTester", "THub"), ("NikonTi2", "Ti2-E__0")]
+)
 def test_hubs(lib: str, hub: str) -> None:
     """Make sure that calling load_available_devices() on a model after loading
     a hub device will find all peripherals when using dev.available_peripherals."""
@@ -239,11 +241,11 @@ def test_hubs(lib: str, hub: str) -> None:
     try:
         core.loadDevice(hub, lib, hub)
     except RuntimeError:
-        if lib == 'SequenceTester':
+        if lib == "SequenceTester":
             raise
-        pytest.skip(reason=f'{lib}, {hub} Not Available')
+        pytest.skip(reason=f"{lib}, {hub} Not Available")
         return
-    
+
     core.initializeDevice(hub)
 
     # successful closing of the dialog will have loaded and initialized the device.


### PR DESCRIPTION
fixes a silly bug in my code that fails to link available peripherals with their parent hub device when the library has multiple hubs.  Test will only work locally for now as it uses the Ti2 device adapter, but we can probably find another example of a multi-hub library that's easy to test.