### PR TITLE
refactor!: more minimal, and overrideable MDA metadata

### DIFF
--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -1536,7 +1536,7 @@ class CMMCorePlus(pymmcore.CMMCore):
         # you shouldn't have to search the code to find out what keys are available
 
         tags = dict(meta) if meta else {}
-        for dev, label, val in self.getSystemStateCache():  # type: ignore
+        for dev, label, val in self.getSystemStateCache():
             tags[f"{dev}-{label}"] = val
 
         tags["BitDepth"] = self.getImageBitDepth()

--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -547,6 +547,14 @@ class CMMCorePlus(pymmcore.CMMCore):
         cfg = super().getSystemState()
         return cfg if native else Configuration.from_configuration(cfg)
 
+    @overload
+    def getSystemStateCache(self, *, native: Literal[True]) -> pymmcore.Configuration:
+        ...
+
+    @overload
+    def getSystemStateCache(self, *, native: Literal[False] = False) -> Configuration:
+        ...
+
     def getSystemStateCache(
         self, *, native: bool = False
     ) -> Configuration | pymmcore.Configuration:
@@ -610,11 +618,13 @@ class CMMCorePlus(pymmcore.CMMCore):
         return (self.fixImage(img) if fix else img, md)
 
     @overload
-    def popNextImageAndMD(self, channel: int, slice: int, *, fix: bool = True) -> Any:
+    def popNextImageAndMD(
+        self, channel: int, slice: int, *, fix: bool = True
+    ) -> tuple[np.ndarray, Metadata]:
         ...
 
     @overload
-    def popNextImageAndMD(self, *, fix: bool = True) -> Any:
+    def popNextImageAndMD(self, *, fix: bool = True) -> tuple[np.ndarray, Metadata]:
         ...
 
     @synchronized(_lock)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -20,7 +20,6 @@ from pymmcore_plus import (
 )
 from pymmcore_plus.core.events import CMMCoreSignaler
 from pymmcore_plus.mda import MDAEngine
-from pymmcore_plus.mda._engine import _summary_meta
 from qtpy.QtCore import QObject
 from qtpy.QtCore import SignalInstance as QSignalInstance
 from useq import MDASequence
@@ -148,7 +147,7 @@ def test_mda(core: CMMCorePlus, qtbot: "QtBot"):
         assert isinstance(_call.args[0], np.ndarray)
         assert _call.args[1] == event
 
-    summary = _summary_meta(core)
+    summary = core.mda.engine.get_summary_metadata()
     summary.pop("DateAndTime", "")
     ss_mock.assert_called_once()
     _seq, _meta = ss_mock.call_args[0]


### PR DESCRIPTION
Metadata handling in the MDA engine is still a bit haphazard.  We largely copied the state of things in MM-studio, and discussions with multiple MM core devs has suggested that perhaps that isn't necessarily the best approach.  MM grabs a *lot* of metadata for every frame, much of which doesn't change over the course of the experiment, and it also will almost always match the metadata in the `MDAEvent` "command" that triggered that given frame.   Nico has suggested that this comes at a pretty big penalty, especially for very fast acquisition.

While this PR doesn't really formalize any approach just yet it does two things:
1) establishes two methods in the MDAEngine that are more easy for a subclass to override and customize:
    - `get_summary_metadata()` - called once at the beginning
    - `get_frame_metadata()` - called for every frame
2) strips some (but not all) of what was being called for `get_frame_metadata`.  Notably `getSystemStateCache` is still there, which is probably unnecessary, but which can be discussed in a follow up.

In general, I would very much like to have a better schema for the format (including keys) of the metadata... but that's a bigger issue, and this PR just simplifies that creation of the metadata.

@wl-stepp, I'm curious to what extent you've begun "depending" on a specific format of information in that third parameter to the `frameReady` event?