### PR TITLE
feat: Add file saving `output` argument to MDARunner.run

### DIFF
--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -54,6 +54,8 @@ if TYPE_CHECKING:
     from typing_extensions import Literal, TypedDict
     from useq import MDAEvent
 
+    from pymmcore_plus.mda._runner import SingleOutput
+
     from ._state import StateDict
 
     _T = TypeVar("_T")
@@ -1411,7 +1413,11 @@ class CMMCorePlus(pymmcore.CMMCore):
         return self._mda_runner
 
     def run_mda(
-        self, events: Iterable[MDAEvent], *, output=None, block: bool = False
+        self,
+        events: Iterable[MDAEvent],
+        *,
+        output: SingleOutput | Sequence[SingleOutput] | None = None,
+        block: bool = False,
     ) -> Thread:
         """Run a sequence of [useq.MDAEvent][] on a new thread.
 
@@ -1428,6 +1434,16 @@ class CMMCorePlus(pymmcore.CMMCore):
         events : Iterable[useq.MDAEvent]
             An iterable of [useq.MDAEvent][] to execute.  This may be an instance
             of [useq.MDASequence][], or any other iterable of [useq.MDAEvent][].
+        output : SingleOutput | Sequence[SingleOutput] | None, optional
+            The output handler(s) to use.  If None, no output will be saved.
+            "SingleOutput" can be any of the following:
+
+            - A string or Path to a directory to save images to. A handler will be
+                created automatically based on the extension of the path.
+            - A handler object that implements the `DataHandler` protocol, currently
+                meaning it has a `frameReady` method.  See `mda_listeners_connected`
+                for more details.
+            - A sequence of either of the above. (all will be connected)
         block : bool, optional
             If True, block until the sequence is complete, by default False.
 

--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -1467,7 +1467,7 @@ class CMMCorePlus(pymmcore.CMMCore):
             raise ValueError(
                 "Cannot start an MDA while the previous MDA is still running."
             )
-        th = Thread(target=self.mda.run, args=(events, output))
+        th = Thread(target=self.mda.run, args=(events,), kwargs={"output": output})
         th.start()
         if block:
             th.join()

--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -1410,7 +1410,9 @@ class CMMCorePlus(pymmcore.CMMCore):
         """
         return self._mda_runner
 
-    def run_mda(self, events: Iterable[MDAEvent], block: bool = False) -> Thread:
+    def run_mda(
+        self, events: Iterable[MDAEvent], *, output=None, block: bool = False
+    ) -> Thread:
         """Run a sequence of [useq.MDAEvent][] on a new thread.
 
         :sparkles: *This method is new in `CMMCorePlus`.*
@@ -1439,7 +1441,7 @@ class CMMCorePlus(pymmcore.CMMCore):
             raise ValueError(
                 "Cannot start an MDA while the previous MDA is still running."
             )
-        th = Thread(target=self.mda.run, args=(events,))
+        th = Thread(target=self.mda.run, args=(events, output))
         th.start()
         if block:
             th.join()

--- a/src/pymmcore_plus/mda/_runner.py
+++ b/src/pymmcore_plus/mda/_runner.py
@@ -192,14 +192,17 @@ class MDARunner:
         """
         error = None
         sequence = events if isinstance(events, MDASequence) else GeneratorMDASequence()
-        try:
-            with self._outputs_connected(output):
+        with self._outputs_connected(output):
+            # NOTE: it's important that `_prepare_to_run` and `_finish_run` are
+            # called inside the context manager, since the `mda_listeners_connected`
+            # context manager expects to see both of those signals.
+            try:
                 engine = self._prepare_to_run(sequence)
                 self._run(engine, events)
-        except Exception as e:
-            error = e
-        with exceptions_logged():
-            self._finish_run(sequence)
+            except Exception as e:
+                error = e
+            with exceptions_logged():
+                self._finish_run(sequence)
         if error is not None:
             raise error
 

--- a/tests/test_handlers/test_image_sequence_writer.py
+++ b/tests/test_handlers/test_image_sequence_writer.py
@@ -26,12 +26,7 @@ def test_tiff_sequence_writer(tmp_path: Path, core: CMMCorePlus) -> None:
     )
 
     dest = tmp_path / "out"
-    writer = ImageSequenceWriter(dest, prefix="hello")
-
-    with mda_listeners_connected(
-        writer, mda_events=core.mda.events, asynchronous=False
-    ):
-        core.mda.run(mda)
+    core.mda.run(mda, output=dest)
 
     files_written = list(dest.glob("*.tif"))
     assert len(files_written) == prod(mda.shape)

--- a/tests/test_handlers/test_ome_zarr.py
+++ b/tests/test_handlers/test_ome_zarr.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING
 
 import pytest
 import useq
-from pymmcore_plus.mda import mda_listeners_connected
 from pymmcore_plus.mda.handlers import OMEZarrWriter
 
 if TYPE_CHECKING:
@@ -86,8 +85,7 @@ def test_ome_zarr_writer(
     else:
         writer = OMEZarrWriter(tmp_path / store)
 
-    with mda_listeners_connected(writer, mda_events=core.mda.events):
-        core.mda.run(mda)
+    core.mda.run(mda, output=writer)
 
     if store:
         # ensure that non-memory stores were written to disk


### PR DESCRIPTION
This implements option number 1 and closes #311 

### 1. Add an `output` field to `MDARunner.run`

```python
core = CMMCorePlus()
core.mda.run(..., output='some/path.ome.zarr')  # pass a string
# or 
my_writer = CustomDataHandler()
core.mda.run(..., output= my_writer). # pass a data handler object 
```

The argument would be either:
- `str` - in which case a builtin Handler would be used based on extension.  Note that fsspec can be used to support remote filesystems.
    - `ome.zarr` - > `OMEZarrWriter`
    - `ome.tiff` -> `OMETiffWriter`
    - `dir` -> no extension would use `ImageSequenceWriter`
- A Handler object, (anything implementing the data handler protocol, meaning it has at least a `frameReady` method that accepts 1-3 arguments).  This could be, for example, something that would deskew and rotate images prior to writing them.