### PR TITLE
refactor: move imageSnapped event

### DIFF
--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -1391,11 +1391,11 @@ class CMMCorePlus(pymmcore.CMMCore):
 
         **Why Override?** To add a lock to prevent concurrent calls across threads.
         """
-        autoshutter = self.getAutoShutter()
-        if autoshutter:
+        if autoshutter := self.getAutoShutter():
             self.events.propertyChanged.emit(self.getShutterDevice(), "State", True)
         try:
             super().snapImage()
+            self.events.imageSnapped.emit()
         finally:
             if autoshutter:
                 self.events.propertyChanged.emit(
@@ -1603,7 +1603,6 @@ class CMMCorePlus(pymmcore.CMMCore):
         """
         self.snapImage()
         img = self.getImage(numChannel, fix=fix)  # type: ignore
-        self.events.imageSnapped.emit(img)
         return img
 
     @overload

--- a/src/pymmcore_plus/core/events/_protocol.py
+++ b/src/pymmcore_plus/core/events/_protocol.py
@@ -119,7 +119,7 @@ class PCoreSignaler(Protocol):
     > :sparkles: This signal is unique to `pymmcore-plus`.
     """
     imageSnapped: PSignal
-    """Emits `(np.ndarray)` whenever snap is called.
+    """Emits with no arguments whenever snap is called.
 
     > :sparkles: This signal is unique to `pymmcore-plus`.
     """

--- a/src/pymmcore_plus/core/events/_psygnal.py
+++ b/src/pymmcore_plus/core/events/_psygnal.py
@@ -24,7 +24,7 @@ class CMMCoreSignaler(_DevicePropertyEventMixin):
     SLMExposureChanged = Signal(str, float)
 
     # added for CMMCorePlus
-    imageSnapped = Signal(np.ndarray)  # whenever snap is called
+    imageSnapped = Signal()  # whenever snapImage is called
     mdaEngineRegistered = Signal(MDAEngine, MDAEngine)
     continuousSequenceAcquisitionStarted = Signal()
     sequenceAcquisitionStarted = Signal(str, int, float, bool)

--- a/src/pymmcore_plus/core/events/_psygnal.py
+++ b/src/pymmcore_plus/core/events/_psygnal.py
@@ -1,4 +1,3 @@
-import numpy as np
 from psygnal import Signal, SignalInstance
 
 from pymmcore_plus.mda import MDAEngine

--- a/src/pymmcore_plus/core/events/_qsignals.py
+++ b/src/pymmcore_plus/core/events/_qsignals.py
@@ -26,7 +26,7 @@ class QCoreSignaler(QObject):
     sLMExposureChanged = SLMExposureChanged  # alias
 
     # added for CMMCorePlus
-    imageSnapped = Signal(object)  # after an image is snapped
+    imageSnapped = Signal()  # on snapImage()
     mdaEngineRegistered = Signal(object, object)  # new engine, old engine
     # when continuousSequenceAcquisition is started
     continuousSequenceAcquisitionStarted = Signal()


### PR DESCRIPTION
this closes #144 by moving the `imageSnapped()` event from the `CMMCorePlus.snap()` method (which is new and unexpected for most people) to the `snapImage()` method (which is both more familiar and semantically correct).

This change is partially motivated by the confusion caused by this in https://github.com/pymmcore-plus/napari-micromanager/issues/305

Some considerations before merge:
1. since `snapImage()` no longer has access to the resulting image, it removes the numpy array as an argument to the callback, which is a breaking change.  Callbacks must now call `core.getImage()` themselves to retrieve the waiting image.  A [github code search](https://github.com/search?type=code&auto_enroll=true&q=imageSnapped.connect) result suggests we're the only ones using it, so not a big deal... but @wl-stepp has [one line of commented-out code](https://github.com/LEB-EPFL/iSIM/blob/856a2d67eecb27b7e8680e13c7086e55d8a3e9ff/control/src/isim_control/gui/position_history.py#L126) that would break if the comment were removed
2. We need to double check that this doesn't play poorly with an in-process MDA, which will also call snapImage periodically.  It's slightly risky in that regard, since someone could carelessly connect something to snapImage and accidentally slow down or otherwise hinder their experiment?  Probably unlikely, but worth thinking about.
