### PR TITLE
feat: add post_sequence_started

### DIFF
--- a/src/pymmcore_plus/mda/_engine.py
+++ b/src/pymmcore_plus/mda/_engine.py
@@ -322,6 +322,16 @@ class MDAEngine(PMDAEngine):
             if tot >= timeout:
                 raise TimeoutError("Failed to stop running sequence")
 
+    def post_sequence_started(self, event: SequencedEvent) -> None:
+        """Perform any actions after startSequenceAcquisition has been called.
+
+        This method is available to subclasses in case they need to perform any
+        actions after a hardware-triggered sequence has been started (i.e. after
+        core.startSequenceAcquisition has been called).
+
+        The default implementation does nothing.
+        """
+
     def exec_sequenced_event(self, event: SequencedEvent) -> Iterable[PImagePayload]:
         """Execute a sequenced (triggered) event and return the image data.
 
@@ -341,6 +351,8 @@ class MDAEngine(PMDAEngine):
             0,  # intervalMS  # TODO: add support for this
             True,  # stopOnOverflow
         )
+
+        self.post_sequence_started(event)
 
         count = 0
         iter_events = iter(event.events)


### PR DESCRIPTION
see conversation in #318 

This PR adds a `post_sequence_started` method to the `MDAEngine` that can be reimplemented by subclasses to perform custom behavior after `startSequencedAcquisition` is called by core.  the default implementation does nothing