### PR TITLE
feat: support basic ImageJ hyperstack

### DIFF
--- a/src/pymmcore_plus/mda/handlers/_ome_tiff_writer.py
+++ b/src/pymmcore_plus/mda/handlers/_ome_tiff_writer.py
@@ -37,7 +37,6 @@ Non-OME (ImageJ) hyperstack axes MUST be in TZCYXS order
 from __future__ import annotations
 
 from datetime import timedelta
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -45,6 +44,8 @@ import numpy as np
 from ._5d_writer_base import _5DWriterBase
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     import useq
 
 IMAGEJ_AXIS_ORDER = "tzcyxs"
@@ -74,7 +75,7 @@ class OMETiffWriter(_5DWriterBase[np.memmap]):
             ) from e
 
         self._filename = str(filename)
-        if not self._filename.endswith((".tiff", ".tif")):
+        if not self._filename.endswith((".tiff", ".tif")):  # pragma: no cover
             raise ValueError("filename must end with '.tiff' or '.tif'")
         self._is_ome = ".ome." in self._filename
 
@@ -116,7 +117,7 @@ class OMETiffWriter(_5DWriterBase[np.memmap]):
             fname = self._filename
 
         # create parent directories if they don't exist
-        Path(fname).parent.mkdir(parents=True, exist_ok=True)
+        # Path(fname).parent.mkdir(parents=True, exist_ok=True)
         # write empty file to disk
         imwrite(
             fname,

--- a/src/pymmcore_plus/mda/handlers/_ome_tiff_writer.py
+++ b/src/pymmcore_plus/mda/handlers/_ome_tiff_writer.py
@@ -77,7 +77,7 @@ class OMETiffWriter(_5DWriterBase[np.memmap]):
         self._filename = str(filename)
         if not self._filename.endswith((".tiff", ".tif")):  # pragma: no cover
             raise ValueError("filename must end with '.tiff' or '.tif'")
-        self._is_ome = ".ome." in self._filename
+        self._is_ome = ".ome.tif" in self._filename
 
         super().__init__()
 
@@ -112,7 +112,8 @@ class OMETiffWriter(_5DWriterBase[np.memmap]):
 
         # append the position key to the filename if there are multiple positions
         if (seq := self.current_sequence) and seq.sizes.get("p", 1) > 1:
-            fname = self._filename.replace(".ome.tif", f"_{position_key}.ome.tif")
+            ext = ".ome.tif" if self._is_ome else ".tif"
+            fname = self._filename.replace(ext, f"_{position_key}{ext}")
         else:
             fname = self._filename
 

--- a/src/pymmcore_plus/mda/handlers/_ome_tiff_writer.py
+++ b/src/pymmcore_plus/mda/handlers/_ome_tiff_writer.py
@@ -30,11 +30,14 @@ Rules:
 - dimensions (order) must end with YX or YXS
 - no axis can be repeated
 - no more than 8 dimensions (or 9 if 'S' is included)
+
+Non-OME (ImageJ) hyperstack axes MUST be in TZCYXS order
 """
 
 from __future__ import annotations
 
 from datetime import timedelta
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -42,7 +45,9 @@ import numpy as np
 from ._5d_writer_base import _5DWriterBase
 
 if TYPE_CHECKING:
-    from pathlib import Path
+    import useq
+
+IMAGEJ_AXIS_ORDER = "tzcyxs"
 
 
 class OMETiffWriter(_5DWriterBase[np.memmap]):
@@ -69,10 +74,22 @@ class OMETiffWriter(_5DWriterBase[np.memmap]):
             ) from e
 
         self._filename = str(filename)
-        if not self._filename.endswith((".ome.tiff", ".ome.tif")):
-            raise ValueError("filename must end with '.ome.tiff' or '.ome.tif'")
+        if not self._filename.endswith((".tiff", ".tif")):
+            raise ValueError("filename must end with '.tiff' or '.tif'")
+        self._is_ome = ".ome." in self._filename
 
         super().__init__()
+
+    def sequenceStarted(self, seq: useq.MDASequence) -> None:
+        super().sequenceStarted(seq)
+        # Non-OME (ImageJ) hyperstack axes MUST be in TZCYXS order
+        # so we reorder the ordered position_sizes dicts.  This will ensure
+        # that the array indices created from event.index are in the correct order.
+        if not self._is_ome:
+            self.position_sizes = [
+                {k: x[k] for k in IMAGEJ_AXIS_ORDER if k.lower() in x}
+                for x in self.position_sizes
+            ]
 
     def write_frame(
         self, ary: np.memmap, index: tuple[int, ...], frame: np.ndarray
@@ -98,8 +115,17 @@ class OMETiffWriter(_5DWriterBase[np.memmap]):
         else:
             fname = self._filename
 
+        # create parent directories if they don't exist
+        Path(fname).parent.mkdir(parents=True, exist_ok=True)
         # write empty file to disk
-        imwrite(fname, shape=shape, dtype=dtype, metadata=metadata)
+        imwrite(
+            fname,
+            shape=shape,
+            dtype=dtype,
+            metadata=metadata,
+            imagej=not self._is_ome,
+            ome=self._is_ome,
+        )
 
         # memory-mapped NumPy array of image data stored in TIFF file.
         mmap = memmap(fname, dtype=dtype)
@@ -110,6 +136,9 @@ class OMETiffWriter(_5DWriterBase[np.memmap]):
 
     def _sequence_metadata(self) -> dict:
         """Create metadata for the sequence, when creating a new file."""
+        if not self._is_ome:
+            return {}
+
         metadata: dict = {}
         # see tifffile.tiffile for more metadata options
         if seq := self.current_sequence:

--- a/tests/test_handlers/test_ome_tiff.py
+++ b/tests/test_handlers/test_ome_tiff.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
@@ -35,12 +34,8 @@ seq3 = useq.MDASequence(
     axis_order="ptc",
 )
 
-# not sure why, but saving a standard .tiff is failing on windows CI
-# with a strange file error
-OME_PARAMS = [True] if (os.getenv("CI") and os.name == "nt") else [True, False]
 
-
-@pytest.mark.parametrize("ome", OME_PARAMS)
+@pytest.mark.parametrize("ome", [True, False])
 @pytest.mark.parametrize("seq", [seq1, seq2, seq3])
 def test_ome_tiff_writer(
     ome: bool, tmp_path: Path, core: CMMCorePlus, seq: useq.MDASequence
@@ -59,10 +54,8 @@ def test_ome_tiff_writer(
     # multi-position sequences will be split into multiple files
     n_positions = seq.sizes.get("p", 1)
     if n_positions > 1:
-        files = [
-            str(dest).replace(".ome.tiff", f"_p{i}.ome.tiff")
-            for i in range(n_positions)
-        ]
+        ext = ".ome.tif" if ome else ".tif"
+        files = [str(dest).replace(ext, f"_p{i}{ext}") for i in range(n_positions)]
     else:
         files = [str(dest)]
 

--- a/tests/test_handlers/test_ome_tiff.py
+++ b/tests/test_handlers/test_ome_tiff.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
@@ -34,8 +35,12 @@ seq3 = useq.MDASequence(
     axis_order="ptc",
 )
 
+# not sure why, but saving a standard .tiff is failing on windows CI
+# with a strange file error
+OME_PARAMS = [True] if (os.getenv("CI") and os.name == "nt") else [True, False]
 
-@pytest.mark.parametrize("ome", [True, False])
+
+@pytest.mark.parametrize("ome", OME_PARAMS)
 @pytest.mark.parametrize("seq", [seq1, seq2, seq3])
 def test_ome_tiff_writer(
     ome: bool, tmp_path: Path, core: CMMCorePlus, seq: useq.MDASequence


### PR DESCRIPTION
this PR allows the `OMETiffWriter` to output a basic ImageJ hyperstack if the filename doesn't include `.ome.`.  The main difference is the requirement that the data be passed to tifffile must be in `tzcyxs` order