### PR TITLE
feat: add `mmcore info` command

### DIFF
--- a/src/pymmcore_plus/_cli.py
+++ b/src/pymmcore_plus/_cli.py
@@ -355,6 +355,17 @@ def logs(
             print(line.strip())
 
 
+@app.command()
+def info() -> None:
+    """Display information about the Micro-Manager and pymmcore install."""
+    from pymmcore_plus._util import system_info
+
+    info = system_info()
+    length = max(len(k) for k in info) + 1
+    for key, value in info.items():
+        typer.secho(f"{key:{length}}: {value}")
+
+
 def _tail_file(file_path: Union[str, Path], interval: float = 0.1) -> None:
     with open(file_path) as file:
         # Move the file pointer to the end

--- a/src/pymmcore_plus/_util.py
+++ b/src/pymmcore_plus/_util.py
@@ -481,9 +481,9 @@ def system_info() -> dict[str, str]:
     if (mm_path := find_micromanager()) is not None:
         path = str(Path(mm_path).resolve())
         path = path.replace(os.path.expanduser("~"), "~")  # privacy
-        info["mm_devices"] = path
+        info["adapter-path"] = path
     else:
-        info["mm_devices"] = "not found"
+        info["adapter-path"] = "not found"
 
     for pkg in (
         "useq-schema",

--- a/src/pymmcore_plus/_util.py
+++ b/src/pymmcore_plus/_util.py
@@ -479,7 +479,9 @@ def system_info() -> dict[str, str]:
         info["api-version-info"] = core.getAPIVersionInfo()
 
     if (mm_path := find_micromanager()) is not None:
-        info["mm_devices"] = str(Path(mm_path).resolve())
+        path = str(Path(mm_path).resolve())
+        path = path.replace(os.path.expanduser("~"), "~")  # privacy
+        info["mm_devices"] = path
     else:
         info["mm_devices"] = "not found"
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -294,3 +294,11 @@ def test_cli_logs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
 #     result = runner.invoke(app, ["install", "--dest", str(tmp_path)])
 #     assert result.exit_code == 0
 #     assert list(tmp_path.iterdir())
+
+
+def test_cli_info() -> None:
+    result = runner.invoke(app, ["info"])
+    assert result.exit_code == 0
+    assert "pymmcore-plus" in result.stdout
+    assert "python" in result.stdout
+    assert "api-version-info" in result.stdout


### PR DESCRIPTION
```shell
❯ mmcore info
python            : 3.11.6 | packaged by conda-forge | (main, Oct  3 2023, 10:37:07) [Clang 15.0.7 ]
platform          : macOS-14.2.1-arm64-arm-64bit
pymmcore-plus     : 0.8.8.dev2+gd6373b0
pymmcore          : 11.0.0.71.0
core-version-info : MMCore version 11.0.0
api-version-info  : Device API version 71, Module API version 10
mm_devices        : ~/Library/Application Support/pymmcore-plus/mm/Micro-Manager-258aa5ac8
useq-schema       : 0.4.7
tifffile          : 2023.9.26
zarr              : 2.16.1
```