### PR TITLE
test: allow testing without Qt installed 

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,8 @@ from unittest.mock import patch
 import pymmcore_plus
 import pytest
 from pymmcore_plus._logger import logger
-from pymmcore_plus.core.events import CMMCoreSignaler, QCoreSignaler
-from pymmcore_plus.mda.events import MDASignaler, QMDASignaler
+from pymmcore_plus.core.events import CMMCoreSignaler
+from pymmcore_plus.mda.events import MDASignaler
 
 
 @pytest.fixture(params=["QSignal", "psygnal"], scope="function")
@@ -16,6 +16,9 @@ def core(request):
         core._events = CMMCoreSignaler()
         core.mda._signals = MDASignaler()
     else:
+        from pymmcore_plus.core.events import QCoreSignaler
+        from pymmcore_plus.mda.events import QMDASignaler
+
         core._events = QCoreSignaler()
         core.mda._signals = QMDASignaler()
     core._callback_relay = pymmcore_plus.core._mmcore_plus.MMCallbackRelay(core.events)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,17 +8,22 @@ from pymmcore_plus._logger import logger
 from pymmcore_plus.core.events import CMMCoreSignaler
 from pymmcore_plus.mda.events import MDASignaler
 
+try:
+    from pymmcore_plus.core.events import QCoreSignaler
+    from pymmcore_plus.mda.events import QMDASignaler
 
-@pytest.fixture(params=["QSignal", "psygnal"], scope="function")
+    PARAMS = ["QSignal", "psygnal"]
+except ImportError:
+    PARAMS = ["psygnal"]
+
+
+@pytest.fixture(params=PARAMS, scope="function")
 def core(request):
     core = pymmcore_plus.CMMCorePlus()
     if request.param == "psygnal":
         core._events = CMMCoreSignaler()
         core.mda._signals = MDASignaler()
     else:
-        from pymmcore_plus.core.events import QCoreSignaler
-        from pymmcore_plus.mda.events import QMDASignaler
-
         core._events = QCoreSignaler()
         core.mda._signals = QMDASignaler()
     core._callback_relay = pymmcore_plus.core._mmcore_plus.MMCallbackRelay(core.events)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -20,12 +20,17 @@ from pymmcore_plus import (
 )
 from pymmcore_plus.core.events import CMMCoreSignaler
 from pymmcore_plus.mda import MDAEngine
-from qtpy.QtCore import QObject
-from qtpy.QtCore import SignalInstance as QSignalInstance
 from useq import MDASequence
 
 if TYPE_CHECKING:
     from pytestqt.qtbot import QtBot
+
+try:
+    from qtpy.QtCore import QObject
+    from qtpy.QtCore import SignalInstance as QSignalInstance
+except ImportError:
+    QObject = None
+    QSignalInstance = None
 
 
 def test_core(core: CMMCorePlus):
@@ -80,6 +85,7 @@ def test_load_system_config(core: CMMCorePlus):
     )
 
 
+@pytest.mark.skipif(QObject is None, reason="Qt not available.")
 def test_cb_exceptions(core: CMMCorePlus, caplog, qtbot: "QtBot"):
     if not isinstance(core.events, QObject):
         pytest.skip(reason="Skip cb exceptions on psygnal.")
@@ -118,6 +124,7 @@ def test_new_position_methods(core: CMMCorePlus):
     assert round(z2, 2) == z1 + 1
 
 
+@pytest.mark.skipif(QObject is None, reason="Qt not available.")
 def test_mda(core: CMMCorePlus, qtbot: "QtBot"):
     """Test signal emission during MDA"""
     mda = MDASequence(
@@ -171,6 +178,7 @@ def test_mda(core: CMMCorePlus, qtbot: "QtBot"):
     )
 
 
+@pytest.mark.skipif(QObject is None, reason="Qt not available.")
 def test_mda_pause_cancel(core: CMMCorePlus, qtbot: "QtBot"):
     """Test signal emission during MDA with cancelation"""
     mda = MDASequence(
@@ -214,6 +222,7 @@ def test_mda_pause_cancel(core: CMMCorePlus, qtbot: "QtBot"):
     sf_mock.assert_called_once_with(mda)
 
 
+@pytest.mark.skipif(QObject is None, reason="Qt not available.")
 def test_register_mda_engine(core: CMMCorePlus, qtbot: "QtBot"):
     orig_engine = core.mda.engine
     assert orig_engine and orig_engine.mmcore is core
@@ -244,6 +253,7 @@ def test_register_mda_engine(core: CMMCorePlus, qtbot: "QtBot"):
     registered_mock.assert_called_once_with(new_engine, orig_engine)
 
 
+@pytest.mark.skipif(QObject is None, reason="Qt not available.")
 def test_not_concurrent_mdas(core, qtbot: "QtBot"):
     mda = MDASequence(
         time_plan={"interval": 0.1, "loops": 2},
@@ -426,7 +436,8 @@ def test_guess_channel_group(core: CMMCorePlus):
     os.getenv("CI", None) is not None and os.name == "nt",
     reason="CI on windows is broken",
 )
-def test_lock_and_callbacks(core: CMMCorePlus, qtbot):
+@pytest.mark.skipif(QObject is None, reason="Qt not available.")
+def test_lock_and_callbacks(core: CMMCorePlus, qtbot: "QtBot") -> None:
     if not isinstance(core.events, QObject):
         pytest.skip(reason="Skip lock tests on psygnal until we can remove qtbot.")
 
@@ -507,6 +518,7 @@ def test_setContext(core: CMMCorePlus):
     assert core.getAutoShutter()
 
 
+@pytest.mark.skipif(QObject is None, reason="Qt not available.")
 def test_snap_signals(core: CMMCorePlus, qtbot: "QtBot") -> None:
     assert core.getAutoShutter()
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -9,21 +9,26 @@ from pymmcore import g_Keyword_Label as LABEL
 from pymmcore import g_Keyword_State as STATE
 from pymmcore_plus import CMMCorePlus
 from pymmcore_plus._util import MMCORE_PLUS_SIGNALS_BACKEND
-from pymmcore_plus.core.events import CMMCoreSignaler, PCoreSignaler, QCoreSignaler
+from pymmcore_plus.core.events import CMMCoreSignaler, PCoreSignaler
 
 if TYPE_CHECKING:
     from qtpy.QtWidgets import QApplication
 
+try:
+    from pymmcore_plus.core.events import QCoreSignaler
+except ImportError:
+    QCoreSignaler = None  # type: ignore
 
-@pytest.mark.parametrize(
-    "env_var, expect",
-    [
-        ("psygnal", CMMCoreSignaler),
-        ("qt", QCoreSignaler),
-        ("nonsense", QCoreSignaler),
-        ("auto", QCoreSignaler),
-    ],
-)
+
+PARAMS = [
+    ("psygnal", CMMCoreSignaler),
+    ("qt", QCoreSignaler),
+    ("nonsense", CMMCoreSignaler if QCoreSignaler is None else QCoreSignaler),
+    ("auto", CMMCoreSignaler if QCoreSignaler is None else QCoreSignaler),
+]
+
+
+@pytest.mark.parametrize("env_var, expect", PARAMS)
 def test_signal_backend_selection(
     env_var: str,
     expect: type[PCoreSignaler],

--- a/tests/test_mda.py
+++ b/tests/test_mda.py
@@ -15,6 +15,15 @@ if TYPE_CHECKING:
     from pytest import LogCaptureFixture
     from pytestqt.qtbot import QtBot
 
+try:
+    import pytestqt
+except ImportError:
+    pytestqt = None
+
+SKIP_NO_PYTESTQT = pytest.mark.skipif(
+    pytestqt is None, reason="pytest-qt not installed"
+)
+
 
 def test_mda_waiting(core: CMMCorePlus):
     seq = MDASequence(
@@ -59,6 +68,7 @@ class BrokenEngine:
     def exec_event(self, event): ...
 
 
+@SKIP_NO_PYTESTQT
 def test_mda_failures(core: CMMCorePlus, qtbot: QtBot):
     mda = MDASequence(
         channels=["Cy5"],
@@ -105,6 +115,7 @@ def test_mda_failures(core: CMMCorePlus, qtbot: QtBot):
 AFPlan = {"autofocus_device_name": "Z", "autofocus_motor_offset": 25, "axes": ("p",)}
 
 
+@SKIP_NO_PYTESTQT
 def test_autofocus(core: CMMCorePlus, qtbot: QtBot, mock_fullfocus) -> None:
     mda = MDASequence(stage_positions=[{"z": 0}], autofocus_plan=AFPlan)
     with qtbot.waitSignal(core.mda.events.sequenceFinished):
@@ -115,6 +126,7 @@ def test_autofocus(core: CMMCorePlus, qtbot: QtBot, mock_fullfocus) -> None:
     assert engine._z_correction[0] == 50
 
 
+@SKIP_NO_PYTESTQT
 def test_autofocus_relative_z_plan(
     core: CMMCorePlus, qtbot: QtBot, mock_fullfocus: Any
 ) -> None:
@@ -143,6 +155,7 @@ def test_autofocus_relative_z_plan(
     assert core.mda.engine._z_correction == {0: 50.0}  # saved the correction
 
 
+@SKIP_NO_PYTESTQT
 def test_autofocus_retries(core: CMMCorePlus, qtbot: QtBot, mock_fullfocus_failure):
     # mock_autofocus sets z=100
     # setting both z pos and autofocus offset to 25 because core does not have a
@@ -162,6 +175,7 @@ def test_autofocus_retries(core: CMMCorePlus, qtbot: QtBot, mock_fullfocus_failu
     assert core.getZPosition() == 25
 
 
+@SKIP_NO_PYTESTQT
 def test_set_mda_fov(core: CMMCorePlus, qtbot: QtBot):
     """Test that the fov size is updated."""
     mda = MDASequence(
@@ -198,6 +212,7 @@ SEQS = [
 ]
 
 
+@SKIP_NO_PYTESTQT
 @pytest.mark.parametrize("seq", SEQS)
 def test_mda_iterable_of_events(
     core: CMMCorePlus, seq: Iterable[MDAEvent], qtbot: QtBot
@@ -342,6 +357,7 @@ def test_engine_protocol(core: CMMCorePlus) -> None:
         core.mda.set_engine(object())  # type: ignore
 
 
+@SKIP_NO_PYTESTQT
 def test_runner_cancel(core: CMMCorePlus, qtbot: QtBot) -> None:
     engine = MagicMock(wraps=core.mda.engine)
     core.mda.set_engine(engine)
@@ -355,6 +371,7 @@ def test_runner_cancel(core: CMMCorePlus, qtbot: QtBot) -> None:
     engine.setup_event.assert_called_once_with(event1)  # not twice
 
 
+@SKIP_NO_PYTESTQT
 def test_runner_pause(core: CMMCorePlus, qtbot: QtBot) -> None:
     engine = MagicMock(wraps=core.mda.engine)
     core.mda.set_engine(engine)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,13 +1,9 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
 import pytest
 from pymmcore_plus._util import listeners_connected, retry
-
-if TYPE_CHECKING:
-    from pytestqt.qtbot import QtBot
 
 
 def test_retry() -> None:
@@ -32,7 +28,7 @@ def test_retry() -> None:
     mock.assert_called_with("ValueError nope caught, trying 1 more times")
 
 
-def test_listener_connected(qtbot: QtBot) -> None:
+def test_listener_connected() -> None:
     from psygnal import Signal
 
     mock = Mock()


### PR DESCRIPTION
we use Qt for testing, both to check our support for running within a Qt event loop, and also because the pytest-qt `qtbot` fixture is a convenient way to assert signals are emitted, *even with psygnal*.

It's long been [on my todo list](https://github.com/pyapp-kit/psygnal/issues/46) to bring something like `qtbot.waitSignals` to psygnal, but until I do that, we'll need to use pytest-qt. 

This PR makes it possible to test stuff without Qt, just skipping those tests for now.  which might be handy for #331 