### PR TITLE
ci: cache built drivers for all platforms

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -54,25 +54,28 @@ jobs:
         if: ${{ matrix.pydantic }}
         run: pip install ${{ matrix.pydantic }}
 
-      - name: Cache Linux Build
+      - name: Set cache path
+        run: |
+          echo "CACHE_PATH=$(python -c 'from pymmcore_plus import install; print(install.USER_DATA_MM_PATH)')" >> $GITHUB_ENV
+
+      - name: Cache Drivers
         id: cache-mm-build
-        if: runner.os == 'Linux'
         uses: actions/cache@v4
         with:
-          path: ~/.local/share/pymmcore-plus/
+          path: ${{ env.CACHE_PATH }}
           key: ${{ runner.os }}-mmbuild-${{ hashFiles('src/pymmcore_plus/_build.py') }}
 
       - name: Build Micro-Manager
         if: runner.os == 'Linux' && steps.cache-mm-build.outputs.cache-hit != 'true'
         run: mmcore build-dev
-
+        
       - name: Install Micro-Manager
-        if: runner.os != 'Linux'
+        if: runner.os != 'Linux' && steps.cache-mm-build.outputs.cache-hit != 'true'
         run: mmcore install
 
       - name: Remove Qt
         if: runner.os == 'Linux'
-        run: pip uninstall -y pytest-qt qtpy PySide2 PyQt5 PyQt6 PySide6
+        run: pip uninstall -y pytest-qt qtpy PyQt6 PySide6
 
       - name: Test
         run: pytest -v --color=yes --cov=pymmcore_plus --cov-report=xml


### PR DESCRIPTION
should speed up tests

to invalidate the cache, either add an additional (arbitrary) string to cache key, or to the the `_build.py` file