### PR TITLE
feat: use event.pos_name when saving the files with tiff and zarr writers

### DIFF
--- a/src/pymmcore_plus/mda/handlers/_5d_writer_base.py
+++ b/src/pymmcore_plus/mda/handlers/_5d_writer_base.py
@@ -95,7 +95,10 @@ class _5DWriterBase(Generic[T]):
         """Write frame to the zarr array for the appropriate position."""
         # get the position key to store the array in the group
         p_index = event.index.get("p", 0)
-        key = f"{POS_PREFIX}{p_index}"
+        pos_key = f"{POS_PREFIX}{p_index}"
+        # get position name from the event if it exists
+        pos_name = event.pos_name
+        key = pos_key if pos_name is None else pos_name
         pos_sizes = self.position_sizes[p_index]
         if key in self.position_arrays:
             ary = self.position_arrays[key]

--- a/src/pymmcore_plus/mda/handlers/_5d_writer_base.py
+++ b/src/pymmcore_plus/mda/handlers/_5d_writer_base.py
@@ -97,8 +97,7 @@ class _5DWriterBase(Generic[T]):
         p_index = event.index.get("p", 0)
         pos_key = f"{POS_PREFIX}{p_index}"
         # get position name from the event if it exists
-        pos_name = event.pos_name
-        key = pos_key if pos_name is None else pos_name
+        key = event.pos_name or pos_key
         pos_sizes = self.position_sizes[p_index]
         if key in self.position_arrays:
             ary = self.position_arrays[key]

--- a/tests/io/test_ome_tiff.py
+++ b/tests/io/test_ome_tiff.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, cast
 
 import pytest
 import useq
+
 from pymmcore_plus import CMMCorePlus
 from pymmcore_plus.mda import mda_listeners_connected
 from pymmcore_plus.mda.handlers import OMETiffWriter
@@ -72,3 +73,22 @@ def test_ome_tiff_writer(
         )
 
         assert data.shape[:-2] == seq_shape
+
+
+def test_ome_tiff_writer_pos_name(tmp_path: Path, core: CMMCorePlus) -> None:
+    dest = tmp_path / "out.ome.tiff"
+    writer = OMETiffWriter(dest)
+
+    seq = useq.MDASequence(
+        axis_order="pc",
+        channels=["FITC"],
+        stage_positions=[
+            {"x": 222, "y": 1, "z": 1, "name": "test_name_000"},
+            {"x": 111, "y": 0, "z": 0},
+        ],
+    )
+
+    core.mda.run(seq, output=writer)
+
+    assert Path(str(dest).replace(".ome.tiff", "_test_name_000.ome.tiff")).exists()
+    assert Path(str(dest).replace(".ome.tiff", "_p1.ome.tiff")).exists()

--- a/tests/io/test_ome_tiff.py
+++ b/tests/io/test_ome_tiff.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING, cast
 
 import pytest
 import useq
-
 from pymmcore_plus import CMMCorePlus
 from pymmcore_plus.mda import mda_listeners_connected
 from pymmcore_plus.mda.handlers import OMETiffWriter

--- a/tests/io/test_ome_tiff.py
+++ b/tests/io/test_ome_tiff.py
@@ -84,6 +84,7 @@ def test_ome_tiff_writer_pos_name(tmp_path: Path, core: CMMCorePlus) -> None:
         channels=["FITC"],
         stage_positions=[
             {"x": 222, "y": 1, "z": 1, "name": "test_name_000"},
+            {"x": 111, "y": 0, "z": 0, "name": ""},
             {"x": 111, "y": 0, "z": 0},
         ],
     )
@@ -92,3 +93,4 @@ def test_ome_tiff_writer_pos_name(tmp_path: Path, core: CMMCorePlus) -> None:
 
     assert Path(str(dest).replace(".ome.tiff", "_test_name_000.ome.tiff")).exists()
     assert Path(str(dest).replace(".ome.tiff", "_p1.ome.tiff")).exists()
+    assert Path(str(dest).replace(".ome.tiff", "_p2.ome.tiff")).exists()

--- a/tests/io/test_ome_zarr.py
+++ b/tests/io/test_ome_zarr.py
@@ -4,14 +4,12 @@ from typing import TYPE_CHECKING
 
 import pytest
 import useq
-
 from pymmcore_plus.mda.handlers import OMEZarrWriter
 
 if TYPE_CHECKING:
     from pathlib import Path
 
     import zarr
-
     from pymmcore_plus import CMMCorePlus
 else:
     zarr = pytest.importorskip("zarr")

--- a/tests/io/test_ome_zarr.py
+++ b/tests/io/test_ome_zarr.py
@@ -120,6 +120,7 @@ def test_ome_zarr_writer_pos_name(tmp_path: Path, core: CMMCorePlus) -> None:
         channels=["FITC"],
         stage_positions=[
             {"x": 222, "y": 1, "z": 1, "name": "test_name_000"},
+            {"x": 111, "y": 0, "z": 0, "name": ""},
             {"x": 111, "y": 0, "z": 0},
         ],
     )
@@ -128,3 +129,4 @@ def test_ome_zarr_writer_pos_name(tmp_path: Path, core: CMMCorePlus) -> None:
 
     assert (dest / "test_name_000").exists()
     assert (dest / "p1").exists()
+    assert (dest / "p2").exists()


### PR DESCRIPTION
Since we have the `pos_name` stored in the `event`, I think it can be useful to use it when saving the files with the `tiff` and `zarr` writers.