### PR TITLE
feat: update 5d writer with isel method, make zarr output nicer to xarray, add a bit more metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ test = [
     "typer >=0.4.2",
     "tifffile >=2021.6.14",
     "zarr >=2.2",
+    "xarray",
 ]
 dev = ["ipython", "mypy", "pdbpp", "pre-commit", "ruff"]
 docs = [

--- a/src/pymmcore_plus/mda/_engine.py
+++ b/src/pymmcore_plus/mda/_engine.py
@@ -310,6 +310,10 @@ class MDAEngine(PMDAEngine):
         # these are added by AcqEngJ
         # yyyy-MM-dd HH:mm:ss.mmmmmm  # NOTE AcqEngJ omits microseconds
         tags["Time"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")
+        tags["PixelSizeUm"] = self._mmc.getPixelSizeUm(True)  # true == cached
+        tags["XPositionUm"] = self._mmc.getXPosition()
+        tags["YPositionUm"] = self._mmc.getYPosition()
+        tags["ZPositionUm"] = self._mmc.getZPosition()
 
         # used by Runner
         tags["PerfCounter"] = time.perf_counter()

--- a/src/pymmcore_plus/mda/_engine.py
+++ b/src/pymmcore_plus/mda/_engine.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import time
+from contextlib import suppress
 from datetime import datetime
 from typing import (
     TYPE_CHECKING,
@@ -311,9 +312,11 @@ class MDAEngine(PMDAEngine):
         # yyyy-MM-dd HH:mm:ss.mmmmmm  # NOTE AcqEngJ omits microseconds
         tags["Time"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")
         tags["PixelSizeUm"] = self._mmc.getPixelSizeUm(True)  # true == cached
-        tags["XPositionUm"] = self._mmc.getXPosition()
-        tags["YPositionUm"] = self._mmc.getYPosition()
-        tags["ZPositionUm"] = self._mmc.getZPosition()
+        with suppress(RuntimeError):
+            tags["XPositionUm"] = self._mmc.getXPosition()
+            tags["YPositionUm"] = self._mmc.getYPosition()
+        with suppress(RuntimeError):
+            tags["ZPositionUm"] = self._mmc.getZPosition()
 
         # used by Runner
         tags["PerfCounter"] = time.perf_counter()

--- a/src/pymmcore_plus/mda/handlers/_ome_tiff_writer.py
+++ b/src/pymmcore_plus/mda/handlers/_ome_tiff_writer.py
@@ -87,7 +87,7 @@ class OMETiffWriter(_5DWriterBase[np.memmap]):
         # so we reorder the ordered position_sizes dicts.  This will ensure
         # that the array indices created from event.index are in the correct order.
         if not self._is_ome:
-            self.position_sizes = [
+            self._position_sizes = [
                 {k: x[k] for k in IMAGEJ_AXIS_ORDER if k.lower() in x}
                 for x in self.position_sizes
             ]

--- a/src/pymmcore_plus/mda/handlers/_ome_zarr_writer.py
+++ b/src/pymmcore_plus/mda/handlers/_ome_zarr_writer.py
@@ -6,7 +6,7 @@ import os.path
 import shutil
 import tempfile
 from contextlib import suppress
-from typing import TYPE_CHECKING, Any, Container, Literal, MutableMapping, Protocol
+from typing import TYPE_CHECKING, Any, Literal, MutableMapping, Protocol
 
 import numpy as np
 
@@ -198,7 +198,7 @@ class OMEZarrWriter(_5DWriterBase["zarr.Array"]):
         if self._minify_metadata:
             self._minify_zattrs_metadata()
 
-    def _populate_xarray_coords(self, dims: Container[str] | None = None) -> None:
+    def _populate_xarray_coords(self) -> None:
         # FIXME:
         # This provides support for xarray coordinates... but it's not obvious
         # how we should deal with positions that have different shapes, etc...
@@ -219,7 +219,7 @@ class OMEZarrWriter(_5DWriterBase["zarr.Array"]):
                     sizes.update(y=shape[-2], x=shape[-1])
 
         for dim, size in sizes.items():
-            if size == 0 or (dims and dim not in dims):
+            if size == 0:
                 continue
 
             # TODO: this could be much cleaner
@@ -243,8 +243,9 @@ class OMEZarrWriter(_5DWriterBase["zarr.Array"]):
             elif dim in "yx":
                 coords = np.arange(size, dtype="float") * px
                 attrs["units"] = "um"
-            # elif dim == "g" and seq.grid_plan:
-            # TODO
+            elif dim == "g":
+                coords = np.arange(size)
+                # TODO
             else:
                 continue
 

--- a/src/pymmcore_plus/mda/handlers/_ome_zarr_writer.py
+++ b/src/pymmcore_plus/mda/handlers/_ome_zarr_writer.py
@@ -5,7 +5,10 @@ import json
 import os.path
 import shutil
 import tempfile
-from typing import TYPE_CHECKING, Any, Literal, MutableMapping, Protocol
+from contextlib import suppress
+from typing import TYPE_CHECKING, Any, Container, Literal, MutableMapping, Protocol
+
+import numpy as np
 
 from ._5d_writer_base import _5DWriterBase
 
@@ -13,7 +16,7 @@ if TYPE_CHECKING:
     from os import PathLike
     from typing import ContextManager, Sequence, TypedDict
 
-    import numpy as np
+    import xarray as xr
     import zarr
     from fsspec import FSMap
     from numcodecs.abc import Codec
@@ -186,6 +189,7 @@ class OMEZarrWriter(_5DWriterBase["zarr.Array"]):
     def finalize_metadata(self) -> None:
         """Called by superclass in sequenceFinished.  Flush metadata to disk."""
         # flush frame metadata to disk
+        self._populate_xarray_coords(dims={"t", "y", "x"})
         while self.frame_metadatas:
             key, metas = self.frame_metadatas.popitem()
             if key in self.position_arrays:
@@ -193,6 +197,66 @@ class OMEZarrWriter(_5DWriterBase["zarr.Array"]):
 
         if self._minify_metadata:
             self._minify_zattrs_metadata()
+
+    def _populate_xarray_coords(
+        self, shape: Sequence[int] | None = None, dims: Container[str] | None = None
+    ) -> None:
+        # FIXME:
+        # This provides support for xarray coordinates... but it's not obvious
+        # how we should deal with positions that have different shapes, etc...
+        # Also: this whole thing should be generalized to support any kind of
+        # dimension, and should be better about populating the coords as the experiment
+        # progresses.  And it's rather ugly...
+        if not (seq := self.current_sequence):
+            return
+
+        sizes = {**seq.sizes}
+        px = 1
+        if self.frame_metadatas:
+            key, metas = next(iter(self.frame_metadatas.items()))
+            if key in self.position_arrays:
+                shape = self.position_arrays[key].shape
+                px = metas[-1].get("PixelSizeUm", 1)
+                with suppress(IndexError):
+                    sizes.update(y=shape[-2], x=shape[-1])  # type: ignore
+
+        for dim, size in sizes.items():
+            if size == 0 or (dims and dim not in dims):
+                continue
+
+            # TODO: this could be much cleaner
+            attrs: dict = {"_ARRAY_DIMENSIONS": [dim]}
+            if dim == "t":
+                if self._timestamps:
+                    coords: Any = list(self._timestamps)
+                elif seq.time_plan:
+                    coords = np.arange(seq.time_plan.num_timepoints(), dtype="float")
+                else:
+                    continue
+                attrs["units"] = "ms"
+            elif dim == "p":
+                # coords = [(p.x, p.y, p.z) for p in seq.stage_positions]
+                coords = np.arange(size)
+            elif dim == "c":
+                coords = [c.config for c in seq.channels]
+            elif dim == "z":
+                coords = list(seq.z_plan) if seq.z_plan else [0]
+                attrs["units"] = "um"
+            elif dim in "yx":
+                coords = np.arange(size, dtype="float") * px
+                attrs["units"] = "um"
+            # elif dim == "g" and seq.grid_plan:
+            # TODO
+            else:
+                continue
+
+            # fill_value=None is important to avoid nan where coords == 0
+            if dim in self._group:
+                ds = self._group[dim]
+                ds[:] = coords
+            else:
+                ds = self._group.create_dataset(dim, data=coords, fill_value=None)
+            ds.attrs.update(attrs)
 
     def new_array(self, key: str, dtype: np.dtype, sizes: dict[str, int]) -> zarr.Array:
         """Create a new array in the group, under `key`."""
@@ -212,6 +276,7 @@ class OMEZarrWriter(_5DWriterBase["zarr.Array"]):
         ary.attrs["_ARRAY_DIMENSIONS"] = dims
         if seq := self.current_sequence:
             ary.attrs["useq_MDASequence"] = json.loads(seq.json(exclude_unset=True))
+        self._populate_xarray_coords(shape=shape)
         return ary
 
     # # the superclass implementation is all we need
@@ -249,6 +314,11 @@ class OMEZarrWriter(_5DWriterBase["zarr.Array"]):
                 data = json_loads(store[key])
                 # dump minified data back to disk
                 store[key] = json.dumps(data, separators=(",", ":")).encode("ascii")
+
+    def as_xarray(self) -> xr.Dataset:
+        import xarray as xr
+
+        return xr.open_zarr(self.group.store, consolidated=False)
 
 
 # https://ngff.openmicroscopy.org/0.4/index.html#axes-md

--- a/src/pymmcore_plus/mda/handlers/_ome_zarr_writer.py
+++ b/src/pymmcore_plus/mda/handlers/_ome_zarr_writer.py
@@ -189,7 +189,7 @@ class OMEZarrWriter(_5DWriterBase["zarr.Array"]):
     def finalize_metadata(self) -> None:
         """Called by superclass in sequenceFinished.  Flush metadata to disk."""
         # flush frame metadata to disk
-        self._populate_xarray_coords(dims={"t", "y", "x"})
+        self._populate_xarray_coords()
         while self.frame_metadatas:
             key, metas = self.frame_metadatas.popitem()
             if key in self.position_arrays:
@@ -198,9 +198,7 @@ class OMEZarrWriter(_5DWriterBase["zarr.Array"]):
         if self._minify_metadata:
             self._minify_zattrs_metadata()
 
-    def _populate_xarray_coords(
-        self, shape: Sequence[int] | None = None, dims: Container[str] | None = None
-    ) -> None:
+    def _populate_xarray_coords(self, dims: Container[str] | None = None) -> None:
         # FIXME:
         # This provides support for xarray coordinates... but it's not obvious
         # how we should deal with positions that have different shapes, etc...
@@ -218,7 +216,7 @@ class OMEZarrWriter(_5DWriterBase["zarr.Array"]):
                 shape = self.position_arrays[key].shape
                 px = metas[-1].get("PixelSizeUm", 1)
                 with suppress(IndexError):
-                    sizes.update(y=shape[-2], x=shape[-1])  # type: ignore
+                    sizes.update(y=shape[-2], x=shape[-1])
 
         for dim, size in sizes.items():
             if size == 0 or (dims and dim not in dims):
@@ -276,7 +274,6 @@ class OMEZarrWriter(_5DWriterBase["zarr.Array"]):
         ary.attrs["_ARRAY_DIMENSIONS"] = dims
         if seq := self.current_sequence:
             ary.attrs["useq_MDASequence"] = json.loads(seq.json(exclude_unset=True))
-        self._populate_xarray_coords(shape=shape)
         return ary
 
     # # the superclass implementation is all we need

--- a/tests/io/test_ome_zarr.py
+++ b/tests/io/test_ome_zarr.py
@@ -90,10 +90,11 @@ def test_ome_zarr_writer(
     if store:
         # ensure that non-memory stores were written to disk
         data = zarr.open(writer.group.store.path)
-        for _, ary in data.arrays():
-            # ensure real data was written
-            assert ary.nchunks_initialized > 0
-            assert ary[0, 0].mean() > ary.fill_value
+        for k, ary in data.arrays():
+            if k in writer.position_arrays:
+                # ensure real data was written
+                assert ary.nchunks_initialized > 0
+                assert ary[0, 0].mean() > ary.fill_value
     else:
         data = writer.group
 

--- a/tests/io/test_ome_zarr.py
+++ b/tests/io/test_ome_zarr.py
@@ -98,12 +98,13 @@ def test_ome_zarr_writer(
         data = writer.group
 
     # check that arrays have expected shape and dimensions
-    actual_shapes = {
-        k: dict(zip(v.attrs["_ARRAY_DIMENSIONS"], v.shape)) for k, v in data.arrays()
-    }
-    assert actual_shapes == expected_shapes
+    for k, v in data.arrays():
+        if k not in writer.position_arrays:
+            continue  # not a position array
 
-    # check that the MDASequence was stored
-    for _, v in data.arrays():
+        actual_shape = dict(zip(v.attrs["_ARRAY_DIMENSIONS"], v.shape))
+        assert expected_shapes[k] == actual_shape
+
+        # check that the MDASequence was stored
         stored_seq = useq.MDASequence.parse_obj(v.attrs["useq_MDASequence"])
         assert stored_seq == mda


### PR DESCRIPTION
some quality of life updates for the 5D writer base and OmeZarrWriter that should help when using as a datastore for display.  This PR mostly adds:

```python
writer = OMEZarrWriter()
writer.as_xarray()

# and
writer.isel(t=0, c=1, x=slice(100,200))
```
