### PR TITLE
feat: add tensorstore writer

### DIFF
--- a/examples/tensorstore_mda.py
+++ b/examples/tensorstore_mda.py
@@ -10,13 +10,13 @@ core.loadSystemConfiguration()
 
 sequence = MDASequence(
     channels=["DAPI", {"config": "FITC", "exposure": 1}],
-    # stage_positions=[{"x": 1, "y": 1, "name": "some position"}, {"x": 0, "y": 0}],
+    stage_positions=[{"x": 1, "y": 1, "name": "some position"}, {"x": 0, "y": 0}],
     time_plan={"interval": 2, "loops": 3},
     z_plan={"range": 4, "step": 0.5},
     axis_order="tpcz",
 )
 
-writer = TensorStoreHandler("dataset", overwrite=True)
+writer = TensorStoreHandler(path="example_ts", delete_existing=True, driver="zarr")
 
 with mda_listeners_connected(writer):
     core.mda.run(sequence)

--- a/examples/tensorstore_mda.py
+++ b/examples/tensorstore_mda.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from pymmcore_plus import CMMCorePlus
-from pymmcore_plus.mda import mda_listeners_connected
 from pymmcore_plus.mda.handlers import TensorStoreHandler
 from useq import MDASequence
 
@@ -16,7 +15,5 @@ sequence = MDASequence(
     axis_order="tpcz",
 )
 
-writer = TensorStoreHandler(path="example_ts", delete_existing=True, driver="zarr")
-
-with mda_listeners_connected(writer):
-    core.mda.run(sequence)
+writer = TensorStoreHandler(path="example_ts.zarr", delete_existing=True, driver="zarr")
+core.mda.run(sequence, output=writer)

--- a/examples/tensorstore_mda.py
+++ b/examples/tensorstore_mda.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from pymmcore_plus import CMMCorePlus
+from pymmcore_plus.mda import mda_listeners_connected
+from pymmcore_plus.mda.handlers._tensorstore_writer import TensorStoreWriter
+from useq import MDASequence
+
+core = CMMCorePlus.instance()
+core.loadSystemConfiguration()
+
+sequence = MDASequence(
+    channels=["DAPI", {"config": "FITC", "exposure": 1}],
+    # stage_positions=[{"x": 1, "y": 1, "name": "some position"}, {"x": 0, "y": 0}],
+    time_plan={"interval": 2, "loops": 3},
+    z_plan={"range": 4, "step": 0.5},
+    axis_order="tpcz",
+)
+
+writer = TensorStoreWriter("dataset", overwrite=True)
+
+with mda_listeners_connected(writer):
+    core.mda.run(sequence)

--- a/examples/tensorstore_mda.py
+++ b/examples/tensorstore_mda.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pymmcore_plus import CMMCorePlus
 from pymmcore_plus.mda import mda_listeners_connected
-from pymmcore_plus.mda.handlers._tensorstore_writer import TensorStoreWriter
+from pymmcore_plus.mda.handlers._tensorstore_writer import TensorStoreHandler
 from useq import MDASequence
 
 core = CMMCorePlus.instance()
@@ -16,7 +16,7 @@ sequence = MDASequence(
     axis_order="tpcz",
 )
 
-writer = TensorStoreWriter("dataset", overwrite=True)
+writer = TensorStoreHandler("dataset", overwrite=True)
 
 with mda_listeners_connected(writer):
     core.mda.run(sequence)

--- a/examples/tensorstore_mda.py
+++ b/examples/tensorstore_mda.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pymmcore_plus import CMMCorePlus
 from pymmcore_plus.mda import mda_listeners_connected
-from pymmcore_plus.mda.handlers._tensorstore_writer import TensorStoreHandler
+from pymmcore_plus.mda.handlers import TensorStoreHandler
 from useq import MDASequence
 
 core = CMMCorePlus.instance()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "typing-extensions",      # not actually required at runtime
     "useq-schema >=0.4.7",
     "wrapt >=1.14",
+    "tensorstore",
     # cli requirements included by default for now
     "typer >=0.4.2",
     "rich >=10.2.0",
@@ -64,7 +65,7 @@ test = [
     "zarr >=2.2",
     "xarray",
 ]
-dev = ["ipython", "mypy", "pdbpp", "pre-commit", "ruff"]
+dev = ["ipython", "mypy", "pdbpp", "pre-commit", "ruff", "tensorstore-stubs"]
 docs = [
     "mkdocs >=1.4",
     "mkdocs-material",

--- a/src/pymmcore_plus/mda/handlers/__init__.py
+++ b/src/pymmcore_plus/mda/handlers/__init__.py
@@ -1,5 +1,11 @@
 from ._img_sequence_writer import ImageSequenceWriter
 from ._ome_tiff_writer import OMETiffWriter
 from ._ome_zarr_writer import OMEZarrWriter
+from ._tensorstore_handler import TensorStoreHandler
 
-__all__ = ["ImageSequenceWriter", "OMEZarrWriter", "OMETiffWriter"]
+__all__ = [
+    "ImageSequenceWriter",
+    "OMEZarrWriter",
+    "OMETiffWriter",
+    "TensorStoreHandler",
+]

--- a/src/pymmcore_plus/mda/handlers/_tensorstore_handler.py
+++ b/src/pymmcore_plus/mda/handlers/_tensorstore_handler.py
@@ -164,9 +164,9 @@ class TensorStoreHandler:
         if cleanup_atexit:
 
             @atexit.register
-            def _atexit_rmtree(_path: str = path) -> None:
+            def _atexit_rmtree(_path: str = path) -> None:  # pragma: no cover
                 if os.path.isdir(_path):
-                    shutil.rmtree(_path)
+                    shutil.rmtree(_path, ignore_errors=True)
 
         return cls(path=path, **kwargs)
 
@@ -285,7 +285,7 @@ class TensorStoreHandler:
     def finalize_metadata(self) -> None:
         """Finalize and flush metadata to storage."""
         if not (store := self._store) or not store.kvstore:
-            return
+            return  # pragma: no cover
 
         data = []
         for event, meta in self.frame_metadatas:
@@ -303,7 +303,7 @@ class TensorStoreHandler:
 
         if self.ts_driver.startswith("zarr"):
             store.kvstore.write(".zattrs", json.dumps(metadata))
-        elif self.ts_driver == "n5":
+        elif self.ts_driver == "n5":  # pragma: no cover
             attrs = json.loads(store.kvstore.read("attributes.json").result().value)
             attrs.update(metadata)
             store.kvstore.write("attributes.json", json.dumps(attrs))

--- a/src/pymmcore_plus/mda/handlers/_tensorstore_handler.py
+++ b/src/pymmcore_plus/mda/handlers/_tensorstore_handler.py
@@ -174,6 +174,7 @@ class TensorStoreHandler:
         """On sequence started, simply store the sequence."""
         self._frame_index = 0
         self._store = None
+        self._futures.clear()
         self.frame_metadatas.clear()
         self.current_sequence = seq
 
@@ -182,8 +183,8 @@ class TensorStoreHandler:
         if self._store is None:
             return  # pragma: no cover
 
-        for f in self._futures:
-            f.result()
+        while self._futures:
+            self._futures.pop().result()
         if not self._nd_storage:
             self._store = self._store.resize(
                 exclusive_max=(self._frame_index, *self._store.shape[-2:])

--- a/src/pymmcore_plus/mda/handlers/_tensorstore_handler.py
+++ b/src/pymmcore_plus/mda/handlers/_tensorstore_handler.py
@@ -180,7 +180,7 @@ class TensorStoreHandler:
     def sequenceFinished(self, seq: useq.MDASequence) -> None:
         """On sequence finished, clear the current sequence."""
         if self._store is None:
-            return
+            return  # pragma: no cover
 
         for f in self._futures:
             f.result()

--- a/src/pymmcore_plus/mda/handlers/_tensorstore_handler.py
+++ b/src/pymmcore_plus/mda/handlers/_tensorstore_handler.py
@@ -323,7 +323,7 @@ class TensorStoreHandler:
         The return value is safe to use as an index to self._store[...]
         """
         if self._nd_storage:
-            return self._ts.d[*index][*index.values()]
+            return self._ts.d[index][tuple(index.values())]
 
         if any(isinstance(v, slice) for v in index.values()):
             idx: list | int | ts.DimExpression = self._get_frame_indices(index)

--- a/src/pymmcore_plus/mda/handlers/_tensorstore_handler.py
+++ b/src/pymmcore_plus/mda/handlers/_tensorstore_handler.py
@@ -59,6 +59,29 @@ class TensorStoreHandler:
         in this object will override the default values provided by the handler.
         This is a complex object that can completely define the tensorstore, see
         <https://google.github.io/tensorstore/spec.html> for more information.
+
+    Examples
+    --------
+    ```python
+    from pymmcore_plus import CMMCorePlus
+    from pymmcore_plus.mda.handlers import TensorStoreHandler
+    from useq import MDASequence
+
+    core = CMMCorePlus.instance()
+    core.loadSystemConfiguration()
+
+    sequence = MDASequence(
+        channels=["DAPI", {"config": "FITC", "exposure": 1}],
+        stage_positions=[{"x": 1, "y": 1, "name": "some position"}, {"x": 0, "y": 0}],
+        time_plan={"interval": 2, "loops": 3},
+        z_plan={"range": 4, "step": 0.5},
+        axis_order="tpcz",
+    )
+
+    writer = TensorStoreHandler(path="example_ts.zarr", delete_existing=True)
+    core.mda.run(sequence, output=writer)
+    ```
+
     """
 
     def __init__(

--- a/src/pymmcore_plus/mda/handlers/_tensorstore_writer.py
+++ b/src/pymmcore_plus/mda/handlers/_tensorstore_writer.py
@@ -1,37 +1,104 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any, Mapping
+import warnings
+from itertools import product
+from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
+    from typing import Literal, Mapping, Sequence, TypeAlias
+
     import numpy as np
+    import tensorstore as ts
     import useq
+
+    TsDriver: TypeAlias = Literal["zarr", "zarr3", "n5", "neuroglancer_precomputed"]
+    EventKey: TypeAlias = frozenset[tuple[str, int]]
+
+# special dimension label used when _nd_storage is False
+FRAME_DIM = "frame"
 
 
 class TensorStoreHandler:
-    def __init__(self, path: str | None = None, overwrite: bool = False) -> None:
+    """Tensorstore handler for writing MDA sequences.
+
+    This is a performant and shape-agnostic handler for writing MDA sequences to
+    chunked storages like zarr, n5, backed by tensorstore:
+    <https://google.github.io/tensorstore/>
+
+    By default, the handler will store frames in a zarr array, with a shape of
+    (nframes, *frame_shape) and a chunk size of (1, *frame_shape), i.e. each frame
+    is stored in a separate chunk. To customize shape or chunking, override the
+    `get_full_shape`, `get_chunk_layout`, and `get_index_domain` methods (these
+    may change in the future as we learn to use tensorstore better).
+
+    Parameters
+    ----------
+    driver : TsDriver, optional
+        The driver to use for the tensorstore, by default "zarr".  Must be one of
+        "zarr", "zarr3", "n5", or "neuroglancer_precomputed".
+    kvstore : str | dict | None, optional
+        The key-value store to use for the tensorstore, by default "memory://".
+        A dict might look like {'driver': 'file', 'path': '/path/to/dataset.zarr'}
+        see <https://google.github.io/tensorstore/kvstore/index.html#json-KvStore>
+        for all options. If path is provided, the kvstore will be set to file://path
+    path : str | Path | None, optional
+        Convenience for specifying a local filepath. If provided, overrides the
+        kvstore option, to be `file://file_path`.
+    delete_existing : bool, optional
+        Whether to delete the existing dataset if it exists, by default False.
+    spec : Mapping, optional
+        A spec to use when opening the tensorstore, by default None. Values provided
+        in this object will override the default values provided by the handler.
+        This is a complex object that can completely define the tensorstore, see
+        <https://google.github.io/tensorstore/spec.html> for more information.
+    """
+
+    def __init__(
+        self,
+        *,
+        driver: TsDriver = "zarr",
+        kvstore: str | dict | None = "memory://",
+        path: str | None = None,
+        delete_existing: bool = False,
+        spec: Mapping | None = None,
+    ) -> None:
         try:
-            import tensorstore as ts
+            import tensorstore
         except ImportError as e:
             raise ImportError("Tensorstore is required to use this handler.") from e
 
-        self.ts = ts
+        self._ts = tensorstore
+
+        self.ts_driver = driver
+        self.kvstore = f"file://{path}" if path is not None else kvstore
+        self.delete_existing = delete_existing
+        self.spec = spec
+
         # storage of individual frame metadata
         # maps position key to list of frame metadata
         self.frame_metadatas: list[tuple[useq.MDAEvent, dict]] = []
-        self.resize_at = 100
-        self.delete_existing = overwrite
-        self.driver = "file" if path else "memory"
-        self.path = path or ""
-        self.compressor = None
-        self._store: Any = None  # tensorstore doesn't have typing.
-        self._counter = 0
+
+        self._size_increment = 300
+
+        self._store: ts.TensorStore | None = None
         self._futures: list[ts.Future] = []
-        self._indices: dict[frozenset[tuple[str, int]], int] = {}
+        self._frame_indices: dict[EventKey, int | ts.DimExpression] = {}
+
+        # "_nd_storage" means we're greedily attempting to store the data in a
+        # multi-dimensional format based on the axes of the sequence.
+        # for non-deterministic experiments, this often won't work...
+        # _nd_storage False means we simply store data as a 3D array of shape
+        # (nframes, y, x).  `_nd_storage` is set when a new_store is created.
+        self._nd_storage: bool = True
+        self._frame_index: int = 0
+
+        # the highest index seen for each axis
+        self._axis_max: dict[str, int] = {}
 
     def sequenceStarted(self, seq: useq.MDASequence) -> None:
         """On sequence started, simply store the sequence."""
-        self._counter = 0
+        self._frame_index = 0
         self._store = None
         self.frame_metadatas.clear()
         self.current_sequence = seq
@@ -40,32 +107,41 @@ class TensorStoreHandler:
         """On sequence finished, clear the current sequence."""
         if self._store is None:
             return
-        self._futures.append(
-            self._store.resize(exclusive_max=(self._counter, *self._store.shape[-2:]))
-        )
+
         for f in self._futures:
             f.result()
+        if not self._nd_storage:
+            self._store = self._store.resize(
+                exclusive_max=(self._frame_index, *self._store.shape[-2:])
+            ).result()
         if self.frame_metadatas:
-            data = []
-            for event, meta in self.frame_metadatas:
-                js = event.model_dump_json(exclude={"sequence"}, exclude_defaults=True)
-                meta["Event"] = json.loads(js)
-                data.append(meta)
-            self._store.kvstore.write(".zattrs", json.dumps({"frame_metadatas": data}))
+            self.finalize_metadata()
 
     def frameReady(self, frame: np.ndarray, event: useq.MDAEvent, meta: dict) -> None:
         """Write frame to the zarr array for the appropriate position."""
         if self._store is None:
-            self._store = self._new_tensorstore(self._make_spec(frame))
-        elif self._counter >= self._store.shape[0]:
-            self._store = self._store.resize(
-                exclusive_max=(self._counter + self.resize_at, *self._store.shape[-2:])
-            ).result()
+            self._store = self.new_store(frame, event.sequence, meta).result()
 
-        self._indices[frozenset(event.index.items())] = self._counter
-        self._futures.append(self._store[self._counter].write(frame))
+        ts_index: ts.DimExpression | int
+        if self._nd_storage:
+            ts_index = self._event_index_to_store_index(event.index)
+        else:
+            if self._frame_index >= self._store.shape[0]:
+                self._store = self._expand_store(self._store).result()
+            ts_index = self._frame_index
+            # store reverse lookup of event.index -> frame_index
+            self._frame_indices[frozenset(event.index.items())] = ts_index
+
+        # write the new frame asynchronously
+        self._futures.append(self._store[ts_index].write(frame))
+
+        # store, but do not process yet, the frame metadata
         self.frame_metadatas.append((event, meta))
-        self._counter += 1
+        # update the frame counter
+        self._frame_index += 1
+        # remember the highest index seen for each axis
+        for k, v in event.index.items():
+            self._axis_max[k] = max(self._axis_max.get(k, 0), v)
 
     def isel(
         self,
@@ -74,25 +150,135 @@ class TensorStoreHandler:
     ) -> np.ndarray:
         """Select data from the array."""
         # FIXME: will fail on slices
-        index = self._indices[frozenset(indexers.items())]
-        return self._store[index].read().result()
+        indexers = {**(indexers or {}), **indexers_kwargs}
+        ts_index = self._event_index_to_store_index(indexers)
+        return self._store[ts_index].read().result().squeeze()  # type: ignore
 
-    def _make_spec(self, frame: np.ndarray) -> dict:
-        return {
-            "kvstore": {"driver": self.driver, "path": self.path},
-            "create": True,
-            "delete_existing": self.delete_existing,
-            "driver": "zarr",
-            "metadata": {
-                "zarr_format": 2,
-                "shape": [self.resize_at, *frame.shape],
-                "chunks": [1, *frame.shape],
-                "dtype": frame.dtype.str,
-                # "compressor": self.compressor,
-                "fill_value": 0,
-                "order": "C",
-            },
-        }
+    def new_store(
+        self, frame: np.ndarray, seq: useq.MDASequence | None, meta: dict
+    ) -> ts.Future[ts.TensorStore]:
+        shape, chunks, labels = self.get_shape_chunks_labels(frame.shape, seq)
+        self._nd_storage = FRAME_DIM not in labels
+        return self._ts.open(
+            self.get_spec(),
+            create=True,
+            delete_existing=self.delete_existing,
+            dtype=self._ts.dtype(frame.dtype),
+            shape=shape,
+            chunk_layout=self._ts.ChunkLayout(chunk_shape=chunks),
+            domain=self._ts.IndexDomain(labels=labels),
+        )
 
-    def _new_tensorstore(self, spec: dict) -> Any:
-        return self.ts.open(spec).result()
+    def get_shape_chunks_labels(
+        self, frame_shape: tuple[int, ...], seq: useq.MDASequence | None
+    ) -> tuple[tuple[int, ...], tuple[int, ...], tuple[str, ...]]:
+        labels: tuple[str, ...]
+        if seq is not None and seq.sizes:
+            # remove axes with length 0
+            labels, sizes = zip(*(x for x in seq.sizes.items() if x[1]))
+            full_shape: tuple[int, ...] = (*sizes, *frame_shape)
+        else:
+            labels = (FRAME_DIM,)
+            full_shape = (self._size_increment, *frame_shape)
+
+        chunks = [1] * len(full_shape)
+        chunks[-len(frame_shape) :] = frame_shape
+        labels = (*labels, "y", "x")
+        return full_shape, tuple(chunks), labels
+
+    def get_spec(self) -> dict:
+        """Construct the tensorstore spec."""
+        spec = {"driver": self.ts_driver, "kvstore": self.kvstore}
+        if self.spec:
+            _merge_nested_dicts(spec, self.spec)
+
+        # HACK
+        if self.ts_driver == "zarr":
+            meta = cast(dict, spec.setdefault("metadata", {}))
+            if "dimension_separator" not in meta:
+                meta["dimension_separator"] = "/"
+        return spec
+
+    def finalize_metadata(self) -> None:
+        """Finalize and flush metadata to storage."""
+        if not (store := self._store) or not store.kvstore:
+            return
+
+        data = []
+        for event, meta in self.frame_metadatas:
+            # FIXME: unnecessary ser/des
+            js = event.model_dump_json(exclude={"sequence"}, exclude_defaults=True)
+            meta["Event"] = json.loads(js)
+            data.append(meta)
+
+        metadata = {"frame_metadatas": data}
+        if not self._nd_storage:
+            metadata["frame_indices"] = [
+                (tuple(dict(k).items()), v)  # type: ignore
+                for k, v in self._frame_indices.items()
+            ]
+
+        if self.ts_driver.startswith("zarr"):
+            store.kvstore.write(".zattrs", json.dumps(metadata))
+        elif self.ts_driver == "n5":
+            attrs = json.loads(store.kvstore.read("attributes.json").result().value)
+            attrs.update(metadata)
+            store.kvstore.write("attributes.json", json.dumps(attrs))
+
+    def _expand_store(self, store: ts.TensorStore) -> ts.Future[ts.TensorStore]:
+        """Grow the store by `self._size_increment` frames.
+
+        This is used when _nd_storage mode is False and we've run out of space.
+        """
+        new_shape = [self._frame_index + self._size_increment, *store.shape[-2:]]
+        return store.resize(exclusive_max=new_shape, expand_only=True)
+
+    def _event_index_to_store_index(self, index: Mapping) -> ts.DimExpression:
+        """Convert event index to store index.
+
+        The return value is safe to use as an index to self._store[...]
+        """
+        if self._nd_storage:
+            return self._ts.d[*index][*index.values()]
+
+        if any(isinstance(v, slice) for v in index.values()):
+            idx: list | int | ts.DimExpression = self._get_frame_indices(index)
+        else:
+            try:
+                idx = self._frame_indices[frozenset(index.items())]
+            except KeyError as e:
+                raise KeyError(f"Index {index} not found in frame_indices.") from e
+        return self._ts.d[FRAME_DIM][idx]
+
+    def _get_frame_indices(self, indexers: Mapping[str, int | slice]) -> list[int]:
+        """Convert indexers (with slices) to a list of frame indices."""
+        # converting slice objects to actual indices
+        axis_indices: dict[str, Sequence[int]] = {}
+        for k, v in indexers.items():
+            if isinstance(v, slice):
+                axis_indices[k] = tuple(range(*v.indices(self._axis_max.get(k, 0) + 1)))
+            else:
+                axis_indices[k] = (v,)
+
+        indices: list[int] = []
+        for p in product(*axis_indices.values()):
+            key = frozenset(dict(zip(axis_indices.keys(), p)).items())
+            try:
+                indices.append(self._frame_indices[key])
+            except KeyError:  # pragma: no cover
+                warnings.warn(
+                    f"Index {dict(key)} not found in frame_indices.", stacklevel=2
+                )
+        return indices
+
+
+def _merge_nested_dicts(dict1: dict, dict2: Mapping) -> None:
+    """Merge two nested dictionaries.
+
+    Values in dict2 will override values in dict1.
+    """
+    for key, value in dict2.items():
+        if key in dict1 and isinstance(dict1[key], dict) and isinstance(value, dict):
+            _merge_nested_dicts(dict1[key], value)
+        else:
+            dict1[key] = value

--- a/src/pymmcore_plus/mda/handlers/_tensorstore_writer.py
+++ b/src/pymmcore_plus/mda/handlers/_tensorstore_writer.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import tensorstore as ts
+
+if TYPE_CHECKING:
+    import numpy as np
+    import useq
+
+
+class TensorStoreWriter:
+    def __init__(self, path: str, overwrite: bool = False) -> None:
+        # storage of individual frame metadata
+        # maps position key to list of frame metadata
+        self.frame_metadatas: list[tuple[useq.MDAEvent, dict]] = []
+        self.resize_at = 100
+        self.delete_existing = overwrite
+        self.path = path
+        self.driver = "file"
+        self.compressor = None
+        self._store: ts.TensorStore | None = None
+        self._counter = 0
+        self._futures: list[ts.Future] = []
+
+    def sequenceStarted(self, seq: useq.MDASequence) -> None:
+        """On sequence started, simply store the sequence."""
+        self._counter = 0
+        self._store = None
+        self.frame_metadatas.clear()
+        self.current_sequence = seq
+
+    def sequenceFinished(self, seq: useq.MDASequence) -> None:
+        """On sequence finished, clear the current sequence."""
+        if self._store is None:
+            return
+        self._futures.append(
+            self._store.resize(exclusive_max=(self._counter, *self._store.shape[-2:]))
+        )
+        for f in self._futures:
+            f.result()
+        if self.frame_metadatas:
+            data = []
+            for event, meta in self.frame_metadatas:
+                js = event.model_dump_json(exclude={"sequence"}, exclude_defaults=True)
+                meta["Event"] = json.loads(js)
+                data.append(meta)
+            self._store.kvstore.write(".zattrs", json.dumps({"frame_metadatas": data}))
+
+    def frameReady(self, frame: np.ndarray, event: useq.MDAEvent, meta: dict) -> None:
+        """Write frame to the zarr array for the appropriate position."""
+        if self._store is None:
+            self._store = self._make_tensorstore(self._make_spec(frame))
+        elif self._counter >= self._store.shape[0]:
+            self._store = self._store.resize(
+                exclusive_max=(self._counter + self.resize_at, *self._store.shape[-2:])
+            ).result()
+
+        self._futures.append(self._store[self._counter].write(frame))
+        self.frame_metadatas.append((event, meta))
+        self._counter += 1
+
+    def _make_spec(self, frame: np.ndarray) -> dict:
+        return {
+            "kvstore": {"driver": self.driver, "path": self.path},
+            "create": True,
+            "delete_existing": self.delete_existing,
+            "driver": "zarr",
+            "metadata": {
+                "zarr_format": 2,
+                "shape": [self.resize_at, *frame.shape],
+                "chunks": [1, *frame.shape],
+                "dtype": frame.dtype.str,
+                # "compressor": self.compressor,
+                "fill_value": 0,
+                "order": "C",
+            },
+        }
+
+    def _make_tensorstore(self, spec: dict) -> ts.TensorStore:
+        return ts.open(spec).result()

--- a/src/pymmcore_plus/mda/handlers/_tensorstore_writer.py
+++ b/src/pymmcore_plus/mda/handlers/_tensorstore_writer.py
@@ -233,7 +233,9 @@ class TensorStoreHandler:
         new_shape = [self._frame_index + self._size_increment, *store.shape[-2:]]
         return store.resize(exclusive_max=new_shape, expand_only=True)
 
-    def _event_index_to_store_index(self, index: Mapping) -> ts.DimExpression:
+    def _event_index_to_store_index(
+        self, index: Mapping[str, int | slice]
+    ) -> ts.DimExpression:
         """Convert event index to store index.
 
         The return value is safe to use as an index to self._store[...]
@@ -245,7 +247,7 @@ class TensorStoreHandler:
             idx: list | int | ts.DimExpression = self._get_frame_indices(index)
         else:
             try:
-                idx = self._frame_indices[frozenset(index.items())]
+                idx = self._frame_indices[frozenset(index.items())]  # type: ignore
             except KeyError as e:
                 raise KeyError(f"Index {index} not found in frame_indices.") from e
         return self._ts.d[FRAME_DIM][idx]

--- a/tests/io/test_zarr_writers.py
+++ b/tests/io/test_zarr_writers.py
@@ -183,16 +183,19 @@ def test_tensorstore_writer_spec_override(tmp_path: Path) -> None:
 
 
 def test_tensorstore_writer_indeterminate(tmp_path: Path, core: CMMCorePlus) -> None:
-    writer = TensorStoreHandler(path=tmp_path / "test.zarr")
+    # FIXME: this test is actually throwing difficult-to-debug exceptions
+    # when driver=='zarr'.  It happens when awaiting the result of self._store.resize()
+    # inside of sequenceFinished.
+    writer = TensorStoreHandler()
 
     que = Queue()
     thread = core.run_mda(iter(que.get, None), output=writer)
-    for t in range(4):
-        for z in range(4):
+    for t in range(2):
+        for z in range(2):
             que.put(useq.MDAEvent(index={"t": t, "z": z, "c": 0}))
     que.put(None)
     thread.join()
 
-    assert writer.isel(t=2, z=2, c=0).shape == (512, 512)
+    assert writer.isel(t=1, z=1, c=0).shape == (512, 512)
     with pytest.raises(KeyError):
-        writer.isel(t=4, z=4, c=0)
+        writer.isel(t=2, z=2, c=0)

--- a/tests/io/test_zarr_writers.py
+++ b/tests/io/test_zarr_writers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from queue import Queue
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -170,3 +171,28 @@ def test_tensorstore_writer(
     x = writer.isel(t=0, c=0, x=slice(0, 100))
     assert isinstance(x, np.ndarray)
     assert x.shape[-1] == 100
+
+
+def test_tensorstore_writer_spec_override(tmp_path: Path) -> None:
+    writer = TensorStoreHandler(
+        path=tmp_path / "test.zarr",
+        spec={"context": {"cache_pool": {"total_bytes_limit": 10000000}}},
+    )
+
+    assert writer.get_spec()["context"]["cache_pool"]["total_bytes_limit"] == 10000000
+
+
+def test_tensorstore_writer_indeterminate(tmp_path: Path, core: CMMCorePlus) -> None:
+    writer = TensorStoreHandler(path=tmp_path / "test.zarr")
+
+    que = Queue()
+    thread = core.run_mda(iter(que.get, None), output=writer)
+    for t in range(4):
+        for z in range(4):
+            que.put(useq.MDAEvent(index={"t": t, "z": z, "c": 0}))
+    que.put(None)
+    thread.join()
+
+    assert writer.isel(t=2, z=2, c=0).shape == (512, 512)
+    with pytest.raises(KeyError):
+        writer.isel(t=4, z=4, c=0)

--- a/tests/io/test_zarr_writers.py
+++ b/tests/io/test_zarr_writers.py
@@ -197,5 +197,6 @@ def test_tensorstore_writer_indeterminate(tmp_path: Path, core: CMMCorePlus) -> 
     thread.join()
 
     assert writer.isel(t=1, z=1, c=0).shape == (512, 512)
+    assert writer.isel(t=1, z=slice(None), c=0).shape == (2, 512, 512)
     with pytest.raises(KeyError):
         writer.isel(t=2, z=2, c=0)


### PR DESCRIPTION
This writer/handler is similar to (and I suspect will eventually replace) the `OMEZarrWriter`.  It uses tensorstore to write to disk, which in my quick-and-dirty benchmarks seems to be writing about 3x faster than python-zarr (note, i haven't tried to tune the python-zarr much to make it faster, but tensorstore is written in C++ and is explicitly designed to take care of multi-threading, and just generally be performant).  

Tensorstore supports a number of formats, though zarr is what we'll likely use the most. I'm not currently worrying about writing out to the ngff spec, as this writer is designed to handle more than 5 dimensions easily (since tensorstore also supports that nicely) and I don't want to artificially restrict it yet... we can add an ome-zarr variant in the future.

This writer has two main "modes" (which are determined implicitly based on the experiment).  When `self._nd_storage == True`, we're greedily attempting to store the data in a multi-dimensional format based on the axes of the sequence.  For non-deterministic  event-driven experiments, this often won't work... so `self._nd_storage == False` means it will simply store frames as they come, with a final shape of ` (nframes, y, x)`.  (It should then be relatively straightforward to reshape the data after the fact if need be).  

This writer was partially created while developing the stack-viewer in pymmcore-widgets: https://github.com/pymmcore-plus/pymmcore-widgets/pull/293 and will be used as the default data store for that.