### PR TITLE
feat: save ome-tiff files in a folder if multi-position

### DIFF
--- a/src/pymmcore_plus/mda/handlers/_ome_tiff_writer.py
+++ b/src/pymmcore_plus/mda/handlers/_ome_tiff_writer.py
@@ -120,6 +120,7 @@ class OMETiffWriter(_5DWriterBase[np.memmap]):
             name = folder_path.name.replace(ext, f"_{position_key}{ext}")
             # create the full path
             fname = folder_path / name
+        # if there is only one position, save the file as the filename
         else:
             fname = Path(self._filename)
 

--- a/tests/io/test_ome_tiff.py
+++ b/tests/io/test_ome_tiff.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, cast
 
 import pytest
 import useq
+
 from pymmcore_plus import CMMCorePlus
 from pymmcore_plus.mda import mda_listeners_connected
 from pymmcore_plus.mda.handlers import OMETiffWriter
@@ -55,12 +56,19 @@ def test_ome_tiff_writer(
     n_positions = seq.sizes.get("p", 1)
     if n_positions > 1:
         ext = ".ome.tif" if ome else ".tif"
-        files = [str(dest).replace(ext, f"_p{i}{ext}") for i in range(n_positions)]
+        folder = Path(dest)
+        files = [folder.name.replace(ext, f"_p{i}{ext}") for i in range(n_positions)]
     else:
         files = [str(dest)]
 
     # check that the files exist and have the correct shape
+    if n_positions > 1:
+        assert dest.is_dir()
+        assert dest.exists()
+        assert set(files) == {f.name for f in dest.iterdir()}
+
     for file in files:
+        file = dest / file if n_positions > 1 else file
         assert Path(file).exists()
         data = cast("np.ndarray", tf.imread(file))
 


### PR DESCRIPTION
related to https://github.com/pymmcore-plus/pymmcore-widgets/pull/295#discussion_r1597513238.

If the `MDASequence` has multiple positions, The `OMETiffWriter` will create a main folder using the provided `filename` and save each position file in this folder updating the name with `_p*` according to the position index (as in the current version).

<img width="289" alt="Screenshot 2024-05-13 at 7 13 04 AM" src="https://github.com/pymmcore-plus/pymmcore-plus/assets/70725613/d4091eee-3dc5-4239-ab34-a020d7974860">
