### PR TITLE
fix: add stopPropertySequence before loadPropertySequence in setup_sequenced_event

### DIFF
--- a/src/pymmcore_plus/mda/_engine.py
+++ b/src/pymmcore_plus/mda/_engine.py
@@ -362,6 +362,7 @@ class MDAEngine(PMDAEngine):
             core.loadStageSequence(zstage, event.z_sequence)
         if prop_seqs := event.property_sequences(core):
             for (dev, prop), value_sequence in prop_seqs.items():
+                core.stopPropertySequence(dev, prop)
                 core.loadPropertySequence(dev, prop, value_sequence)
 
         # TODO: SLM

--- a/src/pymmcore_plus/mda/_engine.py
+++ b/src/pymmcore_plus/mda/_engine.py
@@ -326,8 +326,18 @@ class MDAEngine(PMDAEngine):
         """Teardown state of system (hardware, etc.) after `event`."""
         # autoshutter was set at the beginning of the sequence, and this event
         # doesn't want to leave the shutter open.  Re-enable autoshutter.
+        core = self._mmc
         if not event.keep_shutter_open and self._autoshutter_was_set:
-            self._mmc.setAutoShutter(True)
+            core.setAutoShutter(True)
+        if isinstance(event, SequencedEvent):
+            if event.exposure_sequence:
+                core.stopExposureSequence(self._mmc.getCameraDevice())
+            if event.x_sequence:
+                core.stopXYStageSequence(core.getXYStageDevice())
+            if event.z_sequence:
+                core.stopStageSequence(core.getFocusDevice())
+            for dev, prop in event.property_sequences(core):
+                core.stopPropertySequence(dev, prop)
 
     def teardown_sequence(self, sequence: MDASequence) -> None:
         """Perform any teardown required after the sequence has been executed."""
@@ -351,18 +361,10 @@ class MDAEngine(PMDAEngine):
             stage = core.getXYStageDevice()
             core.loadXYStageSequence(stage, event.x_sequence, event.y_sequence)
         if event.z_sequence:
-            # these notes are from Nico Stuurman in AcqEngJ
-            # https://github.com/micro-manager/AcqEngJ/pull/108
-            # at least some zStages freak out (in this case, NIDAQ board) when you
-            # try to load a sequence while the sequence is still running.  Nothing in
-            # the engine stops a stage sequence if all goes well.
-            # Stopping a sequence if it is not running hopefully will not harm anyone.
             zstage = core.getFocusDevice()
-            core.stopStageSequence(zstage)
             core.loadStageSequence(zstage, event.z_sequence)
         if prop_seqs := event.property_sequences(core):
             for (dev, prop), value_sequence in prop_seqs.items():
-                core.stopPropertySequence(dev, prop)
                 core.loadPropertySequence(dev, prop, value_sequence)
 
         # TODO: SLM

--- a/src/pymmcore_plus/mda/_runner.py
+++ b/src/pymmcore_plus/mda/_runner.py
@@ -278,17 +278,18 @@ class MDARunner:
             logger.info("%s", event)
             engine.setup_event(event)
 
-            output = engine.exec_event(event) or ()  # in case output is None
+            try:
+                output = engine.exec_event(event) or ()  # in case output is None
 
-            for payload in output:
-                img, event, meta = payload
-                if "PerfCounter" in meta:
-                    meta["ElapsedTime-ms"] = (meta["PerfCounter"] - self._t0) * 1000
-                meta["Event"] = event
-                with exceptions_logged():
-                    self._signals.frameReady.emit(img, event, meta)
-
-            teardown_event(event)
+                for payload in output:
+                    img, event, meta = payload
+                    if "PerfCounter" in meta:
+                        meta["ElapsedTime-ms"] = (meta["PerfCounter"] - self._t0) * 1000
+                    meta["Event"] = event
+                    with exceptions_logged():
+                        self._signals.frameReady.emit(img, event, meta)
+            finally:
+                teardown_event(event)
 
     def _prepare_to_run(self, sequence: MDASequence) -> PMDAEngine:
         """Set up for the MDA run.


### PR DESCRIPTION
(hopefully) fixes #352 

@linshaova i've made a couple additional changes here that (technically) undo some of changes I made in #307, but I think it's a better overall fix.  basically, I've moved all of the `core.stop<Thing>Sequence` calls into the `teardown_event` event method of the engine (which always gets called at the end of an event) and removed the "safety" calls to `stop<Thing>Sequence` from the setup_event method.  I've also added a couple more `stop<Thing>Sequence` calls for XYStageDevice and ExposureSequence.

If you have a moment, it would be great if you confirm whether this branch fixes your issues