### PR TITLE
feat: add the tensorstore option to the MDARunner 

### DIFF
--- a/src/pymmcore_plus/mda/_runner.py
+++ b/src/pymmcore_plus/mda/_runner.py
@@ -189,6 +189,7 @@ class MDARunner:
                 created automatically based on the extension of the path.
                 - `.zarr` files will be handled by `OMEZarrWriter`
                 - `.ome.tiff` files will be handled by `OMETiffWriter`
+                - `.tensorstore.zarr` files will be handled by `TensorStoreHandler`
                 - A directory with no extension will be handled by `ImageSequenceWriter`
             - A handler object that implements the `DataHandler` protocol, currently
                 meaning it has a `frameReady` method.  See `mda_listeners_connected`

--- a/src/pymmcore_plus/mda/_runner.py
+++ b/src/pymmcore_plus/mda/_runner.py
@@ -243,6 +243,12 @@ class MDARunner:
         This method picks from the built-in handlers based on the extension of the path.
         """
         path = str(Path(path).expanduser().resolve())
+
+        if path.endswith(".tensorstore.zarr"):
+            from pymmcore_plus.mda.handlers import TensorStoreHandler
+
+            return TensorStoreHandler(path=path, delete_existing=True, driver="zarr")
+
         if path.endswith(".zarr"):
             from pymmcore_plus.mda.handlers import OMEZarrWriter
 

--- a/src/pymmcore_plus/mda/_runner.py
+++ b/src/pymmcore_plus/mda/_runner.py
@@ -37,8 +37,9 @@ MSG = (
     "This sequence is a placeholder for a generator of events with unknown "
     "length & shape. Iterating over it has no effect."
 )
+
 # variables for handler inference
-TESNSORSTORE = r".tensorstore[.a-zA-Z0-9_]*$"
+TESNSORSTORE = "tensorstore"
 TENSORSTORE_DRIVERS = ["zarr", "zarr3", "n5", "neuroglancer_precomputed"]
 ZARR = ".zarr"
 TIFF = (".tif", ".tiff")
@@ -256,13 +257,13 @@ class MDARunner:
         # drivers. We search for the pattern and if it matches, we create a
         # TensorStoreHandler. We get the driver from the path suffix or we default to
         # zarr and pass it to the handler.
-        if re.search(TESNSORSTORE, path):
+        if re.search(f".{TESNSORSTORE}", path):
             from pymmcore_plus.mda.handlers import TensorStoreHandler
 
             # remove the dot
             suffix = Path(path).suffix[1:]
             # default to zarr (if path ends with .tensorstore) or use the suffix
-            driver = "zarr" if suffix == "tensorstore" else suffix
+            driver = "zarr" if suffix == TESNSORSTORE else suffix
             if driver not in TENSORSTORE_DRIVERS:
                 raise ValueError(
                     f"Unsupported tensorstore driver: '{driver}'. "

--- a/tests/io/test_runner_handler_inference.py
+++ b/tests/io/test_runner_handler_inference.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pymmcore_plus.mda import MDARunner
+from pymmcore_plus.mda.handlers import (
+    ImageSequenceWriter,
+    OMETiffWriter,
+    OMEZarrWriter,
+    TensorStoreHandler,
+)
+
+NEUROGLANCER = "neuroglancer_precomputed"
+
+inputs = [
+    ("./test.tensorstore.zarr", TensorStoreHandler, "zarr"),
+    ("./test.tensorstore.zarr3", TensorStoreHandler, "zarr3"),
+    ("./test.tensorstore.n5", TensorStoreHandler, "n5"),
+    (f"./test.tensorstore.{NEUROGLANCER}", TensorStoreHandler, NEUROGLANCER),
+    ("./test.zarr", OMEZarrWriter, ""),
+    ("./test.tif", OMETiffWriter, ""),
+    ("./test.tiff", OMETiffWriter, ""),
+    ("./test", ImageSequenceWriter, ""),
+]
+
+
+@pytest.mark.parametrize("input", inputs)
+def test_runner_handler_inference(input: tuple[str, Any]):
+    runner = MDARunner()
+    path, expected_handler, driver = input
+    handler = runner._handler_for_path(path)
+    assert isinstance(handler, expected_handler)
+    if isinstance(handler, TensorStoreHandler):
+        assert handler.ts_driver == driver

--- a/tests/io/test_runner_handler_inference.py
+++ b/tests/io/test_runner_handler_inference.py
@@ -14,6 +14,8 @@ from pymmcore_plus.mda.handlers import (
 NEUROGLANCER = "neuroglancer_precomputed"
 
 inputs = [
+    # path, expected_handler, driver (if applicable)
+    ("./test.tensorstore", TensorStoreHandler, "zarr"),
     ("./test.tensorstore.zarr", TensorStoreHandler, "zarr"),
     ("./test.tensorstore.zarr3", TensorStoreHandler, "zarr3"),
     ("./test.tensorstore.n5", TensorStoreHandler, "n5"),
@@ -26,7 +28,7 @@ inputs = [
 
 
 @pytest.mark.parametrize("input", inputs)
-def test_runner_handler_inference(input: tuple[str, Any]):
+def test_runner_handler_inference(input: tuple[str, Any, str]):
     runner = MDARunner()
     path, expected_handler, driver = input
     handler = runner._handler_for_path(path)


### PR DESCRIPTION
@tlambert03  not sure what you think about it but in this PR I tried to find a way to add the `tensorstore` option to the `MDARunner` `_handler_for_path` method so we can pass something like `.my/path/ts.tensorstore.zarr` to the `run_mda` method and return a `TensorStoreHandler`.

Basically it assumes that the path for a `tensorstore` ends with either `.tensorstore` or with `.tensorstore.<driver>` (where `driver` is one of the supported `zarr`, `zarr3`, `n5` or `neuroglancer_precomputed` drivers). 

We search for the pattern `.tensorstore` in the provided path and, if it matches, we create a `TensorStoreHandler` with a `zarr` default driver if the path ends with `.tensorstore` or we get the driver form the suffix (for example, if the provided path is `.my/path/ts.tensorstore.n5`, we will use the driver `n5`).