### PR TITLE
feat: guard against premature call to getInstalledDevices

### DIFF
--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -195,7 +195,7 @@ class CMMCorePlus(pymmcore.CMMCore):
 
         try:
             self.enableFeature("StrictInitializationChecks", True)
-        except Exception as e:
+        except Exception as e:  # pragma: no cover
             logger.warn(
                 "Failed to enable StrictInitializationChecks: %s", e, exc_info=True
             )

--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -408,6 +408,35 @@ class CMMCorePlus(pymmcore.CMMCore):
         """
         return FocusDirection(super().getFocusDirection(stageLabel))
 
+    def getInstalledDevices(
+        self, hubLabel: str, force: bool = False
+    ) -> tuple[str, ...]:
+        """Performs auto-detection of child devices that are attached to a Hub device.
+
+        !!! important
+
+            This method may only be called once, and it is generally best to call it
+            only after the device has been initialized, otherwise it may *permanently*
+            return an empty tuple. pymmcore-plus prevents you from calling this before
+            initialization. Use `force=True` to override this safeguard.
+
+        **Why Override?** To prevent calling this method before initialization, which
+        can lead to unexpected behavior.
+        """
+        if (
+            self.getDeviceInitializationState(hubLabel)
+            is DeviceInitializationState.Uninitialized
+            and not force
+        ):
+            warnings.warn(
+                "Not calling getInstalledDevices before initializing the hub device. "
+                "Use force=True to override this safeguard.",
+                stacklevel=2,
+            )
+            return ()
+
+        return super().getInstalledDevices(hubLabel)
+
     def getPropertyType(self, label: str, propName: str) -> PropertyType:
         """Return the intrinsic property type for a given device and property.
 

--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -193,6 +193,13 @@ class CMMCorePlus(pymmcore.CMMCore):
         if _instance is None:
             _instance = self
 
+        try:
+            self.enableFeature("StrictInitializationChecks", True)
+        except Exception as e:
+            logger.warn(
+                "Failed to enable StrictInitializationChecks: %s", e, exc_info=True
+            )
+
         # TODO: test this on windows ... writing to the same file may be an issue there
         if logfile := current_logfile(logger):
             self.setPrimaryLogFile(str(logfile))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -641,3 +641,13 @@ def test_snap_rgb(core: CMMCorePlus) -> None:
         dtype="uint8",
     )
     assert np.array_equal(img[::64, -1], expect)
+
+
+def test_guard_get_devices():
+    core = CMMCorePlus()
+    core.loadDevice("Hub", "DemoCamera", "DHub")
+    with pytest.warns(match="Not calling getInstalledDevices"):
+        assert core.getInstalledDevices("Hub") == ()
+
+    core.initializeDevice("Hub")
+    assert "DCam" in core.getInstalledDevices("Hub")


### PR DESCRIPTION
similar to https://github.com/micro-manager/mmCoreAndDevices/pull/476 but on the python side

it's important not to call `getInstalledDevices` before calling `initializeDevice`, otherwise you may never be able to query the peripherals of a given device (even after later initialization)