### PR TITLE
feat: add `mmcore use` to set the active micro-manager installation

### DIFF
--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -2,4 +2,6 @@
 
 ::: pymmcore_plus.find_micromanager
 
+::: pymmcore_plus.use_micromanager
+
 ::: pymmcore_plus.configure_logging

--- a/docs/install.md
+++ b/docs/install.md
@@ -81,26 +81,52 @@ They can be installed in two ways:
     the corresponding date, roughly
     [here](https://github.com/micro-manager/mmCoreAndDevices/blob/main/MMDevice/MMDevice.h#L30)
 
-!!! tip
+## Show the currently used Micro-Manager installation
 
-    By default, `pymmcore-plus` will look for a `Micro-Manager` folder in the
-    default install location. On Windows this is `C:\Program Files\`, on macOS it is
-    `/Applications/` and on Linux it is `/usr/local/lib/`. To override these default
-    device adapter search path, set the `MICROMANAGER_PATH` environment variable
-    (e.g. `export MICROMANAGER_PATH=/path/to/installation`).
+To see which micro-manager installation `pymmcore-plus` is using, you
+can run:
 
-    To see which micro-manager installation `pymmcore-plus` is using, you
-    can run:
+```shell
+mmcore list
+```
 
-    ```shell
-    mmcore list
-    ```
+or, if you didn't install with the `cli` extra, you can use
+[`find_micromanager`][pymmcore_plus.find_micromanager]:
 
-    or, if you didn't install with the `cli` extra:
+```shell
+python -c "from pymmcore_plus import find_micromanager; print(find_micromanager())"
+```
 
-    ```shell
-    python -c "from pymmcore_plus import find_micromanager; print(find_micromanager())"
-    ```
+## Set the active Micro-Manager installation
+
+By default, `pymmcore-plus` will look for a `Micro-Manager` folder in the
+default install location. On Windows this is `C:\Program Files\`, on macOS it is
+`/Applications/` and on Linux it is `/usr/local/lib/`. To override these default
+device adapter search path, set the `MICROMANAGER_PATH` environment variable
+
+```shell
+export MICROMANAGER_PATH=/path/to/installation
+```
+
+If you want to permanently set the Micro-Manager installation path that
+`pymmcore-plus` uses, you can use the `mmcore use` command:
+
+```shell
+mmcore use <some path or pattern>
+```
+
+... where `<some path or pattern>` is either a path to an existing directory
+(containing micro-manager device adapters) or a pattern to match against
+directories returned by [`find_micromanager`][pymmcore_plus.find_micromanager].
+
+Alternatively, you can use the
+[`use_micromanager`][pymmcore_plus.use_micromanager] function, passing *either*
+a path to an existing directory, or a pattern to match against directories
+returned by [`find_micromanager`][pymmcore_plus.find_micromanager]:
+
+```shell
+python -c "from pymmcore_plus import use_micromanager; use_micromanager(path=..., pattern=...)"
+```
 
 ### On Linux
 

--- a/src/pymmcore_plus/__init__.py
+++ b/src/pymmcore_plus/__init__.py
@@ -9,7 +9,7 @@ except PackageNotFoundError:  # pragma: no cover
 
 
 from ._logger import configure_logging
-from ._util import find_micromanager
+from ._util import find_micromanager, use_micromanager
 from .core import (
     CFGCommand,
     CFGGroup,
@@ -59,4 +59,5 @@ __all__ = [
     "PixelFormat",
     "PortType",
     "PropertyType",
+    "use_micromanager",
 ]

--- a/src/pymmcore_plus/_util.py
+++ b/src/pymmcore_plus/_util.py
@@ -188,7 +188,7 @@ def use_micromanager(
         `find_micromanager`. If no match is found, a `FileNotFoundError` will be raised.
     """
     if path is None:
-        if pattern is None:
+        if pattern is None:  # pragma: no cover
             raise ValueError("One of 'path' or 'pattern' must be provided")
         if (path := _match_mm_pattern(pattern)) is None:
             options = "\n".join(find_micromanager(return_first=False))
@@ -196,13 +196,13 @@ def use_micromanager(
                 f"No micromanager path found matching: {pattern!r}. Options:\n{options}"
             )
 
-    if not isinstance(path, Path):
+    if not isinstance(path, Path):  # pragma: no cover
         path = Path(path)
 
     path = path.expanduser().resolve()
-    if not path.exists():
-        raise FileNotFoundError(f"Path not found: {path!r}")
-    if not path.is_dir():
+    if not path.is_dir():  # pragma: no cover
+        if not path.exists():
+            raise FileNotFoundError(f"Path not found: {path!r}")
         raise NotADirectoryError(f"Not a directory: {path!r}")
 
     USER_DATA_MM_PATH.mkdir(parents=True, exist_ok=True)

--- a/src/pymmcore_plus/_util.py
+++ b/src/pymmcore_plus/_util.py
@@ -4,6 +4,7 @@ import datetime
 import importlib
 import os
 import platform
+import re
 import sys
 import warnings
 from collections import defaultdict
@@ -17,6 +18,7 @@ from typing import TYPE_CHECKING, cast, overload
 from platformdirs import user_data_dir
 
 if TYPE_CHECKING:
+    from re import Pattern
     from typing import Any, Callable, Iterator, Literal, TypeVar
 
     QtConnectionType = Literal["AutoConnection", "DirectConnection", "QueuedConnection"]
@@ -41,6 +43,7 @@ __all__ = ["find_micromanager", "retry", "no_stdout", "signals_backend"]
 APP_NAME = "pymmcore-plus"
 USER_DATA_DIR = Path(user_data_dir(appname=APP_NAME))
 USER_DATA_MM_PATH = USER_DATA_DIR / "mm"
+CURRENT_MM_PATH = USER_DATA_MM_PATH / ".current_mm"
 PYMMCORE_PLUS_PATH = Path(__file__).parent.parent
 
 
@@ -58,16 +61,17 @@ def find_micromanager(return_first: bool = True) -> str | None | list[str]:
     In order, this will look for:
 
     1. An environment variable named `MICROMANAGER_PATH`
-    2. A `Micro-Manager*` folder in the `pymmcore-plus` user data directory
+    2. A path stored in the `CURRENT_MM_PATH` file (set by `use_micromanager`).
+    3. A `Micro-Manager*` folder in the `pymmcore-plus` user data directory
        (this is the default install location when running `mmcore install`)
 
         - **Windows**: C:\Users\\[user]\AppData\Local\pymmcore-plus\pymmcore-plus
         - **macOS**: ~/Library/Application Support/pymmcore-plus
         - **Linux**: ~/.local/share/pymmcore-plus
 
-    3. A `Micro-Manager*` folder in the `pymmcore_plus` package directory (this is the
+    4. A `Micro-Manager*` folder in the `pymmcore_plus` package directory (this is the
        default install location when running `python -m pymmcore_plus.install`)
-    4. The default micro-manager install location:
+    5. The default micro-manager install location:
 
         - **Windows**: `C:/Program Files/`
         - **macOS**: `/Applications`
@@ -89,14 +93,25 @@ def find_micromanager(return_first: bool = True) -> str | None | list[str]:
     """
     from ._logger import logger
 
+    # we use a dict here to avoid duplicates
+    full_list: dict[str, None] = {}
+
     # environment variable takes precedence
-    full_list: list[str] = []
     env_path = os.getenv("MICROMANAGER_PATH")
     if env_path and os.path.isdir(env_path):
         if return_first:
             logger.debug("using MM path from env var: %s", env_path)
             return env_path
-        full_list.append(env_path)
+        full_list[env_path] = None
+
+    # then check for a path in CURRENT_MM_PATH
+    if CURRENT_MM_PATH.exists():
+        path = CURRENT_MM_PATH.read_text().strip()
+        if os.path.isdir(path):
+            if return_first:
+                logger.debug("using MM path from current_mm: %s", path)
+                return path
+            full_list[path] = None
 
     # then look in user_data_dir
     _folders = (p for p in USER_DATA_MM_PATH.glob("Micro-Manager*") if p.is_dir())
@@ -105,7 +120,8 @@ def find_micromanager(return_first: bool = True) -> str | None | list[str]:
         if return_first:
             logger.debug("using MM path from user install: %s", user_install[0])
             return str(user_install[0])
-        full_list.extend([str(x) for x in user_install])
+        for x in user_install:
+            full_list[str(x)] = None
 
     # then look for an installation in this folder (from `pymmcore_plus.install`)
     sfx = "_win" if os.name == "nt" else "_mac"
@@ -116,7 +132,8 @@ def find_micromanager(return_first: bool = True) -> str | None | list[str]:
         if return_first:
             logger.debug("using MM path from local install: %s", local_install[0])
             return str(local_install[0])
-        full_list.extend([str(x) for x in local_install])
+        for x in local_install:
+            full_list[str(x)] = None
 
     applications = {
         "darwin": Path("/Applications/"),
@@ -138,8 +155,59 @@ def find_micromanager(return_first: bool = True) -> str | None | list[str]:
         logger.debug("using MM path found in applications: %s", pth)
         return str(pth)
     if pth is not None:
-        full_list.append(str(pth))
-    return full_list
+        full_list[str(pth)] = None
+    return list(full_list)
+
+
+def _match_mm_pattern(pattern: str | Pattern[str]) -> Path | None:
+    """Locate an existing Micro-Manager folder using a regex pattern."""
+    for _path in find_micromanager(return_first=False):
+        if not isinstance(pattern, re.Pattern):
+            pattern = str(pattern)
+        if re.search(pattern, _path) is not None:
+            return Path(_path)
+    return None
+
+
+def use_micromanager(
+    path: str | Path | None = None, pattern: str | Pattern[str] | None = None
+) -> Path | None:
+    """Set the preferred Micro-Manager path.
+
+    This sets the preferred micromanager path, and persists across sessions.
+    This path takes precedence over everything *except* the `MICROMANAGER_PATH`
+    environment variable.
+
+    Parameters
+    ----------
+    path : str | Path | None
+        Path to an existing directory. This directory should contain micro-manager
+        device adapters. If `None`, the path will be determined using `pattern`.
+    pattern : str Pattern | | None
+        A regex pattern to match against the micromanager paths found by
+        `find_micromanager`. If no match is found, a `FileNotFoundError` will be raised.
+    """
+    if path is None:
+        if pattern is None:
+            raise ValueError("One of 'path' or 'pattern' must be provided")
+        if (path := _match_mm_pattern(pattern)) is None:
+            options = "\n".join(find_micromanager(return_first=False))
+            raise FileNotFoundError(
+                f"No micromanager path found matching: {pattern!r}. Options:\n{options}"
+            )
+
+    if not isinstance(path, Path):
+        path = Path(path)
+
+    path = path.expanduser().resolve()
+    if not path.exists():
+        raise FileNotFoundError(f"Path not found: {path!r}")
+    if not path.is_dir():
+        raise NotADirectoryError(f"Not a directory: {path!r}")
+
+    USER_DATA_MM_PATH.mkdir(parents=True, exist_ok=True)
+    CURRENT_MM_PATH.write_text(str(path))
+    return path
 
 
 def _imported_qt_modules() -> Iterator[str]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,7 +19,7 @@ try:
 except ImportError:
     pytest.skip("cli extras not available", allow_module_level=True)
 
-from pymmcore_plus import CMMCorePlus, __version__, _cli, _logger, install
+from pymmcore_plus import CMMCorePlus, __version__, _cli, _logger, _util, install
 from useq import MDASequence
 
 if TYPE_CHECKING:
@@ -91,7 +91,7 @@ def test_basic_install(tmp_path: Path) -> None:
 
 
 @pytest.mark.skipif(platform.system() == "Linux", reason="Not supported on Linux")
-def test_available_versions(tmp_path: Path) -> None:
+def test_available_versions() -> None:
     """installing with an erroneous version should fail and show available versions."""
     result = runner.invoke(app, ["install", "-r", "xxxx"])
     assert result.exit_code > 0
@@ -123,13 +123,41 @@ def test_clean(tmp_path: Path) -> None:
     assert result.exit_code == 0
 
 
-def test_list(tmp_path: Path) -> None:
+def test_list() -> None:
     """Just shows what's in the user data folder."""
     result = runner.invoke(app, ["list"])
     if result.exit_code != 0:
         raise AssertionError(
             "mmcore list failed... is Micro-Manager installed?  (run mmcore install)"
         )
+
+
+def test_cli_use(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    mm = tmp_path / "mm"
+    current = mm / ".current"
+    monkeypatch.setattr(_util, "USER_DATA_MM_PATH", mm)
+    monkeypatch.setattr(_util, "CURRENT_MM_PATH", current)
+
+    # provide existing path
+    fake = tmp_path / "fake-123456"
+    fake.mkdir()
+    runner.invoke(app, ["use", str(fake)])
+    assert current.read_text() == str(fake)
+    assert _util.find_micromanager() == str(fake)
+
+    # match based on pattern
+    runner.invoke(app, ["use", "1234"])
+    assert current.read_text() == str(fake)
+
+    # error if no match
+    result = runner.invoke(app, ["use", "xyz"])
+    assert result.exit_code > 0
+
+    # error if not directory
+    file = tmp_path / "file.txt"
+    file.touch()
+    result = runner.invoke(app, ["use", str(file)])
+    assert result.exit_code > 0
 
 
 ARGS: list[dict[str, dict | str]] = [


### PR DESCRIPTION
this adds an `mmcore use` command line, along with an `pymmcore_plus.use_micromanager()` function to set the activate micromanager directory if you have multiple installed:

```sh
$ mmcore list
📁 /Users/talley/Library/Application Support/pymmcore-plus/mm
   * Micro-Manager-80d5ac1 (active)
   • Micro-Manager-2.0.3-20240217

$ mmcore use 20240217
using /Users/talley/Library/Application Support/pymmcore-plus/mm/Micro-Manager-2.0.3-20240217

$ mmcore list
📁 /Users/talley/Library/Application Support/pymmcore-plus/mm
   * Micro-Manager-2.0.3-20240217 (active)
   • Micro-Manager-80d5ac1
```
