### PR TITLE
feat: enable hardware sequencing by default

### DIFF
--- a/docs/guides/mda_engine.md
+++ b/docs/guides/mda_engine.md
@@ -274,7 +274,7 @@ mda_sequence = MDASequence(
 )
 ```
 
-1.  The "fastest" axes come last. By putting `z` after `g` in the `axis_order`,
+1. The "fastest" axes come last. By putting `z` after `g` in the `axis_order`,
     we're saying "at each `g`, do a full `z` iteration".
 
 ??? example "output of `list(mda_sequence)`"
@@ -560,9 +560,9 @@ computer.
 Just like [micro-manager's acquisition
 engine](https://micro-manager.org/Hardware-based_Synchronization_in_Micro-Manager),
 the default acquisition engine in `pymmcore-plus` can opportunistically use
-hardware triggering whenever possible. For now, this behavior is off by default
-(in order to avoid unexpected behavior), but you can enable it by setting
-`CMMCorePlus.mda.engine.use_hardware_sequencing = True`:
+hardware triggering whenever possible. This behavior is on by default, but you can
+disable it by setting `CMMCorePlus.mda.engine.use_hardware_sequencing = False`,
+which may be useful for various debugging or testing purposes:
 
 ```python
 from pymmcore_plus import CMMCorePlus
@@ -571,6 +571,7 @@ mmc = CMMCorePlus.instance()
 mmc.loadSystemConfiguration()
 
 # enable hardware triggering
+# this is True by default, this is just an example for how to set it
 mmc.mda.engine.use_hardware_sequencing = True
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
 # https://peps.python.org/pep-0621/#dependencies-optional-dependencies
 [project.optional-dependencies]
 cli = ["typer >=0.4.2", "rich >=10.2.0"]
-io = ["tifffile >=2021.6.14", "zarr >=2.2"]
+io = ["tifffile >=2021.6.14", "zarr >=2.2,<3"]
 test = [
     "msgspec",
     "msgpack",
@@ -63,7 +63,7 @@ test = [
     "rich",
     "typer >=0.4.2",
     "tifffile >=2021.6.14",
-    "zarr >=2.2",
+    "zarr >=2.2,<3",
     "xarray",
 ]
 dev = ["ipython", "mypy", "pdbpp", "pre-commit", "ruff", "tensorstore-stubs"]

--- a/src/pymmcore_plus/mda/_engine.py
+++ b/src/pymmcore_plus/mda/_engine.py
@@ -54,12 +54,11 @@ class MDAEngine(PMDAEngine):
         attempt to combine MDAEvents into a single `SequencedEvent` if
         [`core.canSequenceEvents()`][pymmcore_plus.CMMCorePlus.canSequenceEvents]
         reports that the events can be sequenced. This can be set after instantiation.
-        By default, this is `False`, in order to avoid unexpected behavior, particularly
-        in testing and demo scenarios.  But in many "real world" scenarios, this can be
-        set to `True` to improve performance.
+        By default, this is `True`, however in various testing and demo scenarios, you
+        may wish to set it to `False` in order to avoid unexpected behavior.
     """
 
-    def __init__(self, mmc: CMMCorePlus, use_hardware_sequencing: bool = False) -> None:
+    def __init__(self, mmc: CMMCorePlus, use_hardware_sequencing: bool = True) -> None:
         self._mmc = mmc
         self.use_hardware_sequencing = use_hardware_sequencing
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,7 @@ except ImportError:
 @pytest.fixture(params=PARAMS, scope="function")
 def core(request):
     core = pymmcore_plus.CMMCorePlus()
+    core.mda.engine.use_hardware_sequencing = False
     if request.param == "psygnal":
         core._events = CMMCoreSignaler()
         core.mda._signals = MDASignaler()


### PR DESCRIPTION
we've had a couple cases where people got unexpectedly slow performance, and enabling hardware sequencing was the solution.  I think it's stable enough to make it True by default, but tests still need to enable it explicitly.

cc @simonecoppola