### PR TITLE
fix: fix typing on Signal.disconnect protocol

### DIFF
--- a/src/pymmcore_plus/core/events/_device_signal_view.py
+++ b/src/pymmcore_plus/core/events/_device_signal_view.py
@@ -1,14 +1,16 @@
-from typing import TYPE_CHECKING, Any, Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from pymmcore_plus.core import CMMCorePlus
 
-from ._prop_event_mixin import _C
+    from ._prop_event_mixin import _C
 
 
 class _DevicePropValueSignal:
     def __init__(
-        self, device_label: str, property_name: Optional[str], mmcore: "CMMCorePlus"
+        self, device_label: str, property_name: str | None, mmcore: CMMCorePlus
     ) -> None:
         self._dev = device_label
         self._prop = property_name
@@ -26,5 +28,5 @@ class _DevicePropValueSignal:
         """Emits the signal with the given arguments."""
         self._mmc.events.devicePropertyChanged(self._dev, self._prop).emit(*args)
 
-    def __call__(self, property: str) -> "_DevicePropValueSignal":
+    def __call__(self, property: str) -> _DevicePropValueSignal:
         return _DevicePropValueSignal(self._dev, property, self._mmc)

--- a/src/pymmcore_plus/core/events/_device_signal_view.py
+++ b/src/pymmcore_plus/core/events/_device_signal_view.py
@@ -18,9 +18,9 @@ class _DevicePropValueSignal:
         sig = self._mmc.events.devicePropertyChanged(self._dev, self._prop)
         return sig.connect(callback)  # type: ignore
 
-    def disconnect(self, callback: _C) -> None:
+    def disconnect(self, callback: _C | None = None) -> None:
         sig = self._mmc.events.devicePropertyChanged(self._dev, self._prop)
-        return sig.disconnect(callback)  # type: ignore
+        sig.disconnect(callback)
 
     def emit(self, *args: Any) -> Any:
         """Emits the signal with the given arguments."""

--- a/src/pymmcore_plus/core/events/_prop_event_mixin.py
+++ b/src/pymmcore_plus/core/events/_prop_event_mixin.py
@@ -64,8 +64,11 @@ class _PropertySignal:
         self._events.propertyChanged.connect(_wrapper)
         return callback
 
-    def disconnect(self, callback: Callable) -> None:
+    def disconnect(self, callback: Callable | None = None) -> None:
         """Disconnect `callback` from this device and/or property."""
+        if callback is None:
+            self._events.propertyChanged.disconnect()
+            return
         key = (self._device, self._property, normalize_slot(callback))
         cb = self._events.property_callbacks.pop(key, None)
         if cb is None:

--- a/src/pymmcore_plus/core/events/_protocol.py
+++ b/src/pymmcore_plus/core/events/_protocol.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any, Callable, Protocol, Union, runtime_checkable
+from typing import Any, Callable, Optional, Protocol, Union, runtime_checkable
 
 
 @runtime_checkable
@@ -14,7 +12,7 @@ class PSignalInstance(Protocol):
     def connect(self, slot: Callable) -> Any:
         """Connect slot to this signal."""
 
-    def disconnect(self, slot: Callable | None = None) -> Any:
+    def disconnect(self, slot: Optional[Callable] = None) -> Any:
         """Disconnect slot from this signal.
 
         If `None`, all slots should be disconnected.
@@ -28,7 +26,7 @@ class PSignalInstance(Protocol):
 class PSignalDescriptor(Protocol):
     """Descriptor that returns a signal instance."""
 
-    def __get__(self, instance: Any | None, owner: Any) -> PSignalInstance:
+    def __get__(self, instance: Optional[Any], owner: Any) -> PSignalInstance:
         """Returns the signal instance for this descriptor."""
 
 

--- a/src/pymmcore_plus/core/events/_protocol.py
+++ b/src/pymmcore_plus/core/events/_protocol.py
@@ -174,7 +174,7 @@ class PCoreSignaler(Protocol):
     """
 
     def devicePropertyChanged(
-        self, device: str, property: str | None = None
+        self, device: str, property: Optional[str] = None
     ) -> PSignalInstance:
         """Return object to connect/disconnect to device/property-specific changes.
 

--- a/src/pymmcore_plus/core/events/_protocol.py
+++ b/src/pymmcore_plus/core/events/_protocol.py
@@ -12,8 +12,11 @@ class PSignalInstance(Protocol):
     def connect(self, slot: Callable) -> Any:
         """Connect slot to this signal."""
 
-    def disconnect(self, slot: Callable) -> Any:
-        """Disconnect slot from this signal."""
+    def disconnect(self, slot: Callable | None = None) -> Any:
+        """Disconnect slot from this signal.
+
+        If `None`, all slots should be disconnected.
+        """
 
     def emit(self, *args: Any) -> Any:
         """Emits the signal with the given arguments."""

--- a/src/pymmcore_plus/core/events/_protocol.py
+++ b/src/pymmcore_plus/core/events/_protocol.py
@@ -1,4 +1,6 @@
-from typing import Any, Callable, Optional, Protocol, Union, runtime_checkable
+from __future__ import annotations
+
+from typing import Any, Callable, Protocol, Union, runtime_checkable
 
 
 @runtime_checkable
@@ -26,7 +28,7 @@ class PSignalInstance(Protocol):
 class PSignalDescriptor(Protocol):
     """Descriptor that returns a signal instance."""
 
-    def __get__(self, instance: Optional[Any], owner: Any) -> PSignalInstance:
+    def __get__(self, instance: Any | None, owner: Any) -> PSignalInstance:
         """Returns the signal instance for this descriptor."""
 
 
@@ -174,7 +176,7 @@ class PCoreSignaler(Protocol):
     """
 
     def devicePropertyChanged(
-        self, device: str, property: Optional[str] = None
+        self, device: str, property: str | None = None
     ) -> PSignalInstance:
         """Return object to connect/disconnect to device/property-specific changes.
 


### PR DESCRIPTION
This pull request includes changes to improve the flexibility of the `disconnect` method across multiple files by allowing it to accept `None` as an argument, which disconnects all slots if provided.