### PR TITLE
ci: support python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
             qt: "PyQt6"
           - platform: ubuntu-latest
             python-version: "3.12"
+          - platform: windows-latest
+            python-version: "3.13"
+            qt: "PyQt6"
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,10 +38,10 @@ dependencies = [
     "numpy >=1.17.3",
     "psygnal >=0.7",
     "pymmcore >=10.7.0.71.0",
-    "typing-extensions",      # not actually required at runtime
+    "typing-extensions",                    # not actually required at runtime
     "useq-schema >=0.4.7",
     "wrapt >=1.14",
-    "tensorstore",
+    "tensorstore; python_version < '3.13'",
     # cli requirements included by default for now
     "typer >=0.4.2",
     "rich >=10.2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
 cli = ["typer >=0.4.2", "rich >=10.2.0"]
 io = ["tifffile >=2021.6.14", "zarr >=2.2,<3"]
 test = [
-    "msgspec",
+    "msgspec; python_version < '3.13'",
     "msgpack",
     "pytest-cov >=4",
     "pytest-qt >=4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: System :: Hardware",
     "Topic :: System :: Hardware :: Hardware Drivers",
     "Topic :: Utilities",

--- a/tests/io/test_zarr_writers.py
+++ b/tests/io/test_zarr_writers.py
@@ -24,6 +24,12 @@ try:
 except ImportError:
     xr = None
 
+try:
+    import tensorstore as ts
+except ImportError:
+    ts = None
+
+requires_tensorstore = pytest.mark.skipif(not ts, reason="requires tensorstore")
 
 SIMPLE_MDA = useq.MDASequence(
     channels=["Cy5", "FITC"],
@@ -141,6 +147,7 @@ def test_ome_zarr_writer(
     assert isinstance(writer.isel(p=0, t=0, x=slice(0, 100)), np.ndarray)
 
 
+@requires_tensorstore
 @pytest.mark.parametrize("store, mda, expected_shapes", CASES)
 def test_tensorstore_writer(
     store: str | None,
@@ -183,6 +190,7 @@ def test_tensorstore_writer(
     assert x.shape[-1] == 100
 
 
+@requires_tensorstore
 def test_tensorstore_writer_spec_override(
     tmp_path: Path,
 ) -> None:
@@ -194,6 +202,7 @@ def test_tensorstore_writer_spec_override(
     assert writer.get_spec()["context"]["cache_pool"]["total_bytes_limit"] == 10000000
 
 
+@requires_tensorstore
 @pytest.mark.parametrize("dumps", ["msgspec", "std"])
 def test_tensorstore_writes_metadata(
     tmp_path: Path,
@@ -215,6 +224,7 @@ def test_tensorstore_writes_metadata(
     core.mda.run(SIMPLE_MDA, output=writer)
 
 
+@requires_tensorstore
 def test_tensorstore_writer_indeterminate(tmp_path: Path, core: CMMCorePlus) -> None:
     # FIXME: this test is actually throwing difficult-to-debug exceptions
     # when driver=='zarr'.  It happens when awaiting the result of self._store.resize()


### PR DESCRIPTION
will fail until wheels pymmcore wheels are released to pypi.  See https://github.com/micro-manager/pymmcore/pull/122