### PR TITLE
feat: add support for reset_event_timer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
           - repo: pymmcore-plus/pymmcore-widgets
             qt: "pyqt6"
           - repo: pymmcore-plus/napari-micromanager
-            qt: "pyside2"
+            qt: "pyqt6"
 
   benchmarks:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,6 @@ repos:
         files: "^src/"
         additional_dependencies:
           - pymmcore >=10.7.0.71.0
-          - useq-schema >= 0.4.7
+          - useq-schema >= 0.5.1
           - psygnal
           - typer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "psygnal >=0.7",
     "pymmcore >=10.7.0.71.0",
     "typing-extensions",      # not actually required at runtime
-    "useq-schema >=0.4.7",
+    "useq-schema >=0.5.0",
     "wrapt >=1.14",
     "tensorstore",
     # cli requirements included by default for now

--- a/src/pymmcore_plus/mda/handlers/_tensorstore_handler.py
+++ b/src/pymmcore_plus/mda/handlers/_tensorstore_handler.py
@@ -259,7 +259,7 @@ class TensorStoreHandler:
             # expand the sizes to include the largest size we encounter for each axis
             # in the case of positions with subsequences, we'll still end up with a
             # jagged array, but it won't take extra space, and we won't get index errors
-            max_sizes = seq.sizes.copy()
+            max_sizes = dict(seq.sizes)
             for psize in position_sizes(seq):
                 for k, v in psize.items():
                     max_sizes[k] = max(max_sizes.get(k, 0), v)

--- a/src/pymmcore_plus/mda/handlers/_util.py
+++ b/src/pymmcore_plus/mda/handlers/_util.py
@@ -29,7 +29,7 @@ def position_sizes(seq: useq.MDASequence) -> list[dict[str, int]]:
     `{dim: size}` pairs for each dimension in the sequence. Dimensions with no size
     will be omitted, though singletons will be included.
     """
-    main_sizes = seq.sizes.copy()
+    main_sizes = dict(seq.sizes)
     main_sizes.pop("p", None)  # remove position
 
     if not seq.stage_positions:

--- a/tests/test_mda.py
+++ b/tests/test_mda.py
@@ -407,5 +407,6 @@ def test_reset_event_timer(core: CMMCorePlus) -> None:
     meta: list[float] = []
     core.mda.events.frameReady.connect(lambda f, e, m: meta.append(m["runner_time_ms"]))
     core.mda.run(seq)
-    # ensure that the 4th event occurred at least 200ms after the 3rd event
-    assert meta[3] >= meta[2] + 200
+    # ensure that the 4th event occurred at least 190ms after the 3rd event
+    # (allow some jitter)
+    assert meta[3] >= meta[2] + 190

--- a/tests/test_mda.py
+++ b/tests/test_mda.py
@@ -395,3 +395,17 @@ def test_runner_pause(core: CMMCorePlus, qtbot: QtBot) -> None:
         thread.join()
     assert engine.setup_event.call_count == 2
     engine.teardown_sequence.assert_called_once()
+
+
+def test_reset_event_timer(core: CMMCorePlus) -> None:
+    seq = [
+        MDAEvent(min_start_time=0),
+        MDAEvent(min_start_time=0.2),
+        MDAEvent(min_start_time=0, reset_event_timer=True),
+        MDAEvent(min_start_time=0.2),
+    ]
+    meta: list[float] = []
+    core.mda.events.frameReady.connect(lambda f, e, m: meta.append(m["runner_time_ms"]))
+    core.mda.run(seq)
+    # ensure that the 4th event occurred at least 200ms after the 3rd event
+    assert meta[3] >= meta[2] + 200


### PR DESCRIPTION
closes #380 by supporting the new reset_event_timer attribute in useq schema

pre-commit will fail until useq 0.5.1 (releasing now)