### PR TITLE
Add a hint about the mmcore build-dev command

### DIFF
--- a/src/pymmcore_plus/install.py
+++ b/src/pymmcore_plus/install.py
@@ -209,7 +209,11 @@ def install(
     """
     if PLATFORM not in ("Darwin", "Windows"):  # pragma: no cover
         log_msg(f"Unsupported platform: {PLATFORM!r}", "bold red", ":x:")
-        log_msg(f"Consider building from source (mmcore build-dev).", "bold yellow", ":light_bulb:")
+        log_msg(
+            "Consider building from source (mmcore build-dev).",
+            "bold yellow",
+            ":light_bulb:",
+        )
         raise sys.exit(1)
 
     if release == "latest":

--- a/src/pymmcore_plus/install.py
+++ b/src/pymmcore_plus/install.py
@@ -209,6 +209,7 @@ def install(
     """
     if PLATFORM not in ("Darwin", "Windows"):  # pragma: no cover
         log_msg(f"Unsupported platform: {PLATFORM!r}", "bold red", ":x:")
+        log_msg(f"Consider building from source (mmcore build-dev).", "bold yellow", ":light_bulb:")
         raise sys.exit(1)
 
     if release == "latest":


### PR DESCRIPTION
When `mmcore build` fails due to unsupported platform (e.g. Linux), give a hint that the `mmcore build-dev` command also exists to build Micro-Manager from source.
