### PR TITLE
feat: use rich for logging if available

### DIFF
--- a/src/pymmcore_plus/_logger.py
+++ b/src/pymmcore_plus/_logger.py
@@ -118,9 +118,17 @@ def configure_logging(
 
     # automatically log to stderr
     if log_to_stderr and sys.stderr:
-        stderr_handler = logging.StreamHandler(sys.stderr)
+        # try to use rich for stderr logging
+        # fallback to plain text if rich is not installed
+        try:
+            from rich.logging import RichHandler
+
+            stderr_handler: logging.Handler = RichHandler()
+        except ImportError:
+            stderr_handler = logging.StreamHandler(sys.stderr)
+            stderr_handler.setFormatter(CustomFormatter())
+
         stderr_handler.setLevel(stderr_level)
-        stderr_handler.setFormatter(CustomFormatter())
         logger.addHandler(stderr_handler)
 
     # automatically log to file


### PR DESCRIPTION
This PR checks if rich is installed (and it will be if the cli is also installed) and uses it to make much nicer colored logs.  Its a nicer/lighter solution than the original loguru thing that was removed in #239

without rich:

<img width="1227" alt="Screenshot 2024-11-03 at 8 10 52 AM" src="https://github.com/user-attachments/assets/4ea840e1-3ce6-41f5-8995-db5fd877262a">

with rich:

<img width="1225" alt="Screenshot 2024-11-03 at 8 11 01 AM" src="https://github.com/user-attachments/assets/c8522324-4af0-48bb-9104-dc42893b40c8">
