### PR TITLE
test: fix tests by pinning pyside<6.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
           - platform: macos-13
             python-version: "3.11"
             qt: "PyQt6"
+          - platform: windows-latest
+            python-version: "3.12"
+            qt: "PyQt6"
           - platform: ubuntu-latest
             python-version: "3.12"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,14 +42,13 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        shell: bash
         run: |
           python -m pip install --upgrade pip
-          if {{ matrix.qt }}; then
-            python -m pip install -e .[test,${{ matrix.qt }}]
-          else
-            python -m pip install -e .[test]
-          fi
+          python -m pip install -e .[test]
+
+      - name: Install Qt
+        if: matrix.qt
+        run: pip install -e .[${{ matrix.qt }}]
 
       - name: Set cache path
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   test:
-    name: ${{ matrix.platform }} py${{ matrix.python-version }}
+    name: ${{ matrix.platform }} py${{ matrix.python-version }} ${{ matrix.qt }}
     runs-on: ${{ matrix.platform }}
     strategy:
       fail-fast: false
@@ -42,9 +42,14 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
+        shell: bash
         run: |
           python -m pip install --upgrade pip
-          pip install -e .[test]
+          if {{ matrix.qt }}; then
+            python -m pip install -e .[test,${{ matrix.qt }}]
+          else
+            python -m pip install -e .[test]
+          fi
 
       - name: Set cache path
         shell: bash
@@ -52,14 +57,6 @@ jobs:
           set -e
           CACHE_PATH=$(python -c 'from pymmcore_plus import install; print(install.USER_DATA_MM_PATH)')
           echo "CACHE_PATH=$CACHE_PATH" >> $GITHUB_ENV
-
-      - name: Install  ${{ matrix.qt }}
-        if: ${{ matrix.qt }}
-        run: pip install ${{ matrix.qt }}
-
-      - name: Downgrade pydantic
-        if: ${{ matrix.pydantic }}
-        run: pip install ${{ matrix.pydantic }}
 
       - name: Cache Drivers
         id: cache-mm-build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,10 @@ dependencies = [
 [project.optional-dependencies]
 cli = ["typer >=0.4.2", "rich >=10.2.0"]
 io = ["tifffile >=2021.6.14", "zarr >=2.2,<3"]
+PySide2 = ["PySide2 >=5.15.4"]
+PySide6 = ["PySide6 >=6.4.0,<6.8"]
+PyQt5 = ["PyQt5 >=5.15.4"]
+PyQt6 = ["PyQt6 >=6.4.2,<6.8"]
 test = [
     "msgspec",
     "msgpack",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
 [project.optional-dependencies]
 cli = ["typer >=0.4.2", "rich >=10.2.0"]
 io = ["tifffile >=2021.6.14", "zarr >=2.2,<3"]
-PySide2 = ["PySide2 >=5.15.4"]
+PySide2 = ["PySide2 >=5.15"]
 PySide6 = ["PySide6 >=6.4.0,<6.8"]
 PyQt5 = ["PyQt5 >=5.15.4"]
 PyQt6 = ["PyQt6 >=6.4.2,<6.8"]

--- a/src/pymmcore_plus/mda/handlers/_tensorstore_handler.py
+++ b/src/pymmcore_plus/mda/handlers/_tensorstore_handler.py
@@ -9,6 +9,8 @@ from itertools import product
 from os import PathLike
 from typing import TYPE_CHECKING, Any, cast
 
+import numpy as np
+
 from pymmcore_plus.metadata.serialize import json_dumps, json_loads
 
 from ._util import position_sizes
@@ -17,7 +19,6 @@ if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
     from typing import Literal, TypeAlias
 
-    import numpy as np
     import tensorstore as ts
     import useq
     from typing_extensions import Self  # py311
@@ -234,7 +235,10 @@ class TensorStoreHandler:
         # FIXME: will fail on slices
         indexers = {**(indexers or {}), **indexers_kwargs}
         ts_index = self._event_index_to_store_index(indexers)
-        return self._store[ts_index].read().result().squeeze()  # type: ignore
+        if self._store is None:
+            warnings.warn("No data written.", stacklevel=2)
+            return np.empty([])
+        return self._store[ts_index].read().result().squeeze()  # type: ignore [no-any-return]
 
     def new_store(
         self, frame: np.ndarray, seq: useq.MDASequence | None, meta: FrameMetaV1

--- a/src/pymmcore_plus/mda/handlers/_tensorstore_handler.py
+++ b/src/pymmcore_plus/mda/handlers/_tensorstore_handler.py
@@ -235,7 +235,7 @@ class TensorStoreHandler:
         # FIXME: will fail on slices
         indexers = {**(indexers or {}), **indexers_kwargs}
         ts_index = self._event_index_to_store_index(indexers)
-        if self._store is None:
+        if self._store is None:  # pragma: no cover
             warnings.warn("No data written.", stacklevel=2)
             return np.empty([])
         return self._store[ts_index].read().result().squeeze()  # type: ignore [no-any-return]

--- a/src/pymmcore_plus/metadata/functions.py
+++ b/src/pymmcore_plus/metadata/functions.py
@@ -8,9 +8,8 @@ from pymmcore_plus._util import timestamp
 from pymmcore_plus.core._constants import DeviceType, PixelFormat
 
 if TYPE_CHECKING:
-    from typing import Unpack
-
     import useq
+    from typing_extensions import Unpack
 
     from pymmcore_plus.core import CMMCorePlus
 


### PR DESCRIPTION
It looks like something about Qt6.8 has broken the MDARelayThread pattern in the context of Qt signals.  Specifically, this connection here never gets triggered when the Sequence starts:

https://github.com/pymmcore-plus/pymmcore-plus/blob/8ebd4743b5ca10f4ccf055cafe11a0270600f4d9/src/pymmcore_plus/mda/_thread_relay.py#L86

not sure what changed in 6.8, but for now this just pins the version of pyside6 in testing by adding an extra