### PR TITLE
perf: don't query position on triggered acquisition frames by default, add `include_frame_position_metadata` flag

### DIFF
--- a/src/pymmcore_plus/mda/_engine.py
+++ b/src/pymmcore_plus/mda/_engine.py
@@ -92,7 +92,7 @@ class MDAEngine(PMDAEngine):
 
     @include_frame_position_metadata.setter
     def include_frame_position_metadata(self, value: IncludePositionArg) -> None:
-        if value not in (True, False, "unsequenced-only"):
+        if value not in (True, False, "unsequenced-only"):  # pragma: no cover
             raise ValueError(
                 "include_frame_position_metadata must be True, False, or "
                 "'unsequenced-only'"

--- a/src/pymmcore_plus/metadata/schema.py
+++ b/src/pymmcore_plus/metadata/schema.py
@@ -430,14 +430,15 @@ class FrameMetaV1(TypedDict):
         The label of the camera device used to acquire the image.
     exposure_ms: float
         The exposure time in milliseconds.
-    position: Position
-        The current stage position(s) in 3D space.
     property_values: tuple[PropertyValue, ...]
         Device property settings.  This is not a comprehensive list of all device
         properties, but only those that may have changed for this frame (such as
         properties in the channel config or light path config).
     runner_time_ms: float
         Elapsed time in milliseconds since the beginning of the MDA sequence.
+    position: Position
+        *NotRequired*. The current stage position(s) in 3D space.  This is often slow
+        to retrieve, so its inclusion is optional and left to the implementer.
     mda_event: useq.MDAEvent
         *NotRequired*. The MDA event object that commanded the acquisition of this
         frame.
@@ -461,9 +462,9 @@ class FrameMetaV1(TypedDict):
     pixel_size_um: float
     camera_device: Optional[str]
     exposure_ms: float
-    position: Position
     property_values: tuple[PropertyValue, ...]
     runner_time_ms: float
+    position: NotRequired[Position]
     mda_event: NotRequired[useq.MDAEvent]
     hardware_triggered: NotRequired[bool]
     images_remaining_in_buffer: NotRequired[int]

--- a/tests/test_sequencing.py
+++ b/tests/test_sequencing.py
@@ -93,6 +93,9 @@ def test_fully_sequenceable_core() -> None:
     core_mock.getRemainingImageCount.return_value = 0
     core_mock.isBufferOverflowed.return_value = False
     core_mock.getCameraDevice.return_value = CAM
+    core_mock.getXYPosition.return_value = (0, 0)
+    core_mock.getXPosition.return_value = 0
+    core_mock.getYPosition.return_value = 0
     core_mock.getXYStageDevice.return_value = XYSTAGE
     core_mock.getFocusDevice.return_value = FOCUS
     core_mock.getFocusDevice.return_value = FOCUS


### PR DESCRIPTION
This PR makes it so that the MDAEngine doesn't query stage positions during sequenced/triggered acquisitions by default.  This can be a rather slow call, depending on the stage, and ultimately was at the heart of @simonecoppola's performance issues seen in https://github.com/pymmcore-plus/pymmcore-plus/issues/379 (thank you **SO** much Simone for debugging that).

this PR adds:

```python
MDAEngine:
    include_frame_position_metadata: Literal[True, False, "unsequenced-only"] = "unsequenced-only"
```

which gate whether or not we ask for position.  This is not a "generalizable" solution, as was discussed at the end of #358 (in that it doesn't add a more generic pattern for pruning metadata as desired), but it gets something down for now.

note that `FrameMetaV1.position` now becomes an `NotRequired[Position]`

Note: an elaboration here, should anyone *really* want position information during sequenced acquisitions, is to check whether the `SequencedEvent` itself is changing XYZ during the sequence (right around [here](https://github.com/pymmcore-plus/pymmcore-plus/blob/0f39fb39ab039330986f4b49b7231bd64142ed8a/src/pymmcore_plus/mda/_engine.py#L426-L438))... and if not, just query the position once at the beginning, and use the same position metadata for all the frames (rather than re-querying non-changing information)

fixes #379 