### PR TITLE
feat: enhance describe method to include configuration groups and available devices

### DIFF
--- a/src/pymmcore_plus/_util.py
+++ b/src/pymmcore_plus/_util.py
@@ -418,13 +418,10 @@ def _sorted_rows(data: dict, sort: str | None) -> list[tuple]:
     """Return a list of rows, sorted by the given column name."""
     rows = list(zip(*data.values()))
     if sort is not None:
-        try:
+        with suppress(ValueError):
+            # silently ignore if the sort column is not found
             sort_idx = [x.lower() for x in data].index(sort.lower())
-        except ValueError:  # pragma: no cover
-            raise ValueError(
-                f"invalid sort column: {sort!r}. Must be one of {list(data)}"
-            ) from None
-        rows.sort(key=lambda x: x[sort_idx])
+            rows.sort(key=lambda x: x[sort_idx])
     return rows
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -543,7 +543,7 @@ def test_describe(
 
         monkeypatch.setattr(builtins, "__import__", no_rich)
 
-    core.describe(sort="Type")
+    core.describe(sort="Type", show_available=True, show_config_groups=True)
     assert "Core" in capsys.readouterr().out
 
 


### PR DESCRIPTION
Extends the `describe()` method to show more stuff

```python
core.describe(show_config_groups=True)
```
<img width="752" alt="Screenshot 2024-12-16 at 11 41 56 AM" src="https://github.com/user-attachments/assets/dafadde4-bcc1-4574-92ad-eb5bc67d4061" />


```python
core.describe( show_available=True)
```
<img width="1100" alt="Screenshot 2024-12-16 at 11 42 33 AM" src="https://github.com/user-attachments/assets/b8e263b5-2547-4311-9a74-7e4bb8e148d0" />
