### PR TITLE
feat: Add `mmcore bench` to CLI

### DIFF
--- a/src/pymmcore_plus/_benchmark.py
+++ b/src/pymmcore_plus/_benchmark.py
@@ -1,18 +1,25 @@
 import timeit
 from collections.abc import Iterable
+from types import NoneType
 
 from pymmcore_plus import CMMCorePlus, DeviceType
+from pymmcore_plus.core._device import Device
 
 
 class Benchmark:
     device_type = DeviceType.Camera
 
-    def __init__(self, core: CMMCorePlus, label: str) -> None:
+    def __init__(self, core: CMMCorePlus, label: str = "") -> None:
         self.core = core
         self.label = label
 
     def setup(self) -> None:
         pass
+
+    def device(self) -> Device | None:
+        if self.label is not None:
+            return self.core.getDeviceObject(self.label)
+        return None
 
     def run(self, number: int) -> dict[str, float | str]:
         data: dict[str, float | str] = {}
@@ -30,6 +37,19 @@ class Benchmark:
                 result = str(e)
             data[method_name[6:]] = result
         return data
+
+
+class CoreBenchmark(Benchmark):
+    device_type = DeviceType.Core
+
+    def bench_getDeviceAdapterNames(self) -> None:
+        self.core.getDeviceAdapterNames()
+
+    def bench_getLoadedDevices(self) -> None:
+        self.core.getLoadedDevices()
+
+    def bench_getSystemState(self) -> None:
+        self.core.getSystemState()
 
 
 class CameraBenchmark(Benchmark):
@@ -92,6 +112,9 @@ class XYStageBenchmark(Benchmark):
     def bench_setRelativeXYPosition(self) -> None:
         self.core.setRelativeXYPosition(self.label, 0, 0)
 
+    def bench_isXYStageSequenceable(self) -> None:
+        self.core.isXYStageSequenceable(self.label)
+
 
 class StageBenchmark(Benchmark):
     device_type = DeviceType.Stage
@@ -105,32 +128,54 @@ class StageBenchmark(Benchmark):
     def bench_setPosition(self) -> None:
         self.core.setPosition(self.label, self.position)
 
+    def bench_setRelativePosition(self) -> None:
+        self.core.setRelativePosition(self.label, 0)
 
-class CoreBenchmark(Benchmark):
-    device_type = DeviceType.Core
+    def bench_isStageSequenceable(self) -> None:
+        self.core.isStageSequenceable(self.label)
 
-    def bench_getDeviceAdapterNames(self) -> None:
-        self.core.getDeviceAdapterNames()
+    def bench_isStageLinearSequenceable(self) -> None:
+        self.core.isStageLinearSequenceable(self.label)
 
-    def bench_getLoadedDevices(self) -> None:
-        self.core.getLoadedDevices()
 
-    def bench_getSystemState(self) -> None:
-        self.core.getSystemState()
+class StateBenchmark(Benchmark):
+    device_type = DeviceType.State
+
+    def setup(self) -> None:
+        self.initial_state = self.core.getState(self.label)
+        self.labels = self.core.getStateLabels(self.label)
+
+    def bench_getState(self) -> None:
+        self.core.getState(self.label)
+
+    def bench_setState(self) -> None:
+        self.core.setState(self.label, self.initial_state)
+
+    def bench_getNumberOfStates(self) -> None:
+        self.core.getNumberOfStates(self.label)
+
+    def bench_getStateLabel(self) -> None:
+        self.core.getStateLabel(self.label)
+
+    def bench_getStateFromLabel(self) -> None:
+        for label in self.labels:
+            self.core.getStateFromLabel(self.label, label)
 
 
 def benchmark_core_and_devices(
     core: CMMCorePlus, number: int = 100
-) -> Iterable[tuple[str, dict[str, float | str]]]:
+) -> Iterable[Device | None | tuple[str, dict[str, float | str]]]:
     """Take an initialized core with devices and benchmark various methods."""
     for cls in Benchmark.__subclasses__():
         if cls.device_type == DeviceType.Core:
             bench = cls(core, "Core")
+            yield bench.device()
             bench.setup()
             yield "Core", bench.run(number)
         else:
             for dev in core.getLoadedDevicesOfType(cls.device_type):
                 bench = cls(core, dev)
+                yield bench.device()
                 bench.setup()
                 yield dev, bench.run(number)
 
@@ -176,4 +221,4 @@ if __name__ == "__main__":
     else:
         number = 1000
     data = benchmark_core_and_devices(core, number)
-    print_benchmarks(dict(data))
+    print_benchmarks(dict(x for x in data if not isinstance(x, (Device, NoneType))))

--- a/src/pymmcore_plus/_benchmark.py
+++ b/src/pymmcore_plus/_benchmark.py
@@ -1,0 +1,89 @@
+import timeit
+
+from pymmcore import CMMCore
+
+
+def benchmark_core(core: CMMCore, number: int = 1000) -> dict:
+    """Take an initialized core with devices and benchmark various methods."""
+    data: dict[str, float | str] = {}
+    core.setExposure(1)
+    methods: list[str | tuple[str, tuple]] = [
+        "getDeviceAdapterNames",
+        "getLoadedDevices",
+        "getSystemState",
+        "getCurrentPixelSizeConfig",
+        "getAvailablePixelSizeConfigs",
+        "getPixelSizeUm",
+        "getPixelSizeAffine",
+        "getMagnificationFactor",
+    ]
+
+    if cam := core.getCameraDevice():
+        methods.extend(
+            [
+                "getMultiROI",
+                "getExposure",
+                "snapImage",
+                "getImage",
+                "getImageWidth",
+                "getImageHeight",
+                "getImageBufferSize",
+                "getImageBitDepth",
+                "getNumberOfComponents",
+                "getNumberOfCameraChannels",
+                # "getAutoShutter",
+                # "getShutterOpen",
+                ("prepareSequenceAcquisition", (cam,)),
+                # "getRemainingImageCount",
+                # "getBufferTotalCapacity",
+                # "getBufferFreeCapacity",
+                # "isBufferOverflowed",
+                # "getCircularBufferMemoryFootprint",
+                # ("isExposureSequenceable", (cam,)),
+                # ("getExposureSequenceMaxLength", (cam,)),
+            ]
+        )
+
+    if xystage := core.getXYStageDevice():
+        methods.extend(
+            [
+                "getXYPosition",
+                "getXPosition",
+                "getYPosition",
+                ("setXYPosition", (xystage, *core.getXYPosition(xystage))),
+                # ("home", (xystage,)),
+                # ("stop", (xystage,)),
+            ]
+        )
+
+    if zstage := core.getFocusDevice():
+        methods.extend(
+            [
+                "getPosition",
+                ("setPosition", (zstage, core.getPosition(zstage))),
+            ]
+        )
+    if pxcfgs := core.getAvailablePixelSizeConfigs():
+        methods.append(("getPixelSizeConfigData", (pxcfgs[0],)))
+    for item in methods:
+        if isinstance(item, tuple):
+            meth, args = item
+        else:
+            meth, args = item, ()
+        try:
+            t = timeit.timeit(f"core.{meth}(*{args})", globals=locals(), number=number)
+            data[meth] = round(1000 * t / number, 4)
+        except Exception as e:
+            data[meth] = str(e)
+
+    return data
+
+
+if __name__ == "__main__":
+    from rich import print
+
+    from pymmcore_plus.core._mmcore_plus import CMMCorePlus
+
+    core = CMMCorePlus()
+    core.loadSystemConfiguration()
+    print(benchmark_core(core))

--- a/src/pymmcore_plus/_benchmark.py
+++ b/src/pymmcore_plus/_benchmark.py
@@ -1,99 +1,144 @@
 import timeit
-import warnings
-from collections.abc import Iterable
 
-from pymmcore import CMMCore
-
-try:
-    from tqdm import tqdm
-except ImportError:
-
-    def tqdm(iterable: Iterable) -> Iterable:
-        return iterable
+from pymmcore_plus import CMMCorePlus, DeviceType
 
 
-def benchmark_core(core: CMMCore, number: int = 1000) -> dict:
+class Benchmark:
+    device_type = DeviceType.Camera
+
+    def __init__(self, core: CMMCorePlus, label: str) -> None:
+        self.core = core
+        self.label = label
+
+    def setup(self) -> None:
+        pass
+
+    def run(self, number: int) -> dict[str, float | str]:
+        data: dict[str, float | str] = {}
+
+        # get methods in the order of definition, in reverse MRO order
+        methods: list[str] = []
+        for base in reversed(type(self).mro()):
+            methods.extend(m for m in base.__dict__ if m.startswith("bench_"))
+
+        for method_name in methods:
+            try:
+                t = timeit.timeit(getattr(self, method_name), number=number)
+                result: float | str = round(1000 * t / number, 3)
+            except Exception as e:
+                result = str(e)
+            data[method_name[6:]] = result
+        return data
+
+
+class CameraBenchmark(Benchmark):
+    device_type = DeviceType.Camera
+
+    def setup(self) -> None:
+        self.core.setCameraDevice(self.label)
+        self.core.setExposure(self.label, 1)
+
+    def bench_getMultiROI(self) -> None:
+        self.core.getMultiROI()
+
+    def bench_getExposure(self) -> None:
+        self.core.getExposure(self.label)
+
+    def bench_snapImage(self) -> None:
+        self.core.snapImage()
+
+    def bench_getImage(self) -> None:
+        self.core.getImage()
+
+    def bench_getImageWidth(self) -> None:
+        self.core.getImageWidth()
+
+    def bench_getImageHeight(self) -> None:
+        self.core.getImageHeight()
+
+    def bench_getImageBufferSize(self) -> None:
+        self.core.getImageBufferSize()
+
+    def bench_getImageBitDepth(self) -> None:
+        self.core.getImageBitDepth()
+
+    def bench_getNumberOfComponents(self) -> None:
+        self.core.getNumberOfComponents()
+
+    def bench_getNumberOfCameraChannels(self) -> None:
+        self.core.getNumberOfCameraChannels()
+
+
+class XYStageBenchmark(Benchmark):
+    device_type = DeviceType.XYStage
+
+    def setup(self) -> None:
+        self.core.setXYStageDevice(self.label)
+        self.position = self.core.getXYPosition(self.label)
+
+    def bench_getXYPosition(self) -> None:
+        self.core.getXYPosition(self.label)
+
+    def bench_getXPosition(self) -> None:
+        self.core.getXPosition(self.label)
+
+    def bench_getYPosition(self) -> None:
+        self.core.getYPosition(self.label)
+
+    def bench_setXYPosition(self) -> None:
+        self.core.setXYPosition(self.label, *self.position)
+
+    def bench_setRelativeXYPosition(self) -> None:
+        self.core.setRelativeXYPosition(self.label, 0, 0)
+
+
+class StageBenchmark(Benchmark):
+    device_type = DeviceType.Stage
+
+    def setup(self) -> None:
+        self.position = self.core.getPosition(self.label)
+
+    def bench_getPosition(self) -> None:
+        self.core.getPosition(self.label)
+
+    def bench_setPosition(self) -> None:
+        self.core.setPosition(self.label, self.position)
+
+
+class CoreBenchmark(Benchmark):
+    device_type = DeviceType.Core
+
+    def bench_getDeviceAdapterNames(self) -> None:
+        self.core.getDeviceAdapterNames()
+
+    def bench_getLoadedDevices(self) -> None:
+        self.core.getLoadedDevices()
+
+    def bench_getSystemState(self) -> None:
+        self.core.getSystemState()
+
+
+def benchmark_core_and_devices(
+    core: CMMCorePlus, number: int = 100
+) -> dict[str, dict[str, float | str]]:
     """Take an initialized core with devices and benchmark various methods."""
-    data: dict[str, float | str] = {}
-    methods: list[str | tuple[str, tuple]] = [
-        "getDeviceAdapterNames",
-        "getLoadedDevices",
-        "getSystemState",
-        "getCurrentPixelSizeConfig",
-        "getAvailablePixelSizeConfigs",
-        "getPixelSizeUm",
-        "getPixelSizeAffine",
-        "getMagnificationFactor",
-    ]
+    data: dict[str, dict[str, float | str]] = {}
 
-    if cam := core.getCameraDevice():
-        core.setExposure(1)
-        if not (exp := core.getExposure()) == 1:
-            warnings.warn(
-                f"Exposure setting failed, real exposure: {exp}", stacklevel=2
-            )
-        methods.extend(
-            [
-                "getMultiROI",
-                "getExposure",
-                "snapImage",
-                "getImage",
-                "getImageWidth",
-                "getImageHeight",
-                "getImageBufferSize",
-                "getImageBitDepth",
-                "getNumberOfComponents",
-                "getNumberOfCameraChannels",
-                # "getAutoShutter",
-                # "getShutterOpen",
-                ("prepareSequenceAcquisition", (cam,)),
-                # "getRemainingImageCount",
-                # "getBufferTotalCapacity",
-                # "getBufferFreeCapacity",
-                # "isBufferOverflowed",
-                # "getCircularBufferMemoryFootprint",
-                # ("isExposureSequenceable", (cam,)),
-                # ("getExposureSequenceMaxLength", (cam,)),
-            ]
-        )
-
-    if xystage := core.getXYStageDevice():
-        methods.extend(
-            [
-                "getXYPosition",
-                "getXPosition",
-                "getYPosition",
-                ("setXYPosition", (xystage, *core.getXYPosition(xystage))),
-                # ("home", (xystage,)),
-                # ("stop", (xystage,)),
-            ]
-        )
-
-    if zstage := core.getFocusDevice():
-        methods.extend(
-            [
-                "getPosition",
-                ("setPosition", (zstage, core.getPosition(zstage))),
-            ]
-        )
-
-    if pxcfgs := core.getAvailablePixelSizeConfigs():
-        methods.append(("getPixelSizeConfigData", (pxcfgs[0],)))
-    for item in tqdm(methods):
-        if isinstance(item, tuple):
-            meth, args = item
+    for cls in Benchmark.__subclasses__():
+        if cls.device_type == DeviceType.Core:
+            bench = cls(core, "Core")
+            bench.setup()
+            data["Core"] = bench.run(number)
         else:
-            meth, args = item, ()
-        try:
-            t = timeit.timeit(f"core.{meth}(*{args})", globals=locals(), number=number)
-            data[meth] = round(1000 * t / number, 3)
-        except Exception as e:
-            data[meth] = str(e)
+            for dev in core.getLoadedDevicesOfType(cls.device_type):
+                bench = cls(core, dev)
+                bench.setup()
+                data[dev] = bench.run(number)
 
     return data
 
 
-def print_benchmarks(data: dict[str, float | str]) -> None:
+def print_benchmarks(data: dict[str, dict[str, float | str]]) -> None:
     """Print the benchmark results in a human-readable format."""
     try:
         from rich.console import Console
@@ -102,10 +147,12 @@ def print_benchmarks(data: dict[str, float | str]) -> None:
         table = Table(title="Benchmark results")
         table.add_column("Method", justify="right", style="green")
         table.add_column("Time (ms)", justify="right")
-        for method, time in data.items():
-            if isinstance(time, float):
-                time = f"{time:.4f}"
-            table.add_row(method, str(time))
+        for device, benches in data.items():
+            table.add_row(f"Device: {device}", "------", style="yellow")
+            for method, time in benches.items():
+                if isinstance(time, float):
+                    time = f"{time:.4f}"
+                table.add_row(method, str(time))
 
         console = Console()
         console.print(table)
@@ -131,5 +178,5 @@ if __name__ == "__main__":
         number = int(sys.argv[2])
     else:
         number = 1000
-    data = benchmark_core(core, number)
+    data = benchmark_core_and_devices(core, number)
     print_benchmarks(data)

--- a/src/pymmcore_plus/_benchmark.py
+++ b/src/pymmcore_plus/_benchmark.py
@@ -93,6 +93,26 @@ def benchmark_core(core: CMMCore, number: int = 1000) -> dict:
     return data
 
 
+def print_benchmarks(data: dict[str, float | str]) -> None:
+    """Print the benchmark results in a human-readable format."""
+    try:
+        from rich.console import Console
+        from rich.table import Table
+
+        table = Table(title="Benchmark results")
+        table.add_column("Method", justify="right", style="green")
+        table.add_column("Time (ms)", justify="right")
+        for method, time in data.items():
+            if isinstance(time, float):
+                time = f"{time:.4f}"
+            table.add_row(method, str(time))
+
+        console = Console()
+        console.print(table)
+    except ImportError:
+        print(data)
+
+
 if __name__ == "__main__":
     import sys
 
@@ -112,20 +132,4 @@ if __name__ == "__main__":
     else:
         number = 1000
     data = benchmark_core(core, number)
-
-    try:
-        from rich.console import Console
-        from rich.table import Table
-
-        table = Table(title="Benchmark results")
-        table.add_column("Method", justify="right", style="green")
-        table.add_column("Time (ms)", justify="right")
-        for method, time in data.items():
-            if isinstance(time, float):
-                time = f"{time:.4f}"
-            table.add_row(method, str(time))
-
-        console = Console()
-        console.print(table)
-    except ImportError:
-        print(data)
+    print_benchmarks(data)

--- a/src/pymmcore_plus/_benchmark.py
+++ b/src/pymmcore_plus/_benchmark.py
@@ -80,10 +80,15 @@ def benchmark_core(core: CMMCore, number: int = 1000) -> dict:
 
 
 if __name__ == "__main__":
+    import sys
+
     from rich import print
 
     from pymmcore_plus.core._mmcore_plus import CMMCorePlus
 
     core = CMMCorePlus()
-    core.loadSystemConfiguration()
+    if len(sys.argv) > 1:
+        core.loadSystemConfiguration(sys.argv[1])
+    else:
+        core.loadSystemConfiguration()
     print(benchmark_core(core))

--- a/src/pymmcore_plus/_benchmark.py
+++ b/src/pymmcore_plus/_benchmark.py
@@ -1,4 +1,5 @@
 import timeit
+from collections.abc import Iterable
 
 from pymmcore_plus import CMMCorePlus, DeviceType
 
@@ -120,22 +121,18 @@ class CoreBenchmark(Benchmark):
 
 def benchmark_core_and_devices(
     core: CMMCorePlus, number: int = 100
-) -> dict[str, dict[str, float | str]]:
+) -> Iterable[tuple[str, dict[str, float | str]]]:
     """Take an initialized core with devices and benchmark various methods."""
-    data: dict[str, dict[str, float | str]] = {}
-
     for cls in Benchmark.__subclasses__():
         if cls.device_type == DeviceType.Core:
             bench = cls(core, "Core")
             bench.setup()
-            data["Core"] = bench.run(number)
+            yield "Core", bench.run(number)
         else:
             for dev in core.getLoadedDevicesOfType(cls.device_type):
                 bench = cls(core, dev)
                 bench.setup()
-                data[dev] = bench.run(number)
-
-    return data
+                yield dev, bench.run(number)
 
 
 def print_benchmarks(data: dict[str, dict[str, float | str]]) -> None:
@@ -179,4 +176,4 @@ if __name__ == "__main__":
     else:
         number = 1000
     data = benchmark_core_and_devices(core, number)
-    print_benchmarks(data)
+    print_benchmarks(dict(data))

--- a/src/pymmcore_plus/_benchmark.py
+++ b/src/pymmcore_plus/_benchmark.py
@@ -1,7 +1,11 @@
 import timeit
 
 from pymmcore import CMMCore
-
+try:
+    from tqdm import tqdm
+except ImportError:
+    def tqdm(iterable, *args, **kwargs):
+        return iterable
 
 def benchmark_core(core: CMMCore, number: int = 1000) -> dict:
     """Take an initialized core with devices and benchmark various methods."""
@@ -65,7 +69,7 @@ def benchmark_core(core: CMMCore, number: int = 1000) -> dict:
         )
     if pxcfgs := core.getAvailablePixelSizeConfigs():
         methods.append(("getPixelSizeConfigData", (pxcfgs[0],)))
-    for item in methods:
+    for item in tqdm(methods):
         if isinstance(item, tuple):
             meth, args = item
         else:
@@ -88,7 +92,13 @@ if __name__ == "__main__":
 
     core = CMMCorePlus()
     if len(sys.argv) > 1:
+        print("Loading system configuration from", sys.argv[1])
         core.loadSystemConfiguration(sys.argv[1])
     else:
+        print("using demo configuration")
         core.loadSystemConfiguration()
-    print(benchmark_core(core))
+    if len(sys.argv) > 2:
+        number = int(sys.argv[2])
+    else:
+        number = 1000
+    print(benchmark_core(core, number))

--- a/src/pymmcore_plus/_cli.py
+++ b/src/pymmcore_plus/_cli.py
@@ -435,12 +435,14 @@ def _tail_file(file_path: Union[str, Path], interval: float = 0.1) -> None:
 
 
 @app.command()
-def benchmark(
+def bench(
     config: Optional[Path] = CONFIG_PARAM,
-    number: int = typer.Option(100, help="Number of iterations for each test."),
+    number: int = typer.Option(
+        100, "-n", "--number", help="Number of iterations for each test."
+    ),
 ) -> None:
-    """Run a benchmark of the Micro-Manager API."""
-    from pymmcore_plus._benchmark import benchmark_core, print_benchmarks
+    """Run a benchmark of Core and Devices loaded with `config` (or Demo)."""
+    from pymmcore_plus._benchmark import benchmark_core_and_devices, print_benchmarks
 
     core = CMMCorePlus()
     if config is not None:
@@ -448,7 +450,7 @@ def benchmark(
     else:
         core.loadSystemConfiguration()
 
-    data = benchmark_core(core, number)
+    data = benchmark_core_and_devices(core, number)
     print_benchmarks(data)
 
 

--- a/src/pymmcore_plus/_cli.py
+++ b/src/pymmcore_plus/_cli.py
@@ -462,8 +462,9 @@ def bench(
             table.add_row(f"Device: {device}", "------", style="yellow")
             for method, time in data.items():
                 if isinstance(time, float):
-                    time = f"{time:.4f}"
-                table.add_row(method, str(time))
+                    table.add_row(method, f"{time:.4f}")
+                else:
+                    table.add_row(method, str(time), style="red")
 
 
 def main() -> None:  # pragma: no cover

--- a/src/pymmcore_plus/_cli.py
+++ b/src/pymmcore_plus/_cli.py
@@ -442,7 +442,7 @@ def bench(
     ),
 ) -> None:
     """Run a benchmark of Core and Devices loaded with `config` (or Demo)."""
-    from pymmcore_plus._benchmark import benchmark_core_and_devices, print_benchmarks
+    from pymmcore_plus._benchmark import benchmark_core_and_devices
 
     core = CMMCorePlus()
     if config is not None:
@@ -450,8 +450,20 @@ def bench(
     else:
         core.loadSystemConfiguration()
 
-    data = benchmark_core_and_devices(core, number)
-    print_benchmarks(data)
+    from rich.live import Live
+    from rich.table import Table
+
+    table = Table()
+    table.add_column("Method")
+    table.add_column("Time (ms)")
+
+    with Live(table, refresh_per_second=4):  # update 4 times a second to feel fluid
+        for device, data in benchmark_core_and_devices(core, number):
+            table.add_row(f"Device: {device}", "------", style="yellow")
+            for method, time in data.items():
+                if isinstance(time, float):
+                    time = f"{time:.4f}"
+                table.add_row(method, str(time))
 
 
 def main() -> None:  # pragma: no cover

--- a/src/pymmcore_plus/_cli.py
+++ b/src/pymmcore_plus/_cli.py
@@ -473,7 +473,7 @@ def bench(
             if item is None:
                 table.add_row("Device: Core", "------", style="yellow")
             elif isinstance(item, Device):
-                console.log(
+                console.print(
                     f"Measuring ({item.type()}) Device: "
                     f"{item.label!r} <{item.library()}::{item.name()}>"
                     f": {item.description()}",

--- a/src/pymmcore_plus/_cli.py
+++ b/src/pymmcore_plus/_cli.py
@@ -443,23 +443,27 @@ def bench(
     ),
 ) -> None:
     """Run a benchmark of Core and Devices loaded with `config` (or Demo)."""
-    from pymmcore_plus._benchmark import benchmark_core_and_devices
-
-    core = CMMCorePlus()
-    if config is not None:
-        typer.secho(
-            f"Loading system configuration from {config}", fg=typer.colors.BRIGHT_BLUE
-        )
-        core.loadSystemConfiguration(str(config))
-    else:
-        typer.secho("Loading DEMO configuration", fg=typer.colors.BRIGHT_BLUE)
-        core.loadSystemConfiguration()
-
     from rich.console import Console
     from rich.live import Live
     from rich.table import Table
 
+    from pymmcore_plus._benchmark import benchmark_core_and_devices
+
     console = Console()
+
+    core = CMMCorePlus()
+    if config is not None:
+        console.log(
+            f"Loading config {config} ...",
+            style="bright_blue",
+            end="",
+        )
+        core.loadSystemConfiguration(str(config))
+    else:
+        console.log("Loading DEMO configuration ...", style="bright_blue", end="")
+        core.loadSystemConfiguration()
+    console.log("Loaded.", style="bright_blue")
+
     table = Table()
     table.add_column("Method")
     table.add_column("Time (ms)")

--- a/src/pymmcore_plus/_cli.py
+++ b/src/pymmcore_plus/_cli.py
@@ -481,12 +481,11 @@ def bench(
                 )
                 table.add_row(f"Device: {item.label}", "------", style="yellow")
             else:
-                device, data = item
-                for method, time in data.items():
-                    if isinstance(time, float):
-                        table.add_row(method, f"{time:.4f}")
-                    else:
-                        table.add_row(method, str(time), style="red")
+                method, time = item
+                if isinstance(time, float):
+                    table.add_row(method, f"{time:.4f}")
+                else:
+                    table.add_row(method, str(time), style="red")
 
 
 def main() -> None:  # pragma: no cover

--- a/src/pymmcore_plus/_cli.py
+++ b/src/pymmcore_plus/_cli.py
@@ -439,7 +439,7 @@ def _tail_file(file_path: Union[str, Path], interval: float = 0.1) -> None:
 def bench(
     config: Optional[Path] = CONFIG_PARAM,
     number: int = typer.Option(
-        100, "-n", "--number", help="Number of iterations for each test."
+        10, "-n", "--number", help="Number of iterations for each test."
     ),
 ) -> None:
     """Run a benchmark of Core and Devices loaded with `config` (or Demo)."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -346,5 +346,5 @@ def test_cli_bench() -> None:
     local = Path(__file__).parent / "local_config.cfg"
     result = runner.invoke(app, ["bench", "--config", str(local)])
     assert result.exit_code == 0
+    assert "Loading config" in result.stdout
     assert "Core" in result.stdout
-    assert "local_config" in result.stdout

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,7 @@ import subprocess
 import time
 from multiprocessing import Process, Queue
 from time import sleep
-from typing import TYPE_CHECKING, Any, Callable, cast
+from typing import Any, Callable, cast
 from unittest.mock import Mock, patch
 
 import pytest
@@ -20,12 +20,11 @@ try:
 except ImportError:
     pytest.skip("cli extras not available", allow_module_level=True)
 
+from pathlib import Path
+
 from useq import MDASequence
 
 from pymmcore_plus import CMMCorePlus, __version__, _cli, _logger, _util, install
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 runner = CliRunner()
 subrun = subprocess.run
@@ -341,3 +340,11 @@ def test_cli_info() -> None:
     assert "pymmcore-plus" in result.stdout
     assert "python" in result.stdout
     assert "api-version-info" in result.stdout
+
+
+def test_cli_bench() -> None:
+    local = Path(__file__).parent / "local_config.cfg"
+    result = runner.invoke(app, ["bench", "--config", str(local)])
+    assert result.exit_code == 0
+    assert "Core" in result.stdout
+    assert "local_config" in result.stdout


### PR DESCRIPTION
this adds a simple Device benchmarking cli tool `mmcore bench` that lets you check various method calls to different devices, which may help to determine slow calls for various devices:

here is an example output (it adds rows as they appear in realtime):

```sh
$ mmcore bench --config .\tests\cbmf-hardware.cfg
```

<img width="776" alt="Screenshot 2024-12-17 at 3 44 29 PM" src="https://github.com/user-attachments/assets/13cd7497-315b-44d0-a2f7-0508c5ef8f04" />
