### PR TITLE
fix: Don't use `Engine.event_iterator` when an Iterable is directly passed to `MDARunner.run`

### DIFF
--- a/src/pymmcore_plus/mda/_runner.py
+++ b/src/pymmcore_plus/mda/_runner.py
@@ -274,7 +274,14 @@ class MDARunner:
     def _run(self, engine: PMDAEngine, events: Iterable[MDAEvent]) -> None:
         """Main execution of events, inside the try/except block of `run`."""
         teardown_event = getattr(engine, "teardown_event", lambda e: None)
-        event_iterator = getattr(engine, "event_iterator", iter)
+        if isinstance(events, Iterator):
+            # if an iterator is passed directly, then we use that iterator
+            # instead of the engine's event_iterator.  Directly passing an iterator
+            # is an advanced use case, (for example, `iter(Queue(), None)` for event-
+            # driven acquisition) and we don't want the engine to interfere with it.
+            event_iterator = iter
+        else:
+            event_iterator = getattr(engine, "event_iterator", iter)
         _events: Iterator[MDAEvent] = event_iterator(events)
         self._reset_event_timer()
         self._sequence_t0 = self._t0


### PR DESCRIPTION
This fixes #418  (and is pulled out of #400).

When the user is directly passing an iterator object, such as `iter(queue.get, None)` to `MDARunner.run`, we don't want the MDAEngine to do complicated things like try to setup hardware triggering.  This PR essentially implies that using queues and passing iterables is an advanced use case, and we don't want to inject additional "magic".  This *does* mean that queue users won't be able to use hardware triggering (for now) but that will be solved by asking them to explicitly opt in to hardware triggering by passing in a special SequencedEvent subclass of `MDAEvent` ... more on that in #400