### PR TITLE
Fix Issue with useq MDA Event Properties Not Being Set in MDAEngine

### DIFF
--- a/src/pymmcore_plus/mda/_engine.py
+++ b/src/pymmcore_plus/mda/_engine.py
@@ -248,7 +248,12 @@ class MDAEngine(PMDAEngine):
                 self._mmc.setExposure(event.exposure)
             except Exception as e:
                 logger.warning("Failed to set exposure. %s", e)
-
+        if event.properties is not None:
+            try:
+                for dev, prop, value in event.properties:
+                    self._mmc.setProperty(dev, prop, value)
+            except Exception as e:
+                logger.warning("Failed to set properties. %s", e)
         if (
             # (if autoshutter wasn't set at the beginning of the sequence
             # then it never matters...)

--- a/tests/test_mda.py
+++ b/tests/test_mda.py
@@ -49,19 +49,33 @@ def test_mda_waiting(core: CMMCorePlus) -> None:
 
 def test_setting_position(core: CMMCorePlus) -> None:
     core.mda._running = True
-    event1 = MDAEvent(exposure=123, x_pos=123, y_pos=456, z_pos=1)
+    event1 = MDAEvent(
+        exposure=123,
+        x_pos=123,
+        y_pos=456,
+        z_pos=1,
+        properties=[("Camera", "TestProperty1", 0.05)],
+    )
     core.mda.engine.setup_event(event1)
     assert tuple(core.getXYPosition()) == (123, 456)
     assert core.getPosition() == 1
     assert core.getExposure() == 123
+    assert core.getProperty("Camera", "TestProperty1") == "0.0500"
 
     # check that we aren't check things like: if event.x_pos
     # because then we will not set to zero
-    event2 = MDAEvent(exposure=321, x_pos=0, y_pos=0, z_pos=0)
+    event2 = MDAEvent(
+        exposure=321,
+        x_pos=0,
+        y_pos=0,
+        z_pos=0,
+        properties=[("Camera", "TestProperty2", -0.07)],
+    )
     core.mda.engine.setup_event(event2)
     assert tuple(core.getXYPosition()) == (0, 0)
     assert core.getPosition() == 0
     assert core.getExposure() == 321
+    assert core.getProperty("Camera", "TestProperty2") == "-0.0700"
 
 
 class BrokenEngine:


### PR DESCRIPTION
#### Fix Issue with useq MDA Event Properties Not Being Set in MDAEngine
This commit resolves a bug where the properties of the MDAEvent (as per the useq-schema specification) are not being set when only one event is sent to the MDA engine or when an event-driven acquisition engine is used.
The fix explicitly sets the properties using mmc.setProperty within the setup_single_event method of the MDAEngine. 

#### Testing:
- Tests were conducted using TestProperty1 and TestProperty2 on a simulated camera device.
- The fix also works on a real attached device.


Apologies if this commit doesn't fully align with the contributing guidelines. I encountered difficulties setting up the environment, particularly with pymmcore failing to build on Windows. Below is the error I received:

```
      Microsoft (R) Library Manager Version 14.42.34436.0
      Copyright (C) Microsoft Corporation.  All rights reserved.
      
      building 'pymmcore._pymmcore_swig' extension
      swigging src\pymmcore\pymmcore_swig.i to src\pymmcore\pymmcore_swig_wrap.cpp
      swig.exe -python -c++ -python -builtin -I./mmCoreAndDevices/MMDevice -I./mmCoreAndDevices/MMCore -o src\pymmcore\pymmcore_swig_wrap.cpp src\pymmcore\pymmcore_swig.i
      Only one target language can be supported at a time (both -python and -python were specified).
      error: command 'C:\\Users\\Niesen\\AppData\\Local\\Temp\\pip-build-env-n8jdqsmm\\overlay\\Scripts\\swig.exe' failed with exit code 1
      [end of output]
      
      note: This error originates from a subprocess, and is likely not a problem with pip.
      ERROR: Failed building wheel for pymmcore
    ERROR: ERROR: Failed to build installable wheels for some pyproject.toml based projects (pymmcore)
```
However, installation via conda-forge works without any issues, and I was able to run tests using pytest manually.

I realize this fix is relatively small, but I hope it still contributes to improving the functionality. Thank you again for your hard work on this project and for considering this contribution.