### PR TITLE
feat: add `get_output_handlers` method to `MDARunner`

### DIFF
--- a/src/pymmcore_plus/mda/__init__.py
+++ b/src/pymmcore_plus/mda/__init__.py
@@ -1,5 +1,3 @@
-from typing import TYPE_CHECKING
-
 from ._engine import MDAEngine
 from ._protocol import PMDAEngine
 from ._runner import MDARunner, SupportsFrameReady

--- a/src/pymmcore_plus/mda/__init__.py
+++ b/src/pymmcore_plus/mda/__init__.py
@@ -1,6 +1,8 @@
+from typing import TYPE_CHECKING
+
 from ._engine import MDAEngine
 from ._protocol import PMDAEngine
-from ._runner import MDARunner
+from ._runner import MDARunner, SupportsFrameReady
 from ._thread_relay import mda_listeners_connected
 from .events import PMDASignaler
 
@@ -9,5 +11,6 @@ __all__ = [
     "MDARunner",
     "PMDAEngine",
     "PMDASignaler",
+    "SupportsFrameReady",
     "mda_listeners_connected",
 ]

--- a/src/pymmcore_plus/mda/_runner.py
+++ b/src/pymmcore_plus/mda/_runner.py
@@ -5,7 +5,7 @@ import warnings
 from collections.abc import Iterable, Iterator, Sequence
 from contextlib import AbstractContextManager, nullcontext
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import MagicMock
 from weakref import WeakSet
 
@@ -28,26 +28,26 @@ if TYPE_CHECKING:
     from ._engine import MDAEngine
 
     class FrameReady0(Protocol):
-        """Minimal protocol for a frameReady handler."""
+        """Data handler with a no-argument `frameReady` method."""
 
-        def frameReady(self) -> None: ...
+        def frameReady(self) -> Any: ...
 
     class FrameReady1(Protocol):
-        """Minimal protocol for a frameReady handler."""
+        """Data handler with a `frameReady` method that takes `(image,)` ."""
 
-        def frameReady(self, img: np.ndarray, /) -> None: ...
+        def frameReady(self, img: np.ndarray, /) -> Any: ...
 
     class FrameReady2(Protocol):
-        """Minimal protocol for a frameReady handler."""
+        """Data handler with a `frameReady` method that takes `(image, event)`."""
 
-        def frameReady(self, img: np.ndarray, event: MDAEvent, /) -> None: ...
+        def frameReady(self, img: np.ndarray, event: MDAEvent, /) -> Any: ...
 
     class FrameReady3(Protocol):
-        """Minimal protocol for a frameReady handler."""
+        """Data handler with a `frameReady` method that takes `(image, event, meta)`."""
 
         def frameReady(
             self, img: np.ndarray, event: MDAEvent, meta: FrameMetaV1, /
-        ) -> None: ...
+        ) -> Any: ...
 
 
 SupportsFrameReady: TypeAlias = "FrameReady0 | FrameReady1 | FrameReady2 | FrameReady3"
@@ -291,8 +291,6 @@ class MDARunner:
             if isinstance(item, (str, Path)):
                 _handlers.append(self._handler_for_path(item))
             else:
-                # TODO: better check for valid handler protocol
-                # quick hack for now.
                 if not callable(getattr(item, "frameReady", None)):
                     raise TypeError(
                         "Output handlers must have a callable frameReady method. "

--- a/src/pymmcore_plus/mda/handlers/__init__.py
+++ b/src/pymmcore_plus/mda/handlers/__init__.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from ._img_sequence_writer import ImageSequenceWriter
 from ._ome_tiff_writer import OMETiffWriter
 from ._ome_zarr_writer import OMEZarrWriter
@@ -8,4 +10,35 @@ __all__ = [
     "OMETiffWriter",
     "OMEZarrWriter",
     "TensorStoreHandler",
+    "handler_for_path",
 ]
+
+
+def handler_for_path(path: str | Path) -> object:
+    """Convert a string or Path into a handler object.
+
+    This method picks from the built-in handlers based on the extension of the path.
+    """
+    if str(path).rstrip("/").rstrip(":").lower() == "memory":
+        return TensorStoreHandler(kvstore="memory://")
+
+    path = str(Path(path).expanduser().resolve())
+    if path.endswith(".zarr"):
+        from pymmcore_plus.mda.handlers import OMEZarrWriter
+
+        return OMEZarrWriter(path)
+
+    if path.endswith((".tiff", ".tif")):
+        from pymmcore_plus.mda.handlers import OMETiffWriter
+
+        return OMETiffWriter(path)
+
+    # FIXME: ugly hack for the moment to represent a non-existent directory
+    # there are many features that ImageSequenceWriter supports, and it's unclear
+    # how to infer them all from a single string.
+    if not (Path(path).suffix or Path(path).exists()):
+        from pymmcore_plus.mda.handlers import ImageSequenceWriter
+
+        return ImageSequenceWriter(path)
+
+    raise ValueError(f"Could not infer a writer handler for path: '{path}'")

--- a/src/pymmcore_plus/mda/handlers/__init__.py
+++ b/src/pymmcore_plus/mda/handlers/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 from ._img_sequence_writer import ImageSequenceWriter

--- a/src/pymmcore_plus/mda/handlers/__init__.py
+++ b/src/pymmcore_plus/mda/handlers/__init__.py
@@ -24,21 +24,15 @@ def handler_for_path(path: str | Path) -> object:
 
     path = str(Path(path).expanduser().resolve())
     if path.endswith(".zarr"):
-        from pymmcore_plus.mda.handlers import OMEZarrWriter
-
         return OMEZarrWriter(path)
 
     if path.endswith((".tiff", ".tif")):
-        from pymmcore_plus.mda.handlers import OMETiffWriter
-
         return OMETiffWriter(path)
 
     # FIXME: ugly hack for the moment to represent a non-existent directory
     # there are many features that ImageSequenceWriter supports, and it's unclear
     # how to infer them all from a single string.
     if not (Path(path).suffix or Path(path).exists()):
-        from pymmcore_plus.mda.handlers import ImageSequenceWriter
-
         return ImageSequenceWriter(path)
 
     raise ValueError(f"Could not infer a writer handler for path: '{path}'")

--- a/src/pymmcore_plus/mda/handlers/_img_sequence_writer.py
+++ b/src/pymmcore_plus/mda/handlers/_img_sequence_writer.py
@@ -22,6 +22,8 @@ if TYPE_CHECKING:
     import useq
     from typing_extensions import TypeAlias  # py310
 
+    from pymmcore_plus.metadata.schema import FrameMetaV1
+
     ImgWriter: TypeAlias = Callable[[str, npt.NDArray], Any]
 
 FRAME_KEY = "frame"
@@ -118,7 +120,7 @@ class ImageSequenceWriter:
             shutil.rmtree(self._directory)
 
         # ongoing dict of frame meta... stored for easy rewrite without reading
-        self._frame_metadata: dict[str, dict] = {}
+        self._frame_metadata: dict[str, FrameMetaV1] = {}
         self._frame_meta_file = self._directory.joinpath(self.FRAME_META_PATH)
         self._seq_meta_file = self._directory.joinpath(self.SEQ_META_PATH)
 
@@ -186,7 +188,9 @@ class ImageSequenceWriter:
         # write final frame metadata to disk
         self._frame_meta_file.write_bytes(json_dumps(self._frame_metadata, indent=2))
 
-    def frameReady(self, frame: np.ndarray, event: useq.MDAEvent, meta: dict) -> None:
+    def frameReady(
+        self, frame: np.ndarray, event: useq.MDAEvent, meta: FrameMetaV1, /
+    ) -> None:
         """Write a frame to disk."""
         frame_idx = next(self._counter)
         if self._name_template:

--- a/src/pymmcore_plus/mda/handlers/_tensorstore_handler.py
+++ b/src/pymmcore_plus/mda/handlers/_tensorstore_handler.py
@@ -111,6 +111,8 @@ class TensorStoreHandler:
         self.delete_existing = delete_existing
         self.spec = spec
 
+        self._current_sequence: useq.MDASequence | None = None
+
         # storage of individual frame metadata
         # maps position key to list of frame metadata
         self.frame_metadatas: list[tuple[useq.MDAEvent, FrameMetaV1]] = []
@@ -176,13 +178,25 @@ class TensorStoreHandler:
 
         return cls(path=path, **kwargs)
 
-    def sequenceStarted(self, seq: useq.MDASequence, meta: SummaryMetaV1) -> None:
-        """On sequence started, simply store the sequence."""
+    def reset(self, sequence: useq.MDASequence) -> None:
+        """Reset state to prepare for new `sequence`."""
         self._frame_index = 0
         self._store = None
         self._futures.clear()
         self.frame_metadatas.clear()
-        self.current_sequence = seq
+        self._current_sequence = sequence
+
+    @property
+    def current_sequence(self) -> useq.MDASequence | None:
+        """Return current sequence, or none.
+
+        Use `.reset()` to initialize the handler for a new sequence.
+        """
+        return self._current_sequence
+
+    def sequenceStarted(self, seq: useq.MDASequence, meta: SummaryMetaV1) -> None:
+        """On sequence started, simply store the sequence."""
+        self.reset(seq)
 
     def sequenceFinished(self, seq: useq.MDASequence) -> None:
         """On sequence finished, clear the current sequence."""
@@ -199,7 +213,7 @@ class TensorStoreHandler:
             self.finalize_metadata()
 
     def frameReady(
-        self, frame: np.ndarray, event: useq.MDAEvent, meta: FrameMetaV1
+        self, frame: np.ndarray, event: useq.MDAEvent, meta: FrameMetaV1, /
     ) -> None:
         """Write frame to the zarr array for the appropriate position."""
         if self._store is None:

--- a/tests/test_mda.py
+++ b/tests/test_mda.py
@@ -464,3 +464,29 @@ def test_queue_mda(core: CMMCorePlus) -> None:
     # make sure that the engine's iterator was NOT used when running an iter(Queue)
     mock_engine.event_iterator.assert_not_called()
     assert mock_engine.setup_event.call_count == 2
+
+
+def test_get_handlers(core: CMMCorePlus) -> None:
+    """Test that we can get the handlers"""
+    runner = core.mda
+
+    assert not runner.get_output_handlers()
+    on_start_names: list[str] = []
+    on_finish_names: list[str] = []
+
+    @runner.events.sequenceStarted.connect
+    def _on_start() -> None:
+        on_start_names.extend([type(h).__name__ for h in runner.get_output_handlers()])
+
+    @runner.events.sequenceFinished.connect
+    def _on_end() -> None:
+        on_finish_names.extend([type(h).__name__ for h in runner.get_output_handlers()])
+
+    runner.run([MDAEvent()], output="memory://")
+
+    # weakref is used to store the handlers,
+    # handlers should be cleared after the sequence is finished
+    assert not runner.get_output_handlers()
+    # but they should have been available during start and finish events
+    assert on_start_names == ["TensorStoreHandler"]
+    assert on_finish_names == ["TensorStoreHandler"]


### PR DESCRIPTION
this PR adds `MDARunner.get_output_handlers`.  It solves an issue that @fdrgsp and I came across while trying to display data using ndv during the course of an MDA.  Namely: it's not easy to get a pointer to where the data is being stored/ written from the `core.mda` object unless you yourself created them and passed them in.  So this solves two use cases:

someone starts an mda with either:

```python
core.mda.run(..., output='some_path.zarr')

# or
handler = TensorStoreHandler()
core.mda.run(..., output=handler)
```

Here, the runner will maintain a weak reference to either the explicitly passed `handler`, or the handler that was implicitly created to deal with the provided path.  These can be retrieved all the way from `sequenceStarted` to `sequenceFinished` using the new  `MDARunner.get_output_handlers` method, for example, to show the data without needing to create a second handler

------------

> [!NOTE]
> it's important to note that if one retrieves these handlers and maintains a strong reference, it could create memory leaks.  So care should be taken when holding a reference to a data handler