### PR TITLE
fix: turn most exceptions to warnings when loading config file into a model

### DIFF
--- a/src/pymmcore_plus/core/_constants.py
+++ b/src/pymmcore_plus/core/_constants.py
@@ -209,10 +209,15 @@ class PortType(IntEnum):
     HIDPort = pymmcore.HIDPort
 
 
+# NB:
+# do *not* use `pymmcore.FocusDirection...` enums here.
+# the MMCore API does not use the device enums (which is what pymmcore exposes)
+# but instead translates MM::FocusDirectionTowardSample into a different number:
+# https://github.com/micro-manager/mmCoreAndDevices/tree/MMCore/MMCore.cpp#L2063-L2074
 class FocusDirection(IntEnum):
-    Unknown = pymmcore.FocusDirectionUnknown
-    TowardSample = pymmcore.FocusDirectionTowardSample
-    AwayFromSample = pymmcore.FocusDirectionAwayFromSample
+    Unknown = 0
+    TowardSample = 1
+    AwayFromSample = -1
     # aliases
     FocusDirectionUnknown = Unknown
     FocusDirectionTowardSample = TowardSample

--- a/src/pymmcore_plus/model/_config_file.py
+++ b/src/pymmcore_plus/model/_config_file.py
@@ -209,18 +209,24 @@ def run_command(line: str, scope: Microscope) -> None:
         return
 
     exec_cmd, expected_n_args = COMMAND_EXECUTORS[command]
+    should_raise = command in SHOULD_RAISE
 
     if (nargs := len(args) + 1) not in expected_n_args:
         exp_str = " or ".join(map(str, expected_n_args))
-        raise ValueError(
+        msg = (
             f"Invalid configuration line encountered for command {cmd_name}. "
             f"Expected {exp_str} arguments, got {nargs}: {line!r}"
         )
+        if should_raise:
+            raise ValueError(msg)
+        else:
+            warnings.warn(msg, RuntimeWarning, stacklevel=2)
+            return
 
     try:
         exec_cmd(scope, args)
     except Exception as exc:
-        if command in SHOULD_RAISE:
+        if should_raise:
             raise ValueError(f"Error executing command {line!r}: {exc}") from exc
         warnings.warn(
             f"Failed to execute command {line!r}: {exc}", RuntimeWarning, stacklevel=2

--- a/src/pymmcore_plus/model/_config_file.py
+++ b/src/pymmcore_plus/model/_config_file.py
@@ -220,7 +220,11 @@ def run_command(line: str, scope: Microscope) -> None:
     try:
         exec_cmd(scope, args)
     except Exception as exc:
-        raise ValueError(f"Error executing command {line!r}: {exc}") from exc
+        if command in SHOULD_RAISE:
+            raise ValueError(f"Error executing command {line!r}: {exc}") from exc
+        warnings.warn(
+            f"Failed to execute command {line!r}: {exc}", RuntimeWarning, stacklevel=2
+        )
 
 
 def _exec_Device(scope: Microscope, args: Sequence[str]) -> None:
@@ -352,3 +356,6 @@ COMMAND_EXECUTORS: dict[CFGCommand, tuple[Executor, set[int]]] = {
     CFGCommand.ParentID: (_exec_ParentID, {3}),
     CFGCommand.FocusDirection: (_exec_FocusDirection, {3}),
 }
+
+# Commands that should raise when fail
+SHOULD_RAISE = {CFGCommand.Device, CFGCommand.Property}

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -140,46 +140,47 @@ def test_load_errors() -> None:
         model.load_config("Property,A,B,C,D,E")
     with pytest.raises(ValueError, match="not an integer"):
         model.load_config("Property,Core,Initialize,NotAnInt")
-    with pytest.raises(ValueError, match="not an integer"):
+    model.load_config("Device,Dichroic,DemoCamera,DWheel")  # fine
+    with pytest.warns(RuntimeWarning, match="not an integer"):
         model.load_config(
             """
             Device,Dichroic,DemoCamera,DWheel
             Label,Dichroic,NotAnInt,Q505LP
             """
         )
-    with pytest.raises(ValueError, match="'NotAPreset' not found"):
+    with pytest.warns(RuntimeWarning, match="'NotAPreset' not found"):
         model.load_config("PixelSize_um,NotAPreset,0.5")
-    with pytest.raises(ValueError, match="Expected a float"):
+    with pytest.warns(RuntimeWarning, match="Expected a float"):
         model.load_config(
             """
             ConfigPixelSize,Res40x,Objective,Label,Nikon 40X Plan Flueor ELWD
             PixelSize_um,Res40x,NotAFloat
             """
         )
-    with pytest.raises(ValueError, match="'Res10x' not found"):
+    with pytest.warns(RuntimeWarning, match="'Res10x' not found"):
         model.load_config("PixelSizeAffine,Res10x,1.0,0.0,0.0,0.0,1.1,0.0")
-    with pytest.raises(ValueError, match="Expected 8 arguments, got 5"):
+    with pytest.warns(RuntimeWarning, match="Expected 8 arguments, got 5"):
         model.load_config(
             """
             ConfigPixelSize,Res40x,Objective,Label,Nikon 40X Plan Flueor ELWD
             PixelSizeAffine,Res40x,1.0,0.0,0.0
             """
         )
-    with pytest.raises(ValueError, match="Expected 6 floats"):
+    with pytest.warns(RuntimeWarning, match="Expected 6 floats"):
         model.load_config(
             """
             ConfigPixelSize,Res40x,Objective,Label,Nikon 40X Plan Flueor ELWD
             PixelSizeAffine,Res40x,1.0,0.0,0.0,0.0,1.1,NoFloat
             """
         )
-    with pytest.raises(ValueError, match="Expected a float"):
+    with pytest.warns(RuntimeWarning, match="Expected a float"):
         model.load_config(
             """
             Device,Shutter,DemoCamera,DShutter
             Delay,Shutter,NotAFloat
             """
         )
-    with pytest.raises(ValueError, match="not a valid FocusDirection"):
+    with pytest.warns(RuntimeWarning, match="not a valid FocusDirection"):
         model.load_config(
             """
             Device,Z,DemoCamera,DStage


### PR DESCRIPTION
When loading a config file, this PR makes an error on all commands except load device set property be warnings instead of exceptions