### PR TITLE
fix!: fix focus direction enums

### DIFF
--- a/src/pymmcore_plus/core/_constants.py
+++ b/src/pymmcore_plus/core/_constants.py
@@ -209,10 +209,15 @@ class PortType(IntEnum):
     HIDPort = pymmcore.HIDPort
 
 
+# NB:
+# do *not* use `pymmcore.FocusDirection...` enums here.
+# the MMCore API does not use the device enums (which is what pymmcore exposes)
+# but instead translates MM::FocusDirectionTowardSample into a different number:
+# https://github.com/micro-manager/mmCoreAndDevices/tree/MMCore/MMCore.cpp#L2063-L2074
 class FocusDirection(IntEnum):
-    Unknown = pymmcore.FocusDirectionUnknown
-    TowardSample = pymmcore.FocusDirectionTowardSample
-    AwayFromSample = pymmcore.FocusDirectionAwayFromSample
+    Unknown = 0
+    TowardSample = 1
+    AwayFromSample = -1
     # aliases
     FocusDirectionUnknown = Unknown
     FocusDirectionTowardSample = TowardSample


### PR DESCRIPTION
fixes #427 

pymmcore's `FocusDirectionUnknown`, `FocusDirectionTowardSample`, and `FocusDirectionAwayFromSample` constants expose the `MM::FocusDirection...` values (0,1,2) defined in [`MMDeviceConstants.h`](https://github.com/micro-manager/mmCoreAndDevices/blob/056f4481c13c9ca06047c358277ba81032eb0faf/MMDevice/MMDeviceConstants.h#L269-L273).  However, MMCore does not directly use those enum values, but rather [maps them to (-1, 0, 1)](https://github.com/micro-manager/mmCoreAndDevices/blob/056f4481c13c9ca06047c358277ba81032eb0faf/MMCore/MMCore.cpp#L2063-L2074)

so we shouldn't pass on the `pymmcore` constants, but rather declare our own