### PR TITLE
feat: add continuousSequenceAcquisitionStarting and sequenceAcquisitionStarting signals

### DIFF
--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -1675,6 +1675,7 @@ class CMMCorePlus(pymmcore.CMMCore):
 
         **Why Override?** To emit a `startContinuousSequenceAcquisition` event.
         """
+        self.events.continuousSequenceAcquisitionStarting.emit()
         super().startContinuousSequenceAcquisition(intervalMs)
         self.events.continuousSequenceAcquisitionStarted.emit()
 
@@ -1703,12 +1704,16 @@ class CMMCorePlus(pymmcore.CMMCore):
 
         **Why Override?** To emit a `startSequenceAcquisition` event.
         """
-        super().startSequenceAcquisition(*args, **kwargs)
         if len(args) == 3:
             numImages, intervalMs, stopOnOverflow = args
             cameraLabel = super().getCameraDevice()
         else:
             cameraLabel, numImages, intervalMs, stopOnOverflow = args
+
+        self.events.sequenceAcquisitionStarting.emit(
+            cameraLabel, numImages, intervalMs, stopOnOverflow
+        )
+        super().startSequenceAcquisition(*args, **kwargs)
         self.events.sequenceAcquisitionStarted.emit(
             cameraLabel, numImages, intervalMs, stopOnOverflow
         )

--- a/src/pymmcore_plus/core/events/_protocol.py
+++ b/src/pymmcore_plus/core/events/_protocol.py
@@ -133,14 +133,26 @@ class PCoreSignaler(Protocol):
     > :sparkles: This signal is unique to `pymmcore-plus`.
     """
 
-    continuousSequenceAcquisitionStarted: PSignal
-    """Emits with no arguments when continuous sequence acquisition is started.
+    continuousSequenceAcquisitionStarting: PSignal
+    """Emits with no arguments *before* continuous sequence acquisition is started.
 
     > :sparkles: This signal is unique to `pymmcore-plus`.
     """
-    sequenceAcquisitionStarted: PSignal
-    """Emits `(str, int, float, bool)` when sequence acquisition is started.
+    continuousSequenceAcquisitionStarted: PSignal
+    """Emits with no arguments *after* continuous sequence acquisition has started.
 
+    > :sparkles: This signal is unique to `pymmcore-plus`.
+    """
+    sequenceAcquisitionStarting: PSignal
+    """Emits `(str, int, float, bool)` *before* sequence acquisition is started.
+
+    (cameraLabel, numImages, intervalMs, stopOnOverflow)
+    > :sparkles: This signal is unique to `pymmcore-plus`.
+    """
+    sequenceAcquisitionStarted: PSignal
+    """Emits `(str, int, float, bool)` *after* sequence acquisition has started.
+
+    (cameraLabel, numImages, intervalMs, stopOnOverflow)
     > :sparkles: This signal is unique to `pymmcore-plus`.
     """
     sequenceAcquisitionStopped: PSignal

--- a/src/pymmcore_plus/core/events/_psygnal.py
+++ b/src/pymmcore_plus/core/events/_psygnal.py
@@ -25,7 +25,9 @@ class CMMCoreSignaler(SignalGroup, _DevicePropertyEventMixin):
     # added for CMMCorePlus
     imageSnapped = Signal()  # whenever snapImage is called
     mdaEngineRegistered = Signal(MDAEngine, MDAEngine)
+    continuousSequenceAcquisitionStarting = Signal()
     continuousSequenceAcquisitionStarted = Signal()
+    sequenceAcquisitionStarting = Signal(str, int, float, bool)
     sequenceAcquisitionStarted = Signal(str, int, float, bool)
     sequenceAcquisitionStopped = Signal(str)
     autoShutterSet = Signal(bool)

--- a/src/pymmcore_plus/core/events/_qsignals.py
+++ b/src/pymmcore_plus/core/events/_qsignals.py
@@ -29,8 +29,10 @@ class QCoreSignaler(QObject):
     imageSnapped = Signal()  # on snapImage()
     mdaEngineRegistered = Signal(object, object)  # new engine, old engine
     # when continuousSequenceAcquisition is started
+    continuousSequenceAcquisitionStarting = Signal()
     continuousSequenceAcquisitionStarted = Signal()
     # when SequenceAcquisition is started
+    sequenceAcquisitionStarting = Signal(str, int, float, bool)
     sequenceAcquisitionStarted = Signal(str, int, float, bool)
     # when (Continuous)SequenceAcquisition is stopped
     sequenceAcquisitionStopped = Signal(str)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -171,32 +171,39 @@ def test_device_property_events(core: CMMCorePlus) -> None:
 
 
 def test_sequence_acquisition_events(core: CMMCorePlus) -> None:
-    mock1 = Mock()
-    mock2 = Mock()
+    mock1a = Mock()
+    mock1b = Mock()
+    mock2a = Mock()
+    mock2b = Mock()
     mock3 = Mock()
 
-    core.events.continuousSequenceAcquisitionStarted.connect(mock1)
-    core.events.sequenceAcquisitionStopped.connect(mock2)
-    core.events.sequenceAcquisitionStarted.connect(mock3)
+    core.events.continuousSequenceAcquisitionStarting.connect(mock1a)
+    core.events.continuousSequenceAcquisitionStarted.connect(mock1b)
+    core.events.sequenceAcquisitionStarting.connect(mock2a)
+    core.events.sequenceAcquisitionStarted.connect(mock2b)
+    core.events.sequenceAcquisitionStopped.connect(mock3)
 
     core.startContinuousSequenceAcquisition()
-    mock1.assert_called_once()
+    mock1a.assert_called_once()
+    mock1b.assert_called_once()
 
     core.stopSequenceAcquisition()
-    mock2.assert_any_call(core.getCameraDevice())
+    mock3.assert_any_call(core.getCameraDevice())
 
     # without camera label
     core.startSequenceAcquisition(5, 100.0, True)
-    mock3.assert_any_call(core.getCameraDevice(), 5, 100.0, True)
+    mock2a.assert_any_call(core.getCameraDevice(), 5, 100.0, True)
+    mock2b.assert_any_call(core.getCameraDevice(), 5, 100.0, True)
     core.stopSequenceAcquisition()
-    mock2.assert_any_call(core.getCameraDevice())
+    mock3.assert_any_call(core.getCameraDevice())
 
     # with camera label
     cam = core.getCameraDevice()
     core.startSequenceAcquisition(cam, 5, 100.0, True)
-    mock3.assert_any_call(cam, 5, 100.0, True)
+    mock2a.assert_any_call(cam, 5, 100.0, True)
+    mock2b.assert_any_call(cam, 5, 100.0, True)
     core.stopSequenceAcquisition(cam)
-    mock2.assert_any_call(cam)
+    mock3.assert_any_call(cam)
 
 
 def test_shutter_device_events(core: CMMCorePlus) -> None:


### PR DESCRIPTION
closes #429 by emitting signals *before* calling `core.startContinuousSequenceAcquisition` and `core.startSequenceAcquisition`.  So that users can take action before the call is passed to the devices, for example, to begin a sequence on another non-MM-controlled device.

cc @dpshepherd