### PR TITLE
chore: support useq 0.7, don't try to exec anything but AcquireImage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "psygnal >=0.7",
     "pymmcore >=10.7.0.71.0",
     "typing-extensions",                    # not actually required at runtime
-    "useq-schema >=0.6.2",
+    "useq-schema >=0.7.0",
     "tensorstore; python_version < '3.13'",
     # cli requirements included by default for now
     "typer >=0.4.2",

--- a/src/pymmcore_plus/mda/_engine.py
+++ b/src/pymmcore_plus/mda/_engine.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Literal, NamedTuple, cast
 
 import numpy as np
 import useq
-from useq import HardwareAutofocus, MDAEvent, MDASequence
+from useq import AcquireImage, HardwareAutofocus, MDAEvent, MDASequence
 
 from pymmcore_plus._logger import logger
 from pymmcore_plus._util import retry
@@ -193,6 +193,13 @@ class MDAEngine(PMDAEngine):
                 self._z_correction[p_idx] = new_correction + self._z_correction.get(
                     p_idx, 0.0
                 )
+            return
+
+        # don't try to execute any other action types. Mostly, this is just
+        # CustomAction, which is a user-defined action that the engine doesn't know how
+        # to handle.  But may include other actions in the future, and this ensures
+        # backwards compatibility.
+        if not isinstance(action, (AcquireImage, type(None))):
             return
 
         # if the autofocus was engaged at the start of the sequence AND autofocus action

--- a/tests/test_mda.py
+++ b/tests/test_mda.py
@@ -490,3 +490,9 @@ def test_get_handlers(core: CMMCorePlus) -> None:
     # but they should have been available during start and finish events
     assert on_start_names == ["TensorStoreHandler"]
     assert on_finish_names == ["TensorStoreHandler"]
+
+
+def test_custom_action(core: CMMCorePlus) -> None:
+    """Make sure we can handle custom actions gracefully"""
+
+    core.mda.run([MDAEvent(action=useq.CustomAction())])


### PR DESCRIPTION
This will be necessary for anyone who uses CustomAction added in useq-schema v0.7.0: https://github.com/pymmcore-plus/useq-schema/pull/214

That's a generic escape hatch for anyone who wants to have an MDAEvent that does something other than acquire an image... We don't want MDAEngine to do anything with it (users will need to subclass and handle it themselves in the `exec_event` method of their custom engine)

cc @dpshepherd