### PR TITLE
fix: Fix missing metadata in popNextImageAndMD

### DIFF
--- a/src/pymmcore_plus/_pymmcore.py
+++ b/src/pymmcore_plus/_pymmcore.py
@@ -5,8 +5,10 @@ try:
     from pymmcore_nano import __version__
 
     BACKEND = "pymmcore-nano"
+    NANO = True
 except ImportError:
     from pymmcore import *  # noqa F403
     from pymmcore import __version__  # noqa F401
 
     BACKEND = "pymmcore"
+    NANO = False

--- a/src/pymmcore_plus/core/_metadata.py
+++ b/src/pymmcore_plus/core/_metadata.py
@@ -20,8 +20,7 @@ class Metadata(pymmcore.Metadata):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__()
         if args and isinstance(args[0], Mapping):
-            for k, v in args[0].items():
-                self[k] = v
+            kwargs = {**args[0], **kwargs}
         for k, v in kwargs.items():
             self[k] = v
 
@@ -88,3 +87,7 @@ class Metadata(pymmcore.Metadata):
 metadata_keys = new_class("metadata_keys", (KeysView,), {})
 metadata_items = new_class("metadata_items", (ItemsView,), {})
 metadata_values = new_class("metadata_values", (ValuesView,), {})
+
+# Register the new classes with the `collections.abc` module
+# so that isistance() works as expected.
+Mapping.register(Metadata)

--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -642,10 +642,7 @@ class CMMCorePlus(pymmcore.CMMCore):
             img = super().getLastImageMD(channel, slice, md)
         else:
             img = super().getLastImageMD(md)
-        return (
-            self.fixImage(img) if fix and pymmcore.BACKEND == "pymmcore" else img,
-            md,
-        )
+        return (self.fixImage(img) if fix and not pymmcore.NANO else img, md)
 
     @overload
     def popNextImageAndMD(
@@ -687,11 +684,7 @@ class CMMCorePlus(pymmcore.CMMCore):
         """
         md = Metadata()
         img = super().popNextImageMD(channel, slice, md)
-        md = Metadata(md)
-        return (
-            self.fixImage(img) if fix and pymmcore.BACKEND == "pymmcore" else img,
-            md,
-        )
+        return (self.fixImage(img) if fix and not pymmcore.NANO else img, md)
 
     def popNextImage(self, *, fix: bool = True) -> np.ndarray:
         """Gets and removes the next image from the circular buffer.
@@ -707,7 +700,7 @@ class CMMCorePlus(pymmcore.CMMCore):
             will be reshaped to (w, h, n_components) using `fixImage`.
         """
         img: np.ndarray = super().popNextImage()
-        return self.fixImage(img) if fix and pymmcore.BACKEND == "pymmcore" else img
+        return self.fixImage(img) if fix and not pymmcore.NANO else img
 
     def getNBeforeLastImageAndMD(
         self, n: int, *, fix: bool = True
@@ -735,7 +728,7 @@ class CMMCorePlus(pymmcore.CMMCore):
         """
         md = Metadata()
         img = super().getNBeforeLastImageMD(n, md)
-        return self.fixImage(img) if fix and pymmcore.BACKEND == "pymmcore" else img, md
+        return self.fixImage(img) if fix and not pymmcore.NANO else img, md
 
     def setConfig(self, groupName: str, configName: str) -> None:
         """Applies a configuration to a group.
@@ -1668,7 +1661,7 @@ class CMMCorePlus(pymmcore.CMMCore):
             if numChannel is not None
             else super().getImage()
         )
-        return self.fixImage(img) if fix and pymmcore.BACKEND == "pymmcore" else img
+        return self.fixImage(img) if fix and not pymmcore.NANO else img
 
     def startContinuousSequenceAcquisition(self, intervalMs: float = 0) -> None:
         """Start a ContinuousSequenceAcquisition.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,6 @@
 import os
 import re
+from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 from unittest.mock import MagicMock, call, patch
@@ -357,6 +358,10 @@ def test_get_image_and_meta(core: CMMCorePlus) -> None:
     assert isinstance(image, np.ndarray)
     assert isinstance(md, Metadata)
     assert "TimeReceivedByCore" in md
+
+    assert Metadata(md) == md
+    assert isinstance(md, Mapping)
+    assert issubclass(Metadata, Mapping)
 
 
 def test_configuration(core: CMMCorePlus) -> None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -346,17 +346,17 @@ def test_get_image_and_meta(core: CMMCorePlus) -> None:
     image, md = core.getNBeforeLastImageAndMD(0)
     assert isinstance(image, np.ndarray)
     assert isinstance(md, Metadata)
-    assert bool(dict(md))
+    assert "TimeReceivedByCore" in md
 
     image, md = core.getLastImageAndMD()
     assert isinstance(image, np.ndarray)
     assert isinstance(md, Metadata)
-    assert bool(dict(md))
+    assert "TimeReceivedByCore" in md
 
     image, md = core.popNextImageAndMD()
     assert isinstance(image, np.ndarray)
     assert isinstance(md, Metadata)
-    assert bool(dict(md))
+    assert "TimeReceivedByCore" in md
 
 
 def test_configuration(core: CMMCorePlus) -> None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -339,18 +339,24 @@ def test_new_metadata():
     assert isinstance(md, pymmcore.Metadata)
 
 
-def test_md_(core: CMMCorePlus) -> None:
+def test_get_image_and_meta(core: CMMCorePlus) -> None:
     core.startContinuousSequenceAcquisition(10)
     core.stopSequenceAcquisition()
 
     image, md = core.getNBeforeLastImageAndMD(0)
-    assert isinstance(image, np.ndarray) and isinstance(md, Metadata)
+    assert isinstance(image, np.ndarray)
+    assert isinstance(md, Metadata)
+    assert bool(dict(md))
 
     image, md = core.getLastImageAndMD()
-    assert isinstance(image, np.ndarray) and isinstance(md, Metadata)
+    assert isinstance(image, np.ndarray)
+    assert isinstance(md, Metadata)
+    assert bool(dict(md))
 
     image, md = core.popNextImageAndMD()
-    assert isinstance(image, np.ndarray) and isinstance(md, Metadata)
+    assert isinstance(image, np.ndarray)
+    assert isinstance(md, Metadata)
+    assert bool(dict(md))
 
 
 def test_configuration(core: CMMCorePlus) -> None:


### PR DESCRIPTION
fixes #435

This also fixes what should have been a fine call to `md = Metadata(md)` by making `pymmcore_plus.Metadata` behave *both* as a subclass of `pymmcore.Metadata`, and also a (virtual) subclass of `abc.collections.Mapping`