### PR TITLE
feat: extend object-oriented device API

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ ci:
 
 repos:
   - repo: https://github.com/crate-ci/typos
-    rev: v1
+    rev: v1.31.1
     hooks:
       - id: typos
         args: [--force-exclude]

--- a/src/pymmcore_plus/core/__init__.py
+++ b/src/pymmcore_plus/core/__init__.py
@@ -1,10 +1,14 @@
 __all__ = [
     "ActionType",
+    "AutoFocusDevice",
     "CFGCommand",
     "CFGGroup",
     "CMMCorePlus",
+    "CameraDevice",
     "ConfigGroup",
     "Configuration",
+    "CoreDevice",
+    "Device",
     "Device",
     "DeviceAdapter",
     "DeviceDetectionStatus",
@@ -13,12 +17,24 @@ __all__ = [
     "DeviceProperty",
     "DeviceType",
     "FocusDirection",
+    "GalvoDevice",
+    "GenericDevice",
+    "HubDevice",
+    "ImageProcessorDevice",
     "Keyword",
+    "MagnifierDevice",
     "Metadata",
     "PixelFormat",
     "PortType",
     "PropertyType",
+    "SLMDevice",
     "SequencedEvent",
+    "SerialDevice",
+    "ShutterDevice",
+    "SignalIODevice",
+    "StageDevice",
+    "StateDevice",
+    "XYStageDevice",
     "iter_sequenced_events",
 ]
 
@@ -39,7 +55,24 @@ from ._constants import (
     PortType,
     PropertyType,
 )
-from ._device import Device
+from ._device import (
+    AutoFocusDevice,
+    CameraDevice,
+    CoreDevice,
+    Device,
+    GalvoDevice,
+    GenericDevice,
+    HubDevice,
+    ImageProcessorDevice,
+    MagnifierDevice,
+    SerialDevice,
+    ShutterDevice,
+    SignalIODevice,
+    SLMDevice,
+    StageDevice,
+    StateDevice,
+    XYStageDevice,
+)
 from ._metadata import Metadata
 from ._mmcore_plus import CMMCorePlus
 from ._property import DeviceProperty

--- a/src/pymmcore_plus/core/_device.py
+++ b/src/pymmcore_plus/core/_device.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Self
+from typing import TYPE_CHECKING, Any, Literal, Self, overload
 
-from ._constants import DeviceType
+from ._constants import DeviceType, FocusDirection, Keyword
 from ._property import DeviceProperty
 from .events._device_signal_view import _DevicePropValueSignal
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from pymmcore import StateLabel
     from typing_extensions import Self
 
     from pymmcore_plus.core.events._protocol import PSignalInstance
@@ -16,7 +19,7 @@ if TYPE_CHECKING:
 
 
 class Device:
-    """Convenience view onto a device.
+    """Convenience object-oriented device API.
 
     This is the type of object that is returned by
     [`pymmcore_plus.CMMCorePlus.getDeviceObject`][]
@@ -24,9 +27,9 @@ class Device:
     Parameters
     ----------
     device_label : str
-        Device this property belongs to
+        Device label assigned to this device.
     mmcore : CMMCorePlus
-        CMMCorePlus instance
+        CMMCorePlus instance that owns this device.
 
     Examples
     --------
@@ -49,7 +52,20 @@ class Device:
     propertyChanged: PSignalInstance
 
     @classmethod
-    def create(cls, device_label: str, mmcore: CMMCorePlus) -> Self: ...
+    def create(cls, device_label: str, mmcore: CMMCorePlus) -> Self:
+        sub_cls = cls.get_subclass(device_label, mmcore)
+        # make sure it's an error to call this class method on a subclass with
+        # a non-matching type
+        if issubclass(sub_cls, cls):
+            return sub_cls(device_label, mmcore)
+        dev_type = mmcore.getDeviceType(device_label).name
+        raise TypeError(f"Cannot cast {dev_type} {device_label!r} to {cls}")
+
+    @classmethod
+    def get_subclass(cls, device_label: str, mmcore: CMMCorePlus) -> type[Device]:
+        dev_type = mmcore.getDeviceType(device_label)
+        return _TYPE_MAP[dev_type]
+
     def __init__(
         self,
         device_label: str = UNASSIGNED,
@@ -67,6 +83,18 @@ class Device:
             self._mmc = mmcore
 
         self._label = device_label
+        self._type = None
+        if self.isLoaded():
+            adapter_name = self._mmc.getDeviceLibrary(device_label)
+            device_name = self._mmc.getDeviceName(device_label)
+            description = self._mmc.getDeviceDescription(device_label)
+            type = self._mmc.getDeviceType(device_label)  # noqa: A001
+            if self.type() != type:
+                raise TypeError(
+                    f"Cannot create loaded device with label {device_label!r} and type "
+                    f"{type.name!r} as an instance of {self.__class__.__name__!r}"
+                )
+
         self._adapter_name = adapter_name
         self._device_name = device_name
         self._type = type
@@ -81,7 +109,9 @@ class Device:
     @label.setter
     def label(self, value: str) -> None:
         if self.isLoaded():
-            raise RuntimeError("Cannot change label of loaded device")
+            raise RuntimeError(f"Cannot change label of loaded device {self.label!r}.")
+        if value in self._mmc.getLoadedDevices():
+            raise RuntimeError(f"Label {value!r} is already in use.")
         self._label = value
 
     @property
@@ -124,24 +154,53 @@ class Device:
     @property
     def properties(self) -> tuple[DeviceProperty, ...]:
         """Get all properties supported by device as DeviceProperty objects."""
-        return tuple(
-            DeviceProperty(self.label, name, self._mmc) for name in self.propertyNames()
-        )
+        return tuple(self.getPropertyObject(name) for name in self.propertyNames())
 
     def getPropertyObject(self, property_name: str) -> DeviceProperty:
         """Return a `DeviceProperty` object bound to this device on this core."""
+        if not self._mmc.hasProperty(self.label, property_name):
+            raise ValueError(f"Device {self.label!r} has no property {property_name!r}")
         return DeviceProperty(self.label, property_name, self._mmc)
+
+    def setProperty(self, property_name: str, value: bool | float | int | str) -> None:
+        """Set a device property value.
+
+        See also: [`Device.getPropertyObject`][].
+
+        Examples
+        --------
+        >>> camera = Device("Camera")
+        >>> camera.setProperty("Exposure", 100)
+        >>> print(camera.getProperty("Exposure"))
+        # or
+        >>> exposure = camera.getPropertyObject("Exposure")
+        >>> exposure.value = 100
+        >>> print(exposure.value)
+        """
+        return self._mmc.setProperty(self.label, property_name, value)
+
+    def getProperty(self, property_name: str) -> str:
+        """Get a device property value."""
+        return self._mmc.getProperty(self.label, property_name)
 
     def initialize(self) -> None:
         """Initialize device."""
         return self._mmc.initializeDevice(self.label)
+
+    def unload(self) -> None:
+        """Unload device from the core and adjust all configuration data."""
+        return self._mmc.unloadDevice(self.label)
+
+    def isLoaded(self) -> bool:
+        """Return `True` if device is loaded."""
+        return self.label in self._mmc.getLoadedDevices()
 
     def load(
         self,
         adapter_name: str = "",
         device_name: str = "",
         device_label: str = "",
-    ) -> None:
+    ) -> Device:
         """Load device from the plugin library.
 
         Parameters
@@ -160,6 +219,9 @@ class Device:
             assigned a default name: `adapter_name-device_name`, unless this Device
             instance was initialized with a label.
         """
+        # if self.isLoaded():
+        # raise RuntimeError(f"Device {self.label!r} is already loaded.")
+
         if not (adapter_name := adapter_name or self._adapter_name):
             raise TypeError("Must specify adapter_name")
         if not (device_name := device_name or self._device_name):
@@ -169,15 +231,10 @@ class Device:
         elif self.label == self.UNASSIGNED:
             self.label = f"{adapter_name}-{device_name}"
 
+        # note: this method takes care of label already being loaded and only
+        # warns if the exact label, adapter, and device are in use
         self._mmc.loadDevice(self.label, adapter_name, device_name)
-
-    def unload(self) -> None:
-        """Unload device from the core and adjust all configuration data."""
-        return self._mmc.unloadDevice(self.label)
-
-    def isLoaded(self) -> bool:
-        """Return `True` if device is loaded."""
-        return self.label in self._mmc.getLoadedDevices()
+        return Device.create(self.label, self._mmc)
 
     def detect(self) -> DeviceDetectionStatus:
         """Tries to communicate to device through a given serial port.
@@ -209,6 +266,14 @@ class Device:
         """Block the calling thread until device becomes non-busy."""
         self._mmc.waitForDevice(self.label)
 
+    def getParentLabel(self) -> str:
+        """Return the parent device label of this device."""
+        return self._mmc.getParentLabel(self.label)
+
+    def setParentLabel(self, parent_label: str) -> None:
+        """Set the parent device label of this device."""
+        self._mmc.setParentLabel(self.label, parent_label)
+
     def __repr__(self) -> str:
         if self.isLoaded():
             n = len(self.propertyNames())
@@ -218,49 +283,640 @@ class Device:
             props = "NOT LOADED"
             lib = ""
         core = repr(self._mmc).strip("<>")
-        return f"<Device {self.label!r} {lib}on {core}: {props}>"
+        return f"<{self.__class__.__name__} {self.label!r} {lib}on {core}: {props}>"
 
 
-class CameraDevice(Device): ...
+class CameraDevice(Device):
+    def type(self) -> Literal[DeviceType.Camera]:
+        return DeviceType.Camera
+
+    def setROI(self, x: int, y: int, width: int, height: int) -> None:
+        """Set region of interest for camera."""
+        self._mmc.setROI(self.label, x, y, width, height)
+
+    def getROI(self) -> list[int]:  # always a list of 4 ints ... but not a tuple
+        """Return region of interest for camera."""
+        return self._mmc.getROI(self.label)
+
+    # no device label-specific method for these ... would need to implement directly
+    # clearROI
+    # isMultiROISupported
+    # isMultiROIEnabled
+    # setMultiROI
+    # getMultiROI
+    # snapImage
+    # getImage
+    # getImageWidth
+    # getImageHeight
+    # getBytesPerPixel
+    # getImageBitDepth
+    # getNumberOfComponents
+    # getNumberOfCameraChannels
+
+    @property
+    def exposure(self) -> float:
+        return self.getExposure()
+
+    @exposure.setter
+    def exposure(self, value: float) -> None:
+        self.setExposure(value)
+
+    def setExposure(self, exposure: float) -> None:
+        """Set exposure time for camera."""
+        self._mmc.setExposure(self.label, exposure)
+
+    def getExposure(self) -> float:
+        """Return exposure time for camera."""
+        return self._mmc.getExposure(self.label)
+
+    def startSequenceAcquisition(
+        self, numImages: int, intervalMs: float, stopOnOverflow: bool
+    ) -> None:
+        """Start sequence acquisition."""
+        self._mmc.startSequenceAcquisition(
+            self.label, numImages, intervalMs, stopOnOverflow
+        )
+
+    def prepareSequenceAcquisition(self) -> None:
+        """Prepare sequence acquisition."""
+        self._mmc.prepareSequenceAcquisition(self.label)
+
+    def stopSequenceAcquisition(self) -> None:
+        """Stop sequence acquisition."""
+        self._mmc.stopSequenceAcquisition(self.label)
+
+    def isSequenceRunning(self) -> bool:
+        """Return `True` if sequence acquisition is running."""
+        return self._mmc.isSequenceRunning(self.label)
+
+    def isExposureSequenceable(self) -> bool:
+        """Return `True` if camera supports exposure sequence."""
+        return self._mmc.isExposureSequenceable(self.label)
+
+    def loadExposureSequence(self, sequence: Sequence[float]) -> None:
+        """Load exposure sequence."""
+        self._mmc.loadExposureSequence(self.label, sequence)
+
+    def startExposureSequence(self) -> None:
+        """Start exposure sequence."""
+        self._mmc.startExposureSequence(self.label)
+
+    def stopExposureSequence(self) -> None:
+        """Stop exposure sequence."""
+        self._mmc.stopExposureSequence(self.label)
+
+    def getExposureSequenceMaxLength(self) -> int:
+        """Return the maximum length of a camera's exposure sequence."""
+        return self._mmc.getExposureSequenceMaxLength(self.label)
+
+    isSequenceable = isExposureSequenceable
+    loadSequence = loadExposureSequence
+    startSequence = startExposureSequence
+    stopSequence = stopExposureSequence
+    getSequenceMaxLength = getExposureSequenceMaxLength
 
 
-class ShutterDevice(Device): ...
+class ShutterDevice(Device):
+    def type(self) -> Literal[DeviceType.Shutter]:
+        return DeviceType.Shutter
+
+    def open(self) -> None:
+        """Open shutter."""
+        self._mmc.setShutterOpen(self.label, True)
+
+    def close(self) -> None:
+        """Close shutter."""
+        self._mmc.setShutterOpen(self.label, False)
+
+    def isOpen(self) -> bool:
+        """Return `True` if shutter is open."""
+        return self._mmc.getShutterOpen(self.label)
 
 
-class StateDevice(Device): ...
+class StateDevice(Device):
+    def type(self) -> Literal[DeviceType.State]:
+        return DeviceType.State
+
+    @property
+    def state(self) -> int:
+        return self._mmc.getState(self.label)
+
+    @state.setter
+    def state(self, state: int) -> None:
+        self._mmc.setState(self.label, state)
+
+    def setState(self, state: int) -> None:
+        """Set state."""
+        self._mmc.setState(self.label, state)
+
+    def getState(self) -> int:
+        """Return state."""
+        return self._mmc.getState(self.label)
+
+    def getNumberOfStates(self) -> int:
+        """Return number of states."""
+        return self._mmc.getNumberOfStates(self.label)
+
+    def setStateLabel(self, label: str) -> None:
+        """Set state by label."""
+        self._mmc.setStateLabel(self.label, label)
+
+    def getStateLabel(self) -> StateLabel:
+        """Return state label."""
+        return self._mmc.getStateLabel(self.label)
+
+    def defineStateLabel(self, state: int, label: str) -> None:
+        """Define state labels."""
+        self._mmc.defineStateLabel(self.label, state, label)
+
+    def getStateLabels(self) -> tuple[StateLabel, ...]:
+        """Return state labels."""
+        return self._mmc.getStateLabels(self.label)
+
+    def getStateFromLabel(self, label: str) -> int:
+        """Return state for given label."""
+        return self._mmc.getStateFromLabel(self.label, label)
 
 
-class StageDevice(Device): ...
+class _StageBase(Device):
+    def stop(self) -> None:
+        """Stop XY stage movement."""
+        self._mmc.stop(self.label)
+
+    def home(self) -> None:
+        """Home XY stage."""
+        self._mmc.home(self.label)
 
 
-class XYStageDevice(Device): ...
+class StageDevice(_StageBase):
+    def type(self) -> Literal[DeviceType.Stage]:
+        return DeviceType.Stage
+
+    def setPosition(self, position: float) -> None:
+        self._mmc.setPosition(self.label, position)
+
+    def getPosition(self) -> float:
+        return self._mmc.getPosition(self.label)
+
+    @property
+    def position(self) -> float:
+        return self.getPosition()
+
+    @position.setter
+    def position(self, value: float) -> None:
+        self.setPosition(value)
+
+    def setRelativePosition(self, offset: float) -> None:
+        self._mmc.setRelativePosition(self.label, offset)
+
+    def setOrigin(self) -> None:
+        self._mmc.setOrigin(self.label)
+
+    def setAdapterOrigin(self, newZUm: float) -> None:
+        self._mmc.setAdapterOrigin(self.label, newZUm)
+
+    def setFocusDirection(self, sign: int) -> None:
+        self._mmc.setFocusDirection(self.label, sign)
+
+    def getFocusDirection(self) -> FocusDirection:
+        return self._mmc.getFocusDirection(self.label)
+
+    def isContinuousFocusDrive(self) -> bool:
+        """Return `True` if device supports continuous focus."""
+        return self._mmc.isContinuousFocusDrive(self.label)
+
+    def isStageSequenceable(self) -> bool:
+        """Return `True` if device supports stage sequence."""
+        return self._mmc.isStageSequenceable(self.label)
+
+    def isStageLinearSequenceable(self) -> bool:
+        """Return `True` if device supports linear stage sequence."""
+        return self._mmc.isStageLinearSequenceable(self.label)
+
+    def startStageSequence(self) -> None:
+        """Start stage sequence."""
+        self._mmc.startStageSequence(self.label)
+
+    def stopStageSequence(self) -> None:
+        """Stop stage sequence."""
+        self._mmc.stopStageSequence(self.label)
+
+    def getStageSequenceMaxLength(self) -> int:
+        """Return maximum length of stage sequence."""
+        return self._mmc.getStageSequenceMaxLength(self.label)
+
+    def loadStageSequence(self, positions: Sequence[float]) -> None:
+        """Load stage sequence."""
+        self._mmc.loadStageSequence(self.label, positions)
+
+    def setStageLinearSequence(self, dZ_um: float, nSlices: int) -> None:
+        """Set stage linear sequence."""
+        self._mmc.setStageLinearSequence(self.label, dZ_um, nSlices)
+
+    isSequenceable = isStageSequenceable
+    loadSequence = loadStageSequence
+    startSequence = startStageSequence
+    stopSequence = stopStageSequence
+    getSequenceMaxLength = getStageSequenceMaxLength
 
 
-class SerialDevice(Device): ...
+class XYStageDevice(_StageBase):
+    def type(self) -> Literal[DeviceType.XYStage]:
+        return DeviceType.XYStage
+
+    def setXYPosition(self, x: float, y: float) -> None:
+        """Set the position of the XY stage in microns."""
+        self._mmc.setXYPosition(self.label, x, y)
+
+    def getXYPosition(self) -> Sequence[float]:
+        """Return the position of the XY stage in microns."""
+        return self._mmc.getXYPosition(self.label)
+
+    @property
+    def position(self) -> tuple[float, float]:
+        """Return the position of the XY stage in microns."""
+        return tuple(self._mmc.getXYPosition(self.label))  # type: ignore [return-value]
+
+    @position.setter
+    def position(self, value: tuple[float, float]) -> None:
+        """Set the position of the XY stage in microns."""
+        self._mmc.setXYPosition(self.label, *value)
+
+    def setRelativeXYPosition(self, dx: float, dy: float) -> None:
+        """Set the relative position of the XY stage in microns."""
+        self._mmc.setRelativeXYPosition(self.label, dx, dy)
+
+    def getXPosition(self) -> float:
+        """Return the X position of the XY stage in microns."""
+        return self._mmc.getXPosition(self.label)
+
+    def getYPosition(self) -> float:
+        """Return the Y position of the XY stage in microns."""
+        return self._mmc.getYPosition(self.label)
+
+    def setOriginXY(self) -> None:
+        """Zero the current XY stage's coordinates at the current position."""
+        self._mmc.setOriginXY(self.label)
+
+    setOrigin = setOriginXY
+
+    def setOriginX(self) -> None:
+        """Zero the given XY stage's X coordinate at the current position."""
+        self._mmc.setOriginX(self.label)
+
+    def setOriginY(self) -> None:
+        """Zero the given XY stage's Y coordinate at the current position."""
+        self._mmc.setOriginY(self.label)
+
+    def setAdapterOriginXY(self, newXUm: float, newYUm: float) -> None:
+        """Enable software translation of coordinates for the current XY stage.
+
+        The current position of the stage becomes (newXUm, newYUm). It is recommended
+        that setOriginXY() be used instead where available.
+        """
+        self._mmc.setAdapterOriginXY(self.label, newXUm, newYUm)
+
+    def isXYStageSequenceable(self) -> bool:
+        """Return `True` if device supports XY stage sequence."""
+        return self._mmc.isXYStageSequenceable(self.label)
+
+    def startXYStageSequence(self) -> None:
+        """Start XY stage sequence."""
+        self._mmc.startXYStageSequence(self.label)
+
+    def stopXYStageSequence(self) -> None:
+        """Stop XY stage sequence."""
+        self._mmc.stopXYStageSequence(self.label)
+
+    def getXYStageSequenceMaxLength(self) -> int:
+        """Return maximum length of XY stage sequence."""
+        return self._mmc.getXYStageSequenceMaxLength(self.label)
+
+    def loadXYStageSequence(
+        self, xSequence: Sequence[float], ySequence: Sequence[float]
+    ) -> None:
+        """Load XY stage sequence."""
+        self._mmc.loadXYStageSequence(self.label, xSequence, ySequence)
+
+    def loadSequence(self, sequence: Sequence[tuple[float, float]]) -> None:
+        """Load XY stage sequence with a sequence of 2-tuples.
+
+        Provided as a wrapper for loadXYStageSequence, for API parity with other
+        sequencaable devices.
+        """
+        xSequence, ySequence = zip(*sequence)
+        self._mmc.loadXYStageSequence(self.label, xSequence, ySequence)
+
+    isSequenceable = isXYStageSequenceable
+    startSequence = startXYStageSequence
+    stopSequence = stopXYStageSequence
+    getSequenceMaxLength = getXYStageSequenceMaxLength
 
 
-class GenericDevice(Device): ...
+class SerialDevice(Device):
+    def type(self) -> Literal[DeviceType.Serial]:
+        return DeviceType.Serial
+
+    def setCommand(self, command: str, term: str) -> None:
+        """Send string to the serial device and return an answer."""
+        self._mmc.setSerialPortCommand(self.label, command, term)
+
+    def getAnswer(self, term: str) -> str:
+        """Continuously read from the serial port until the term is encountered."""
+        return self._mmc.getSerialPortAnswer(self.label, term)
+
+    def write(self, data: bytes) -> None:
+        """Send string to the serial device."""
+        self._mmc.writeToSerialPort(self.label, data)
+
+    def read(self) -> list[str]:
+        """Reads the contents of the Rx buffer."""
+        return self._mmc.readFromSerialPort(self.label)
+
+    def setProperties(
+        self,
+        answerTimeout: str,
+        baudRate: str,
+        delayBetweenCharsMs: str,
+        handshaking: str,
+        parity: str,
+        stopBits: str,
+    ) -> None:
+        """Sets all com port properties in a single call."""
+        self._mmc.setSerialProperties(
+            self.label,
+            answerTimeout,
+            baudRate,
+            delayBetweenCharsMs,
+            handshaking,
+            parity,
+            stopBits,
+        )
+
+    @property
+    def answer_timeout(self) -> str:
+        """Return the timeout for serial port commands."""
+        return self._mmc.getProperty(self.label, Keyword.AnswerTimeout)
+
+    @property
+    def baud_rate(self) -> str:
+        """Return the baud rate for serial port commands."""
+        return self._mmc.getProperty(self.label, Keyword.BaudRate)
+
+    @property
+    def data_bits(self) -> str:
+        """Return the data bits for serial port commands."""
+        return self._mmc.getProperty(self.label, Keyword.DataBits)
+
+    @property
+    def parity(self) -> str:
+        """Return the parity for serial port commands."""
+        return self._mmc.getProperty(self.label, Keyword.Parity)
+
+    @property
+    def stop_bits(self) -> str:
+        """Return the stop bits for serial port commands."""
+        return self._mmc.getProperty(self.label, Keyword.StopBits)
+
+    @property
+    def handshaking(self) -> str:
+        """Return the handshaking for serial port commands."""
+        return self._mmc.getProperty(self.label, Keyword.Handshaking)
+
+    @property
+    def delay_between_chars_ms(self) -> str:
+        """Return the delay between characters in milliseconds."""
+        return self._mmc.getProperty(self.label, Keyword.DelayBetweenCharsMs)
 
 
-class AutoFocusDevice(Device): ...
+class GenericDevice(Device):
+    def type(self) -> Literal[DeviceType.Generic]:
+        return DeviceType.Generic
 
 
-class CoreDevice(Device): ...
+class AutoFocusDevice(Device):
+    def type(self) -> Literal[DeviceType.AutoFocus]:
+        return DeviceType.AutoFocus
+
+    # none of these actually accept a label, and should be called on Core
+    # getLastFocusScore
+    # getCurrentFocusScore
+    # enableContinuousFocus
+    # isContinuousFocusEnabled
+    # isContinuousFocusLocked
+    # isContinuousFocusDrive
+    # fullFocus
+    # incrementalFocus
+    # setAutoFocusOffset
+    # getAutoFocusOffset
 
 
-class ImageProcessorDevice(Device): ...
+class SLMDevice(Device):
+    def type(self) -> Literal[DeviceType.SLM]:
+        return DeviceType.SLM
+
+    def setImage(self, pixels: Any) -> None:
+        """Write an image to the SLM ."""
+        self._mmc.setSLMImage(self.label, pixels)
+
+    @overload
+    def setPixelsTo(self, intensity: int, /) -> None: ...
+    @overload
+    def setPixelsTo(self, red: int, green: int, blue: int, /) -> None: ...
+    def setPixelsTo(self, *args: int) -> None:
+        """Set all SLM pixels to a single 8-bit intensity or RGB color."""
+        self._mmc.setSLMPixelsTo(self.label, *args)
+
+    def displayImage(self) -> None:
+        """Display the image on the SLM."""
+        self._mmc.displaySLMImage(self.label)
+
+    def setExposure(self, exposure_ms: float) -> None:
+        """Set exposure time for SLM."""
+        self._mmc.setSLMExposure(self.label, exposure_ms)
+
+    def getExposure(self) -> float:
+        """Return exposure time for SLM."""
+        return self._mmc.getSLMExposure(self.label)
+
+    @property
+    def exposure(self) -> float:
+        return self.getExposure()
+
+    @exposure.setter
+    def exposure(self, value: float) -> None:
+        self.setExposure(value)
+
+    def width(self) -> int:
+        """Return the width of the SLM image."""
+        return self._mmc.getSLMWidth(self.label)
+
+    def height(self) -> int:
+        """Return the height of the SLM image."""
+        return self._mmc.getSLMHeight(self.label)
+
+    def numberOfComponents(self) -> int:
+        """Return the number of components in the SLM image."""
+        return self._mmc.getSLMNumberOfComponents(self.label)
+
+    def bytesPerPixel(self) -> int:
+        """Return the number of bytes per pixel in the SLM image."""
+        return self._mmc.getSLMBytesPerPixel(self.label)
+
+    def getSequenceMaxLength(self) -> int:
+        """Return the maximum length of a sequence for the SLM."""
+        return self._mmc.getSLMSequenceMaxLength(self.label)
+
+    def isSequenceable(self) -> bool:
+        """Return `True` if the SLM supports sequences."""
+        # there is no MMCore API for this
+        try:
+            return self.getSequenceMaxLength() > 0
+        except RuntimeError:
+            return False
+
+    def loadSequence(self, imageSequence: list[bytes]) -> None:
+        """Load a sequence of images to the SLM."""
+        self._mmc.loadSLMSequence(self.label, imageSequence)
+
+    def startSequence(self) -> None:
+        """Start the sequence of images on the SLM."""
+        self._mmc.startSLMSequence(self.label)
+
+    def stopSequence(self) -> None:
+        """Stop the sequence of images on the SLM."""
+        self._mmc.stopSLMSequence(self.label)
 
 
-class SignalIODevice(Device): ...
+class HubDevice(Device):
+    def type(self) -> Literal[DeviceType.Hub]:
+        return DeviceType.Hub
+
+    def getInstalledDevices(self) -> tuple[str, ...]:
+        """Return the list of installed devices."""
+        return self._mmc.getInstalledDevices(self.label)
+
+    def getInstalledDeviceDescription(self, device_label: str) -> str:
+        """Return the description of the installed device."""
+        return self._mmc.getInstalledDeviceDescription(self.label, device_label)
+
+    def getLoadedPeripheralDevices(self) -> tuple[str, ...]:
+        """Return the list of loaded peripheral devices."""
+        return self._mmc.getLoadedPeripheralDevices(self.label)
 
 
-class MagnifierDevice(Device): ...
+class GalvoDevice(Device):
+    def type(self) -> Literal[DeviceType.Galvo]:
+        return DeviceType.Galvo
+
+    def pointAndFire(self, x: float, y: float, pulseTime_us: float) -> None:
+        """Set Galvo to (x, y) and fire the laser for a predetermined duration."""
+        self._mmc.pointGalvoAndFire(self.label, x, y, pulseTime_us)
+
+    def setSpotInterval(self, pulseTime_us: float) -> None:
+        """Set the SpotInterval for the specified galvo device."""
+        self._mmc.setGalvoSpotInterval(self.label, pulseTime_us)
+
+    def setPosition(self, x: float, y: float) -> None:
+        """Set the position of the galvo device."""
+        self._mmc.setGalvoPosition(self.label, x, y)
+
+    def getPosition(self) -> list[float]:
+        """Return the position of the galvo device."""
+        return self._mmc.getGalvoPosition(self.label)
+
+    @property
+    def position(self) -> list[float]:
+        return self._mmc.getGalvoPosition(self.label)
+
+    @position.setter
+    def position(self, value: tuple[float, float]) -> None:
+        self._mmc.setGalvoPosition(self.label, *value)
+
+    def setIlluminationState(self, state: bool) -> None:
+        """Set the galvo's illumination state to on or off."""
+        self._mmc.setGalvoIlluminationState(self.label, state)
+
+    def getXRange(self) -> float:
+        """Get the Galvo x range."""
+        return self._mmc.getGalvoXRange(self.label)
+
+    def getXMinimum(self) -> float:
+        """Get the Galvo x minimum."""
+        return self._mmc.getGalvoXMinimum(self.label)
+
+    def getYRange(self) -> float:
+        """Get the Galvo y range."""
+        return self._mmc.getGalvoYRange(self.label)
+
+    def getYMinimum(self) -> float:
+        """Get the Galvo y minimum."""
+        return self._mmc.getGalvoYMinimum(self.label)
+
+    def addPolygonVertex(self, polygonIndex: int, x: float, y: float) -> None:
+        """Add a vertex to the polygon."""
+        self._mmc.addGalvoPolygonVertex(self.label, polygonIndex, x, y)
+
+    def deletePolygons(self) -> None:
+        """Delete all polygons."""
+        self._mmc.deleteGalvoPolygons(self.label)
+
+    def loadPolygons(self) -> None:
+        """Load a set of galvo polygons to the device."""
+        self._mmc.loadGalvoPolygons(self.label)
+
+    def runPolygons(self) -> None:
+        """Run a loop of galvo polygons."""
+        self._mmc.runGalvoPolygons(self.label)
+
+    def runSequence(self) -> None:
+        """Run a sequence of galvo positions."""
+        self._mmc.runGalvoSequence(self.label)
+
+    def setPolygonRepetitions(self, repetitions: int) -> None:
+        """Set the number of times the galvo polygon should be repeated."""
+        self._mmc.setGalvoPolygonRepetitions(self.label, repetitions)
+
+    def getChannel(self) -> str:
+        """Get the name of the active galvo channel (for a multi-laser galvo device)."""
+        return self._mmc.getGalvoChannel(self.label)
 
 
-class SLMDevice(Device): ...
+class ImageProcessorDevice(Device):
+    def type(self) -> Literal[DeviceType.ImageProcessor]:
+        return DeviceType.ImageProcessor
 
 
-class HubDevice(Device): ...
+class SignalIODevice(Device):
+    def type(self) -> Literal[DeviceType.SignalIO]:
+        return DeviceType.SignalIO
 
 
-class GalvoDevice(Device): ...
+class MagnifierDevice(Device):
+    def type(self) -> Literal[DeviceType.Magnifier]:
+        return DeviceType.Magnifier
+
+
+# Special device...
+class CoreDevice(Device):
+    def type(self) -> Literal[DeviceType.Core]:
+        return DeviceType.Core
+
+
+_TYPE_MAP: dict[DeviceType, type[Device]] = {
+    DeviceType.Camera: CameraDevice,
+    DeviceType.Shutter: ShutterDevice,
+    DeviceType.State: StateDevice,
+    DeviceType.Stage: StageDevice,
+    DeviceType.XYStage: XYStageDevice,
+    DeviceType.Serial: SerialDevice,
+    DeviceType.Generic: GenericDevice,
+    DeviceType.AutoFocus: AutoFocusDevice,
+    DeviceType.Core: CoreDevice,
+    DeviceType.ImageProcessor: ImageProcessorDevice,
+    DeviceType.SignalIO: SignalIODevice,
+    DeviceType.Magnifier: MagnifierDevice,
+    DeviceType.SLM: SLMDevice,
+    DeviceType.Hub: HubDevice,
+    DeviceType.Galvo: GalvoDevice,
+}

--- a/src/pymmcore_plus/core/_device.py
+++ b/src/pymmcore_plus/core/_device.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Self
 
 from ._constants import DeviceType
 from ._property import DeviceProperty
 from .events._device_signal_view import _DevicePropValueSignal
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from pymmcore_plus.core.events._protocol import PSignalInstance
 
     from ._constants import DeviceDetectionStatus
@@ -46,6 +48,8 @@ class Device:
     UNASSIGNED = "__UNASSIGNED__"
     propertyChanged: PSignalInstance
 
+    @classmethod
+    def create(cls, device_label: str, mmcore: CMMCorePlus) -> Self: ...
     def __init__(
         self,
         device_label: str = UNASSIGNED,
@@ -215,3 +219,48 @@ class Device:
             lib = ""
         core = repr(self._mmc).strip("<>")
         return f"<Device {self.label!r} {lib}on {core}: {props}>"
+
+
+class CameraDevice(Device): ...
+
+
+class ShutterDevice(Device): ...
+
+
+class StateDevice(Device): ...
+
+
+class StageDevice(Device): ...
+
+
+class XYStageDevice(Device): ...
+
+
+class SerialDevice(Device): ...
+
+
+class GenericDevice(Device): ...
+
+
+class AutoFocusDevice(Device): ...
+
+
+class CoreDevice(Device): ...
+
+
+class ImageProcessorDevice(Device): ...
+
+
+class SignalIODevice(Device): ...
+
+
+class MagnifierDevice(Device): ...
+
+
+class SLMDevice(Device): ...
+
+
+class HubDevice(Device): ...
+
+
+class GalvoDevice(Device): ...

--- a/src/pymmcore_plus/core/_device.py
+++ b/src/pymmcore_plus/core/_device.py
@@ -110,7 +110,7 @@ class Device:
     def label(self, value: str) -> None:
         if self.isLoaded():
             raise RuntimeError(f"Cannot change label of loaded device {self.label!r}.")
-        if value in self._mmc.getLoadedDevices():
+        if value in self._mmc.getLoadedDevices():  # pragma: no cover
             raise RuntimeError(f"Label {value!r} is already in use.")
         self._label = value
 

--- a/src/pymmcore_plus/core/_device.py
+++ b/src/pymmcore_plus/core/_device.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal, Self, overload
+from typing import TYPE_CHECKING, Any, Literal, overload
 
 from ._constants import DeviceType, FocusDirection, Keyword
 from ._property import DeviceProperty

--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -23,6 +23,7 @@ from pymmcore_plus._util import find_micromanager, print_tabular_data
 from pymmcore_plus.mda import MDAEngine, MDARunner, PMDAEngine
 from pymmcore_plus.metadata.functions import summary_metadata
 
+from . import _device
 from ._adapter import DeviceAdapter
 from ._config import Configuration
 from ._config_group import ConfigGroup
@@ -34,7 +35,6 @@ from ._constants import (
     PixelType,
     PropertyType,
 )
-from ._device import Device
 from ._metadata import Metadata
 from ._property import DeviceProperty
 from .events import CMMCoreSignaler, PCoreSignaler, _get_auto_core_callback_class
@@ -50,6 +50,7 @@ if TYPE_CHECKING:
     from pymmcore_plus.metadata.schema import SummaryMetaV1
 
     _T = TypeVar("_T")
+    _DT = TypeVar("_DT", bound=_device.Device)
     ListOrTuple = list[_T] | tuple[_T, ...]
 
     class PropertySchema(TypedDict, total=False):
@@ -887,7 +888,7 @@ class CMMCorePlus(pymmcore.CMMCore):
             devices = [d for d in devices if ptrn.search(self.getDeviceLibrary(d))]
 
         for dev in devices:
-            yield Device(dev, mmcore=self) if as_object else dev
+            yield _device.Device(dev, mmcore=self) if as_object else dev
 
     @overload
     def iterProperties(
@@ -1068,7 +1069,34 @@ class CMMCorePlus(pymmcore.CMMCore):
         """
         return DeviceAdapter(library_name, mmcore=self)
 
-    def getDeviceObject(self, device_label: str) -> Device:
+    @overload
+    def getDeviceObject(
+        self, device_label: str, device_type: Literal[DeviceType.Camera]
+    ) -> _DT: ...
+    @overload
+    def getDeviceObject(
+        self, device_label: str, device_type: Literal[DeviceType.Camera]
+    ) -> _DT: ...
+    @overload
+    def getDeviceObject(
+        self, device_label: str, device_type: Literal[DeviceType.Camera]
+    ) -> _DT: ...
+    @overload
+    def getDeviceObject(
+        self, device_label: str, device_type: Literal[DeviceType.Camera]
+    ) -> _DT: ...
+    @overload
+    def getDeviceObject(
+        self, device_label: str, device_type: Literal[DeviceType.Camera]
+    ) -> _DT: ...
+    def getDeviceObject(
+        self, device_label: str, device_type: Literal[DeviceType.Any] = ...
+    ) -> Device: ...
+    @overload
+    def getDeviceObject(self, device_label: str, device_type: type[_DT]) -> _DT: ...
+    def getDeviceObject(
+        self, device_label: str, device_type: type[_DT] | DeviceType = DeviceType.Any
+    ) -> _DT:
         """Return a `Device` object bound to device_label on this core.
 
         :sparkles: *This method is new in `CMMCorePlus`.*

--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -338,7 +338,7 @@ class CMMCorePlus(pymmcore.CMMCore):
         with self._property_change_emission_ensured(stateDeviceLabel, STATE_PROPS):
             try:
                 super().setStateLabel(stateDeviceLabel, stateLabel)
-            except RuntimeError as e:
+            except RuntimeError as e:  # pragma: no cover
                 state_labels = self.getStateLabels(stateDeviceLabel)
                 msg = f"{e}.  Available Labels: {state_labels}"
                 raise RuntimeError(msg) from None
@@ -384,7 +384,7 @@ class CMMCorePlus(pymmcore.CMMCore):
             recognized by the specific plugin library. See
             [`pymmcore.CMMCore.getAvailableDevices`][] for a list of valid device names.
         """
-        if str(label).lower() == Keyword.CoreDevice.value.lower():
+        if str(label).lower() == Keyword.CoreDevice.value.lower():  # pragma: no cover
             raise ValueError(f"Label {label!r} is reserved.")
 
         try:

--- a/tests/test_device_class.py
+++ b/tests/test_device_class.py
@@ -62,6 +62,11 @@ def test_device_load_errors(core: CMMCorePlus) -> None:
         dev.getPropertyObject("NotAProperty")
 
 
+def test_device_object_wrong_type(core: CMMCorePlus) -> None:
+    with pytest.raises(TypeError, match="requested but device"):
+        core.getDeviceObject("Camera", DeviceType.XYStage)
+
+
 def test_device_callbacks(core: CMMCorePlus) -> None:
     dev = Device("Camera", core)
     mock = Mock()

--- a/tests/test_device_class.py
+++ b/tests/test_device_class.py
@@ -3,20 +3,31 @@ from unittest.mock import Mock
 import pytest
 
 from pymmcore_plus import CMMCorePlus, Device, DeviceDetectionStatus, DeviceType
+from pymmcore_plus import core as _core
+from pymmcore_plus.core._constants import FocusDirection
+from pymmcore_plus.core._property import DeviceProperty
 
 
-def test_device_object(core: CMMCorePlus):
+def test_device_object(core: CMMCorePlus) -> None:
     for device in core.iterDevices(as_object=True):
         device.wait()
         assert not device.isBusy()
         assert device.schema()
+        assert isinstance(device.schema(), dict)
         assert device.description()
+        assert isinstance(device.description(), str)
         lib = device.library()
         assert lib if device.type() is not DeviceType.Core else not lib
         assert device.name()
         assert repr(device)
         assert device.core is core
         assert device.isLoaded()
+        assert isinstance(device.usesDelay(), bool)
+        if device.usesDelay():
+            device.setDelayMs(0.1)
+            assert device.delayMs() == 0.1
+
+        assert all(isinstance(prop, DeviceProperty) for prop in device.properties)
 
         if device.supportsDetection():
             assert device.detect() is not DeviceDetectionStatus.Unimplemented
@@ -28,8 +39,10 @@ def test_device_object(core: CMMCorePlus):
             assert not device.isLoaded()
             assert "NOT LOADED" in repr(device)
 
+        assert repr(device)
 
-def test_device_load_errors(core: CMMCorePlus):
+
+def test_device_load_errors(core: CMMCorePlus) -> None:
     dev = Device("Something", core)
 
     with pytest.raises(RuntimeError) as e:
@@ -45,8 +58,11 @@ def test_device_load_errors(core: CMMCorePlus):
     with pytest.warns(UserWarning):
         dev.load("DemoCamera", "DCam")
 
+    with pytest.raises(ValueError, match="has no property"):
+        dev.getPropertyObject("NotAProperty")
 
-def test_device_callbacks(core: CMMCorePlus):
+
+def test_device_callbacks(core: CMMCorePlus) -> None:
     dev = Device("Camera", core)
     mock = Mock()
     mock2 = Mock()
@@ -71,3 +87,143 @@ def test_device_callbacks(core: CMMCorePlus):
     core.setProperty("Camera", "Gain", "4")
     mock.assert_not_called()
     mock2.assert_not_called()
+
+
+DEV_TYPES: dict[str, DeviceType] = {
+    "Camera": DeviceType.Camera,
+    "Emission": DeviceType.State,
+    "Z": DeviceType.Stage,
+    "XY": DeviceType.XYStage,
+    "LED Shutter": DeviceType.Shutter,
+    "Autofocus": DeviceType.AutoFocus,
+    "Core": DeviceType.Core,
+    "DHub": DeviceType.Hub,
+}
+
+
+@pytest.mark.parametrize("label, dev_type", DEV_TYPES.items())
+def test_device_sub_types(core: CMMCorePlus, label: str, dev_type: DeviceType) -> None:
+    device = core.getDeviceObject(label, dev_type)
+    assert device.type() is dev_type
+
+    # note, some of these tests are specific to the exact label being used
+    if device.type() is DeviceType.Camera:
+        assert isinstance(device, _core.CameraDevice)
+        device.setROI(0, 0, 10, 10)
+        assert tuple(device.getROI()) == (0, 0, 10, 10)
+        device.setExposure(42)
+        assert device.getExposure() == 42
+        device.exposure = 12
+        assert device.exposure == 12
+        assert not device.isSequenceable()
+        assert not device.isSequenceRunning()
+        assert device.getParentLabel() == "DHub"
+    elif device.type() is DeviceType.XYStage:
+        assert isinstance(device, _core.XYStageDevice)
+        device.setXYPosition(10, 10)
+        device.wait()
+        assert tuple(round(x) for x in device.getXYPosition()) == (10, 10)
+        device.position = (20, 30)
+        device.wait()
+        assert tuple(round(x) for x in device.position) == (20, 30)
+        device.setRelativeXYPosition(1, 1)
+        device.wait()
+        assert tuple(round(x) for x in device.getXYPosition()) == (21, 31)
+        assert round(device.getXPosition()) == 21
+        assert round(device.getYPosition()) == 31
+        device.setOriginXY()
+        device.setOrigin()
+        device.setAdapterOriginXY(2, 2)
+        assert not device.isXYStageSequenceable()
+        assert not device.isSequenceable()
+
+    elif device.type() is DeviceType.Stage:
+        assert isinstance(device, _core.StageDevice)
+        device.setPosition(10)
+        assert device.getPosition() == 10
+        device.position = 1
+        assert device.position == 1
+        device.setRelativePosition(1)
+        assert device.getPosition() == 2
+        device.setOrigin()
+        try:
+            device.setAdapterOrigin(2)
+        except RuntimeError:
+            pass
+        device.setFocusDirection(10)
+        assert device.getFocusDirection() is FocusDirection.TowardSample
+        device.setFocusDirection(-1)
+        assert device.getFocusDirection() is FocusDirection.AwayFromSample
+        assert not device.isContinuousFocusDrive()
+        assert not device.isStageLinearSequenceable()
+        assert not device.isStageSequenceable()
+        assert not device.isSequenceable()
+        device.wait()
+        device.stop()
+    elif device.type() is DeviceType.Shutter:
+        assert isinstance(device, _core.ShutterDevice)
+        device.open()
+        assert device.isOpen()
+        device.close()
+        assert not device.isOpen()
+    elif device.type() is DeviceType.State:
+        assert isinstance(device, _core.StateDevice)
+        device.state = 2
+        assert device.state == 2
+        device.setState(1)
+        assert device.getState() == 1
+        assert device.getNumberOfStates() == 10
+        device.setStateLabel("Chroma-D460")
+        assert device.getStateLabel() == "Chroma-D460"
+        device.defineStateLabel(0, "MyState")
+        device.state = 0
+        assert device.getStateLabel() == "MyState"
+        assert "MyState" in device.getStateLabels()
+        assert device.getStateFromLabel("MyState") == 0
+    elif device.type() is DeviceType.AutoFocus:
+        assert isinstance(device, _core.AutoFocusDevice)
+    elif device.type() is DeviceType.Core:
+        assert isinstance(device, _core.CoreDevice)
+    elif device.type() is DeviceType.Hub:
+        assert isinstance(device, _core.HubDevice)
+        assert "DWheel" in device.getInstalledDevices()
+        assert isinstance(device.getInstalledDeviceDescription("DCam"), str)
+        assert "Camera" in device.getLoadedPeripheralDevices()
+    # ------------------------------
+    # these aren't actually tested with the test config
+    elif device.type() is DeviceType.SLM:
+        assert isinstance(device, _core.SLMDevice)
+    elif device.type() is DeviceType.SignalIO:
+        assert isinstance(device, _core.SignalIODevice)
+    elif device.type() is DeviceType.Generic:
+        assert isinstance(device, _core.GenericDevice)
+    elif device.type() is DeviceType.Magnifier:
+        assert isinstance(device, _core.MagnifierDevice)
+    elif device.type() is DeviceType.Galvo:
+        assert isinstance(device, _core.GalvoDevice)
+    elif device.type() is DeviceType.ImageProcessor:
+        assert isinstance(device, _core.ImageProcessorDevice)
+    elif device.type() is DeviceType.Serial:
+        assert isinstance(device, _core.SerialDevice)
+    # --------------------------------
+
+
+def test_device_errors(core: CMMCorePlus) -> None:
+    assert not isinstance(Device("Camera", core), _core.CameraDevice)
+
+    cam = _core.CameraDevice("Camera", core)
+    assert isinstance(cam, _core.CameraDevice)
+    assert cam.isLoaded()
+    with pytest.raises(RuntimeError, match="Cannot change label"):
+        cam.label = "Camera2"
+
+    assert isinstance(_core.Device.create("Camera", core), _core.CameraDevice)
+    with pytest.raises(TypeError, match="Cannot cast"):
+        _core.StageDevice.create("Camera", core)
+
+    with pytest.raises(RuntimeError, match="No device with label"):
+        _core.StageDevice.create("NotExist", core)
+
+    # wrong type
+    with pytest.raises(TypeError, match="Cannot create loaded device with label "):
+        _core.StageDevice("Camera", core)


### PR DESCRIPTION
this adds `pymmcore_plus.core.Device` subclasses for each `DeviceType`, with device-type specific methods:

for example:

```python
In [1]: core = CMMCorePlus()

In [2]: core.loadSystemConfiguration()

In [4]: xy = core.getDeviceObject('XY')

In [5]: xy.position
Out[5]: (-0.0, -0.0)

In [6]: xy.position = (10, 20)

In [7]: xy.position
Out[7]: (10.004999999999999, 19.995)

In [10]: xy.getXYPosition()  # standard API alias
Out[10]: [10.004999999999999, 19.995]

In [12]: xy.isSequenceable()
Out[12]: False
```

cc @marktsuchida 

`core.getDeviceObject` also becomes type-safe.  If you know the type of the device for the label you're passing, you can pass either the `pymmcore_plus.core.Device` subclass, or the `DeviceType` enum and your IDE will know what subtype you're getting (and an exception will be raised if you were wrong about the device type)

<img width="1097" alt="Screenshot 2025-02-16 at 1 43 56 PM" src="https://github.com/user-attachments/assets/c8b060d8-5e93-461b-87d7-bc58ccccd4f2" />

