### PR TITLE
refactor: set config only when different

### DIFF
--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from re import Pattern
 from textwrap import dedent
 from threading import Thread
-from typing import TYPE_CHECKING, Any, Callable, NamedTuple, TypeVar, overload
+from typing import TYPE_CHECKING, Any, Callable, NamedTuple, TypeVar, cast, overload
 
 from psygnal import SignalInstance
 
@@ -221,7 +221,13 @@ class CMMCorePlus(pymmcore.CMMCore):
             self.setPrimaryLogFile(str(logfile))
             logger.debug("Initialized core %s", self)
 
-        self._last_config: str | None = None  # last loaded config file
+        # some internal state, remembering the last arguments passed to various
+        # functions.  These are subject to change: do not depend on externally
+        self._last_sys_config: str | None = None  # last loaded config file
+        self._last_config: tuple[str, str] = ("", "")
+        # last position set by setXYPosition, None means currentXYStageDevice
+        self._last_xy_position: dict[str | None, tuple[float, float]] = {}
+
         self._mm_path = mm_path or find_micromanager()
         if not adapter_paths and self._mm_path:
             adapter_paths = [self._mm_path]
@@ -399,15 +405,15 @@ class CMMCorePlus(pymmcore.CMMCore):
             fpath = Path(self._mm_path) / fileName
         if not fpath.exists():
             raise FileNotFoundError(f"Path does not exist: {fpath}")
-        self._last_config = str(fpath.resolve())
-        super().loadSystemConfiguration(self._last_config)
+        self._last_sys_config = str(fpath.resolve())
+        super().loadSystemConfiguration(self._last_sys_config)
 
     def systemConfigurationFile(self) -> str | None:
         """Return the path to the last loaded system configuration file, or `None`.
 
         :sparkles: *This method is new in `CMMCorePlus`.*
         """
-        return self._last_config
+        return self._last_sys_config
 
     def unloadAllDevices(self) -> None:
         """Unload all devices from the core and reset all configuration data.
@@ -740,6 +746,7 @@ class CMMCorePlus(pymmcore.CMMCore):
         """
         super().setConfig(groupName, configName)
         self.events.configSet.emit(groupName, configName)
+        self._last_config = (groupName, configName)
 
     # NEW methods
 
@@ -1340,6 +1347,25 @@ class CMMCorePlus(pymmcore.CMMCore):
             self.setZPosition(z + dz)
         self.waitForDevice(self.getXYStageDevice())
         self.waitForDevice(self.getFocusDevice())
+
+    @overload
+    def setXYPosition(self, x: float, y: float, /) -> None: ...
+    @overload
+    def setXYPosition(self, xyStageLabel: str, x: float, y: float, /) -> None: ...
+    def setXYPosition(self, *args: str | float) -> None:
+        """Sets the position of the XY stage in microns.
+
+        **Why Override?** to store the last commanded stage position internally.
+        """
+        if len(args) == 2:
+            label: str | None = None
+            x, y = cast(tuple[float, float], args)
+        elif len(args) == 3:
+            label, x, y = args  # type: ignore
+        else:
+            raise ValueError("Invalid number of arguments. Expected 2 or 3.")
+        super().setXYPosition(*args)  # type: ignore
+        self._last_xy_position[label] = (x, y)
 
     def getZPosition(self) -> float:
         """Obtains the current position of the Z axis of the Z stage in microns.

--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -1359,7 +1359,7 @@ class CMMCorePlus(pymmcore.CMMCore):
         """
         if len(args) == 2:
             label: str | None = None
-            x, y = cast(tuple[float, float], args)
+            x, y = cast("tuple[float, float]", args)
         elif len(args) == 3:
             label, x, y = args  # type: ignore
         else:

--- a/tests/test_sequencing.py
+++ b/tests/test_sequencing.py
@@ -66,7 +66,7 @@ def test_sequenced_mda(core: CMMCorePlus) -> None:
     expected_exposure = [call(5), call(10)] * 2
     assert core_mock.setExposure.call_args_list == expected_exposure
 
-    expected_pos = [call(0, 0), call(0, 0), call(1, 1), call(1, 1)]
+    expected_pos = [call(0, 0), call(1, 1)]
     assert core_mock.setXYPosition.call_args_list == expected_pos
 
 


### PR DESCRIPTION
This might speed up https://github.com/pymmcore-plus/pymmcore-plus/issues/445 ... @zbaker11, @ssalteko if you have time and are able/willing to install this branch, it would be good to know if this speeds up your use case.  Note: you would only notice a difference here for the single-channel case (i.e. where no actual config change is needed).

cc @fdrgsp 