### PR TITLE
feat: Support mm-device-adapters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,9 @@ jobs:
             qt: "PyQt6"
           - platform: ubuntu-latest
             python-version: "3.12"
-          # - platform: windows-latest
-          #   python-version: "3.13"
-          #   qt: "PyQt6"
+          - platform: windows-latest
+            python-version: "3.13"
+            qt: "PyQt6"
 
     steps:
       - uses: actions/checkout@v4
@@ -109,24 +109,6 @@ jobs:
           python -m pip install -e .[test,PyQt6]
           python -m pip uninstall -y pymmcore
           python -m pip install pymmcore-nano>=11.3.0.71.1
-
-      - name: Set cache path
-        shell: bash
-        run: |
-          set -e
-          CACHE_PATH=$(python -c 'from pymmcore_plus import install; print(install.USER_DATA_MM_PATH)')
-          echo "CACHE_PATH=$CACHE_PATH" >> $GITHUB_ENV
-
-      - name: Cache Drivers
-        id: cache-mm-build
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.CACHE_PATH }}
-          key: ${{ runner.os }}-mmbuild-73-${{ hashFiles('src/pymmcore_plus/_build.py') }}
-
-      - name: Install Micro-Manager
-        if: steps.cache-mm-build.outputs.cache-hit != 'true'
-        run: mmcore install
 
       - name: Test
         run: pytest -v --color=yes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         run: pip install -e .[${{ matrix.qt }}]
 
       - name: Set cache path
-        shell: bash
+        if: runner.os == 'Linux'
         run: |
           set -e
           CACHE_PATH=$(python -c 'from pymmcore_plus import install; print(install.USER_DATA_MM_PATH)')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,10 +74,6 @@ jobs:
         if: runner.os == 'Linux' && steps.cache-mm-build.outputs.cache-hit != 'true'
         run: mmcore build-dev
 
-      - name: Install Micro-Manager
-        if: runner.os != 'Linux' && steps.cache-mm-build.outputs.cache-hit != 'true'
-        run: mmcore install
-
       - name: Remove Qt
         if: runner.os == 'Linux'
         run: pip uninstall -y pytest-qt qtpy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
     uses: pyapp-kit/workflows/.github/workflows/test-dependents.yml@main
     with:
       os: windows-latest
-      python-version: "3.10"
+      python-version: "3.12"
       dependency-repo: ${{ matrix.repo }}
       dependency-extras: "test"
       post-install-cmd: "mmcore install"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
           echo "CACHE_PATH=$CACHE_PATH" >> $GITHUB_ENV
 
       - name: Cache Drivers
+        if: runner.os == 'Linux'
         id: cache-mm-build
         uses: actions/cache@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ PySide6 = ["PySide6 >=6.4.0,<6.8"]
 PyQt5 = ["PyQt5 >=5.15.4"]
 PyQt6 = ["PyQt6 >=6.4.2,<6.8"]
 test = [
-    "msgspec; python_version < '3.13'",
+    "msgspec",
     "msgpack",
     "pytest-cov >=4",
     "pytest-qt >=4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,8 @@ test = [
     "tifffile >=2021.6.14",
     "zarr >=2.2,<3",
     "xarray",
+    "mm-device-adapters; sys_platform == 'win32'",
+    "mm-device-adapters; sys_platform == 'darwin' and platform_machine == 'x86_64'",
 ]
 dev = [
     "ipython",

--- a/src/pymmcore_plus/_util.py
+++ b/src/pymmcore_plus/_util.py
@@ -115,12 +115,26 @@ def find_micromanager(return_first: bool = True) -> str | None | list[str]:
             full_list[path] = None
 
     # then look for mm-device-adapters
-    try:
+    with suppress(ImportError):
         import mm_device_adapters
 
+        from . import _pymmcore
+
+        mm_dev_div = mm_device_adapters.__version__.split(".")[0]
+        pymm_div = str(_pymmcore.version_info.device_interface)
+
+        if pymm_div != mm_dev_div:  # pragma: no cover
+            warnings.warn(
+                "mm-device-adapters installed, but its device interface "
+                f"version ({mm_dev_div}) "
+                f"does not match the device interface version of {_pymmcore.BACKEND}"
+                f"({pymm_div}). You may wish to run"
+                f" `pip install --force-reinstall mm-device-adapters=={pymm_div}`. "
+                "mm-device-adapters will be ignored.",
+                stacklevel=2,
+            )
+
         return mm_device_adapters.device_adapter_path()  # type: ignore
-    except ImportError:
-        pass
 
     # then look in user_data_dir
     _folders = (p for p in USER_DATA_MM_PATH.glob("Micro-Manager*") if p.is_dir())

--- a/src/pymmcore_plus/_util.py
+++ b/src/pymmcore_plus/_util.py
@@ -163,7 +163,7 @@ def find_micromanager(return_first: bool = True) -> str | None | list[str]:
             first := next(
                 (x for x in local_install if _mm_path_has_compatible_div(x)), None
             )
-        ):
+        ):  # pragma: no cover
             logger.debug("using MM path from local install: %s", first)
             return str(first)
         for x in local_install:
@@ -186,7 +186,7 @@ def find_micromanager(return_first: bool = True) -> str | None | list[str]:
                 "could not find micromanager directory. Please run 'mmcore install'"
             )
             return None
-        if _mm_path_has_compatible_div(pth):
+        if _mm_path_has_compatible_div(pth):  # pragma: no cover
             logger.debug("using MM path found in applications: %s", pth)
             return str(pth)
     if pth is not None:
@@ -682,4 +682,4 @@ def _mm_path_has_compatible_div(folder: Path | str) -> bool:
     for lib_path in Path(folder).glob("*mmgr_dal*"):
         with suppress(Exception):
             return get_device_interface_version(lib_path) == div
-    return False
+    return False  # pragma: no cover

--- a/src/pymmcore_plus/_util.py
+++ b/src/pymmcore_plus/_util.py
@@ -114,6 +114,14 @@ def find_micromanager(return_first: bool = True) -> str | None | list[str]:
                 return path
             full_list[path] = None
 
+    # then look for mm-device-adapters
+    try:
+        import mm_device_adapters
+
+        return mm_device_adapters.device_adapter_path()  # type: ignore
+    except ImportError:
+        pass
+
     # then look in user_data_dir
     _folders = (p for p in USER_DATA_MM_PATH.glob("Micro-Manager*") if p.is_dir())
     user_install = sorted(_folders, reverse=True)


### PR DESCRIPTION
this supports device adapters installed with `pip install mm-device-adapters` (https://github.com/pymmcore-plus/mm-device-adapters).  which makes it possible to get a fully working system just with `pip install pymmcore-plus mm-device-adapters`