### PR TITLE
chore: revert mm-device-adapters usage in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,14 +57,13 @@ jobs:
         run: pip install -e .[${{ matrix.qt }}]
 
       - name: Set cache path
-        if: runner.os == 'Linux'
+        shell: bash
         run: |
           set -e
           CACHE_PATH=$(python -c 'from pymmcore_plus import install; print(install.USER_DATA_MM_PATH)')
           echo "CACHE_PATH=$CACHE_PATH" >> $GITHUB_ENV
 
       - name: Cache Drivers
-        if: runner.os == 'Linux'
         id: cache-mm-build
         uses: actions/cache@v4
         with:
@@ -74,6 +73,10 @@ jobs:
       - name: Build Micro-Manager
         if: runner.os == 'Linux' && steps.cache-mm-build.outputs.cache-hit != 'true'
         run: mmcore build-dev
+
+      - name: Install Micro-Manager
+        if: runner.os != 'Linux' && steps.cache-mm-build.outputs.cache-hit != 'true'
+        run: mmcore install
 
       - name: Remove Qt
         if: runner.os == 'Linux'
@@ -110,6 +113,24 @@ jobs:
           python -m pip install -e .[test,PyQt6]
           python -m pip uninstall -y pymmcore
           python -m pip install pymmcore-nano>=11.3.0.71.1
+
+      - name: Set cache path
+        shell: bash
+        run: |
+          set -e
+          CACHE_PATH=$(python -c 'from pymmcore_plus import install; print(install.USER_DATA_MM_PATH)')
+          echo "CACHE_PATH=$CACHE_PATH" >> $GITHUB_ENV
+
+      - name: Cache Drivers
+        id: cache-mm-build
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.CACHE_PATH }}
+          key: ${{ runner.os }}-mmbuild-73-${{ hashFiles('src/pymmcore_plus/_build.py') }}
+
+      - name: Install Micro-Manager
+        if: steps.cache-mm-build.outputs.cache-hit != 'true'
+        run: mmcore install
 
       - name: Test
         run: pytest -v --color=yes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.CACHE_PATH }}
-          key: ${{ runner.os }}-mmbuild-73-${{ hashFiles('src/pymmcore_plus/_build.py') }}-1
+          key: ${{ runner.os }}-mmbuild-73-${{ hashFiles('src/pymmcore_plus/_build.py') }}
 
       - name: Build Micro-Manager
         if: runner.os == 'Linux' && steps.cache-mm-build.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.CACHE_PATH }}
-          key: ${{ runner.os }}-mmbuild-73-${{ hashFiles('src/pymmcore_plus/_build.py') }}
+          key: ${{ runner.os }}-mmbuild-73-${{ hashFiles('src/pymmcore_plus/_build.py') }}-1
 
       - name: Build Micro-Manager
         if: runner.os == 'Linux' && steps.cache-mm-build.outputs.cache-hit != 'true'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,8 +69,6 @@ test = [
     "tifffile >=2021.6.14",
     "zarr >=2.2,<3",
     "xarray",
-    "mm-device-adapters; sys_platform == 'win32'",
-    "mm-device-adapters; sys_platform == 'darwin' and platform_machine == 'x86_64'",
 ]
 dev = [
     "ipython",

--- a/src/pymmcore_plus/_util.py
+++ b/src/pymmcore_plus/_util.py
@@ -184,8 +184,12 @@ def find_micromanager(return_first: bool = True) -> str | None | list[str]:
         if pth and _mm_path_has_compatible_div(pth):  # pragma: no cover
             logger.debug("using MM path found in applications: %s", pth)
             return str(pth)
+        from . import _pymmcore
+
+        div = _pymmcore.version_info.device_interface
         logger.error(
-            "could not find micromanager directory. Please run 'mmcore install'"
+            f"could not find micromanager directory for device interface {div}. "
+            "Please run 'mmcore install'"
         )
         return None
     if pth is not None:

--- a/src/pymmcore_plus/_util.py
+++ b/src/pymmcore_plus/_util.py
@@ -658,9 +658,9 @@ def get_device_interface_version(lib_path: str | Path) -> int:
     import ctypes
 
     if sys.platform.startswith("win"):
-        lib = ctypes.WinDLL(lib_path)
+        lib = ctypes.WinDLL(str(lib_path))
     else:
-        lib = ctypes.CDLL(lib_path)
+        lib = ctypes.CDLL(str(lib_path))
 
     try:
         func = lib.GetDeviceInterfaceVersion

--- a/src/pymmcore_plus/_util.py
+++ b/src/pymmcore_plus/_util.py
@@ -114,32 +114,6 @@ def find_micromanager(return_first: bool = True) -> str | None | list[str]:
                 return path
             full_list[path] = None
 
-    # then look for mm-device-adapters
-    with suppress(ImportError):
-        import mm_device_adapters
-
-        from . import _pymmcore
-
-        mm_dev_div = mm_device_adapters.__version__.split(".")[0]
-        pymm_div = str(_pymmcore.version_info.device_interface)
-
-        if pymm_div != mm_dev_div:  # pragma: no cover
-            warnings.warn(
-                "mm-device-adapters installed, but its device interface "
-                f"version ({mm_dev_div}) "
-                f"does not match the device interface version of {_pymmcore.BACKEND}"
-                f"({pymm_div}). You may wish to run"
-                f" `pip install --force-reinstall mm-device-adapters=={pymm_div}`. "
-                "mm-device-adapters will be ignored.",
-                stacklevel=2,
-            )
-        else:
-            path = mm_device_adapters.device_adapter_path()
-            if return_first:
-                logger.debug("using MM path from mm-device-adapters: %s", path)
-                return str(path)
-            full_list[path] = None
-
     # then look in user_data_dir
     _folders = (p for p in USER_DATA_MM_PATH.glob("Micro-Manager*") if p.is_dir())
     if user_install := sorted(_folders, reverse=True):

--- a/src/pymmcore_plus/_util.py
+++ b/src/pymmcore_plus/_util.py
@@ -181,14 +181,13 @@ def find_micromanager(return_first: bool = True) -> str | None | list[str]:
     app_path = applications[sys.platform]
     pth = next(app_path.glob("[m,M]icro-[m,M]anager*"), None)
     if return_first:
-        if pth is None:
-            logger.error(
-                "could not find micromanager directory. Please run 'mmcore install'"
-            )
-            return None
-        if _mm_path_has_compatible_div(pth):  # pragma: no cover
+        if pth and _mm_path_has_compatible_div(pth):  # pragma: no cover
             logger.debug("using MM path found in applications: %s", pth)
             return str(pth)
+        logger.error(
+            "could not find micromanager directory. Please run 'mmcore install'"
+        )
+        return None
     if pth is not None:
         full_list[str(pth)] = None
     return list(full_list)


### PR DESCRIPTION
reverts the addition of mm-device-adapters to the testing suite from #455 


this also fixes a bug seen by @fdrgsp where, on windows, no micromanager is found (for python 3.11 and below) due to an error in check_device_interface... due to `ctypes.winDLL()` not accepting Path objects 