### PR TITLE
feat: add ValueBatcher pattern, for sharing control of a slow target value

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,8 @@ sources = ["src"]
 [tool.ruff]
 line-length = 88
 target-version = "py39"
+fix = true
+unsafe-fixes = true
 
 [tool.ruff.lint]
 pydocstyle = { convention = "numpy" }

--- a/src/pymmcore_plus/__init__.py
+++ b/src/pymmcore_plus/__init__.py
@@ -8,6 +8,7 @@ except PackageNotFoundError:  # pragma: no cover
     __version__ = "unknown"
 
 
+from ._batcher import AbstractValueBatcher, get_device_batcher
 from ._logger import configure_logging
 from ._util import find_micromanager, use_micromanager
 from .core import (
@@ -34,6 +35,7 @@ from .core.events import CMMCoreSignaler, PCoreSignaler
 from .mda._runner import GeneratorMDASequence
 
 __all__ = [
+    "AbstractValueBatcher",
     "ActionType",
     "CFGCommand",
     "CFGGroup",
@@ -59,5 +61,6 @@ __all__ = [
     "__version__",
     "configure_logging",
     "find_micromanager",
+    "get_device_batcher",
     "use_micromanager",
 ]

--- a/src/pymmcore_plus/_batcher.py
+++ b/src/pymmcore_plus/_batcher.py
@@ -1,0 +1,282 @@
+"""Batch setX calls to a device."""
+
+from __future__ import annotations
+
+import abc
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+from typing import Any, Generic, Literal, TypeVar
+
+import psygnal
+from typing_extensions import TypeAlias
+
+from pymmcore_plus.core._constants import DeviceType
+from pymmcore_plus.core._mmcore_plus import CMMCorePlus
+
+T = TypeVar("T")
+DT = TypeVar("DT", bound=DeviceType)
+
+
+class AbstractValueBatcher(ABC, Generic[T]):
+    """Abstract base class for batching a series of setX calls to a device.
+
+    A ValueBatcher is a class that batches a series of setX calls to a device, retaining
+    an internal target value, and emitting a signal when the device has reached its
+    target and is idle. It can be shared by multiple players (e.g. widgets, or other
+    classes) that want to control the same device, and allows them all to issue
+    relative/absolute moves, and be notified when the device is idle.
+
+    A common use case is to batch setPosition calls to a stage device, where you might
+    want to accumulate a series of relative moves, and snap an image only when the stage
+    is idle.
+    """
+
+    finished = psygnal.Signal()
+    """Signal emitted when the device has reached its target and is idle."""
+
+    def __init__(self, zero: T) -> None:
+        self._zero = zero
+        self._reset()
+
+    def _reset(self) -> None:
+        self._base: T | None = None
+        self._delta: T | None = None
+
+    # ------------------------ Public API ------------------------
+
+    def add_relative(self, delta: T) -> None:
+        """Add a relative value to the batch."""
+        if self._delta is None:
+            # start new batch
+            self._base = self._get_value()
+            self._delta = delta
+        else:
+            self._delta = self._add(self._delta, delta)
+        self._issue_move()
+
+    def set_absolute(self, target: T) -> None:
+        """Assign an absolute target position to the batch.
+
+        This will reset the batch state and issue a move to the target position.
+        After the move finishes, new `move_relative()` calls are interpreted
+        relative to *target*.
+        """
+        self._base = target  # anchor for later relatives
+        self._delta = self._zero  # target == base + delta
+        self._issue_move()
+
+    def poll_done(self) -> bool:
+        """Check if the device is done moving.
+
+        This should be called repeatedly by some event loop driver.
+
+        Returns True exactly once when:
+        1. The device is idle (not busy) AND
+        2. The last issued move command has been completed
+
+        After returning True it resets its state and will return False until the next
+        move_relative() call.
+        """
+        # if we have no base or delta, we're not moving
+        if self._delta is None:
+            return False
+
+        # if the device is busy, we're not done
+        if self._is_busy():
+            return False
+
+        # no new work, we're done
+        self._reset()
+        self.finished.emit()
+        return True
+
+    @property
+    def is_moving(self) -> bool:
+        """Returns True if the device is moving."""
+        return self._delta is not None
+
+    @property
+    def target(self) -> T | None:
+        """The target position of the stage. Or None if not moving."""
+        if self._base is None or self._delta is None:
+            return None
+        return self._add(self._base, self._delta)
+
+    # ------------------------ Public API ------------------------
+
+    def _issue_move(self) -> None:
+        # self._base and self._delta are guaranteed to be not None here
+        target = self._add(self._base, self._delta)  # type: ignore[arg-type]
+        # issue the move command
+        try:
+            self._set_value(target)
+        except Exception:  # pragma: no cover
+            from pymmcore_plus._logger import logger
+
+            logger.exception(f"Error setting ValueBatcher to {target}")
+
+    # ------------------------ Abstract methods ------------------------
+
+    @abstractmethod
+    def _get_value(self) -> T:
+        """Get the current position of the device."""
+
+    @abstractmethod
+    def _set_value(self, value: T) -> None:
+        """Set the position of the device."""
+
+    @abstractmethod
+    def _add(self, a: T, b: T) -> T:
+        """Add two values together.
+
+        Provided for more complex types like sequences.
+        """
+
+    @abstractmethod
+    def _is_busy(self) -> bool:
+        """Return True if the device is busy."""
+
+
+class FloatValueBatcher(AbstractValueBatcher[float]):
+    def __init__(self) -> None:
+        super().__init__(zero=0.0)
+
+    def _add(self, a: float, b: float) -> float:
+        return a + b
+
+
+class IntValueBatcher(AbstractValueBatcher[int]):
+    def __init__(self) -> None:
+        super().__init__(zero=0)
+
+    def _add(self, a: int, b: int) -> int:
+        return a + b
+
+
+class SequenceValueBatcher(AbstractValueBatcher[Sequence[float]]):
+    def __init__(self, sequence_length: int) -> None:
+        self.sequence_length = sequence_length
+        super().__init__(zero=[0.0] * sequence_length)
+
+    def _add(self, a: Sequence[float], b: Sequence[float]) -> Sequence[float]:
+        return [x + y for x, y in zip(a, b, strict=True)]
+
+
+class DeviceTypeMixin(abc.ABC, Generic[DT]):
+    def __init__(
+        self,
+        device_type: DT,
+        *,
+        device: str | None = None,
+        mmcore: CMMCorePlus | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self._mmcore = mmcore or CMMCorePlus.instance()
+
+        if device is None:
+            device = self._current_device_label()
+            if not device:
+                raise ValueError(f"No {device_type.name} found.")
+
+        if not self._mmcore.getDeviceType(device) == device_type:
+            raise ValueError(f"Device {device!r} is not a {device_type.name}.")
+
+        self._device = device
+        self._device_type = device_type
+        super().__init__(**kwargs)
+
+    def _is_busy(self) -> bool:
+        return self._mmcore.deviceBusy(self._device)
+
+    @abstractmethod
+    def _current_device_label(self) -> str:
+        """Return the current device of the given type."""
+        ...
+
+
+class StageBatcher(DeviceTypeMixin[Literal[DeviceType.StageDevice]], FloatValueBatcher):
+    """Batcher for single axis stage devices."""
+
+    def __init__(
+        self, device: str | None = None, mmcore: CMMCorePlus | None = None
+    ) -> None:
+        super().__init__(DeviceType.StageDevice, device=device, mmcore=mmcore)
+
+    def _current_device_label(self) -> str:
+        return self._mmcore.getFocusDevice()
+
+    def _get_value(self) -> float:
+        return self._mmcore.getPosition(self._device)
+
+    def _set_value(self, value: float) -> None:
+        self._mmcore.setPosition(self._device, value)
+
+
+class XYStageBatcher(
+    DeviceTypeMixin[Literal[DeviceType.XYStageDevice]], SequenceValueBatcher
+):
+    """Batcher for XY stage devices."""
+
+    def __init__(
+        self, device: str | None = None, mmcore: CMMCorePlus | None = None
+    ) -> None:
+        super().__init__(
+            DeviceType.XYStageDevice,
+            device=device,
+            mmcore=mmcore,
+            sequence_length=2,
+        )
+
+    def _current_device_label(self) -> str:
+        return self._mmcore.getXYStageDevice()
+
+    def _get_value(self) -> Sequence[float]:
+        return self._mmcore.getXYPosition(self._device)
+
+    def _set_value(self, value: Sequence[float]) -> None:
+        self._mmcore.setXYPosition(self._device, *value)
+
+
+DeviceBatcher: TypeAlias = XYStageBatcher | StageBatcher
+_CACHED_BATCHERS: dict[tuple[int, str], DeviceBatcher] = {}
+
+
+def get_device_batcher(
+    device_label: str, mmcore: CMMCorePlus | None = None
+) -> DeviceBatcher:
+    """Get a value batcher for the given device.
+
+    Stage devices are batched using a StageBatcher, and XYStage devices are batched
+    using a XYStageBatcher.  Each controls the position of the device using methods
+    `add_relative()` and `set_absolute()`, and emits a signal `finished` when the device
+    is idle.
+
+    Parameters
+    ----------
+    device_label : str
+        The device label to get the batcher for.
+    mmcore : CMMCorePlus, optional
+        The CMMCorePlus instance to use. If not provided, the default instance is used.
+    """
+    mmcore = mmcore or CMMCorePlus.instance()
+
+    cache_key = (id(mmcore), device_label)
+
+    if cache_key not in _CACHED_BATCHERS:
+        device_type = mmcore.getDeviceType(device_label)
+        if device_type == DeviceType.XYStageDevice:
+            _CACHED_BATCHERS[cache_key] = XYStageBatcher(device_label, mmcore)
+        elif device_type == DeviceType.StageDevice:
+            _CACHED_BATCHERS[cache_key] = StageBatcher(device_label, mmcore)
+        else:
+            raise ValueError(
+                f"Unsupported device type for value batching: {device_type.name}"
+            )
+
+        # pop the key on mmcore.events.systemConfigurationLoaded?
+        # @mmcore.events.systemConfigurationLoaded.connect
+        # def _on_system_configuration_loaded() -> None:
+        #     # remove the batcher from the cache
+        #     _CACHED_BATCHERS.pop(cache_key, None)
+
+    return _CACHED_BATCHERS[cache_key]

--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -41,16 +41,28 @@ from .events import CMMCoreSignaler, PCoreSignaler, _get_auto_core_callback_clas
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator, Sequence
-    from typing import Literal, TypedDict, Unpack
+    from typing import Literal, TypeAlias, TypedDict, Union, Unpack
 
     import numpy as np
+    from pymmcore import DeviceLabel
     from useq import MDAEvent
 
+    from pymmcore_plus._batcher import DeviceBatcher
     from pymmcore_plus.mda._runner import SingleOutput
     from pymmcore_plus.metadata.schema import SummaryMetaV1
 
     _T = TypeVar("_T")
     ListOrTuple = list[_T] | tuple[_T, ...]
+    DeviceTypesWithCurrent: TypeAlias = Union[
+        Literal[DeviceType.CameraDevice]
+        | Literal[DeviceType.ShutterDevice]
+        | Literal[DeviceType.StageDevice]
+        | Literal[DeviceType.XYStageDevice]
+        | Literal[DeviceType.AutoFocusDevice]
+        | Literal[DeviceType.SLMDevice]
+        | Literal[DeviceType.GalvoDevice]
+        | Literal[DeviceType.ImageProcessorDevice]
+    ]
 
     class PropertySchema(TypedDict, total=False):
         """JSON schema `dict` describing a device property."""
@@ -1093,6 +1105,38 @@ class CMMCorePlus(pymmcore.CMMCore):
         """
         return DeviceAdapter(library_name, mmcore=self)
 
+    def getDeviceBatcher(self, device_label: str) -> DeviceBatcher:
+        """Get a value batcher for the given device.
+
+        A ValueBatcher is a class that batches a series of setX calls to a device,
+        retaining an internal target value, and emitting a signal when the device has
+        reached its target and is idle. It can be shared by multiple players (e.g.
+        widgets, or other classes) that want to control the same device, and allows them
+        all to issue relative/absolute moves, and be notified when the device is idle.
+
+        A common use case is to batch setPosition calls to a stage device, where you
+        might want to accumulate a series of relative moves (e.g. clicks on a move stage
+        button), and snap an image only when the stage is idle.
+
+        The main API of a [`ValueBatcher`][pymmcore_plus._batcher.AbstractValueBatcher]:
+            - `finished`: signal emitted when the device has reached its target.
+            - `set_relative`: set the target position of the device relative to its
+               current target.
+            - `set_absolute`: set the target position of the device.  Calling
+              `set_absolute` overrides any previous relative or absolute target.
+            - `poll_done`:  This method must be called by some event loop or timer to
+               poll the device and emit the `finished` signal when the device is idle.
+               The event loop is NOT handled in this library.
+
+        Parameters
+        ----------
+        device_label : str
+            The device label to batch.
+        """
+        from pymmcore_plus._batcher import get_device_batcher
+
+        return get_device_batcher(device_label, mmcore=self)
+
     def getDeviceObject(self, device_label: str) -> Device:
         """Return a `Device` object bound to device_label on this core.
 
@@ -1188,6 +1232,61 @@ class CMMCorePlus(pymmcore.CMMCore):
         """
         for group in self.getAvailableConfigGroups():
             yield ConfigGroup(group, mmcore=self)
+
+    def getCurrentDeviceOfType(
+        self, device_type: DeviceTypesWithCurrent
+    ) -> DeviceLabel | Literal[""]:
+        """Return the current device of type `device_type`.
+
+        Only the following device types have a "current" device:
+            - CameraDevice
+            - ShutterDevice
+            - StageDevice
+            - XYStageDevice
+            - AutoFocusDevice
+            - SLMDevice
+            - GalvoDevice
+            - ImageProcessorDevice
+
+        Calling this method with any other device type will raise a `ValueError`.
+
+        :sparkles: *This method is new in `CMMCorePlus`.*
+
+        Parameters
+        ----------
+        device_type : DeviceType
+            The type of device to get the current device for.
+            See [`DeviceType`][pymmcore_plus.DeviceType] for a list of device types.
+
+        Returns
+        -------
+        str
+            The label of the current device of type `device_type`.
+            If no device of that type is currently set, an empty string is returned.
+
+        Raises
+        ------
+        ValueError
+            If the core does not have the concept of a "current" device of the provided
+            `device_type`.
+        """
+        if device_type == DeviceType.CameraDevice:
+            return self.getCameraDevice()
+        if device_type == DeviceType.ShutterDevice:
+            return self.getShutterDevice()
+        if device_type == DeviceType.StageDevice:
+            return self.getFocusDevice()
+        if device_type == DeviceType.XYStageDevice:
+            return self.getXYStageDevice()
+        if device_type == DeviceType.AutoFocusDevice:
+            return self.getAutoFocusDevice()
+        if device_type == DeviceType.SLMDevice:
+            return self.getSLMDevice()
+        if device_type == DeviceType.GalvoDevice:
+            return self.getGalvoDevice()
+        if device_type == DeviceType.ImageProcessorDevice:
+            return self.getImageProcessorDevice()
+        raise ValueError(f"'Current' {device_type.name} is undefined. ")
 
     def getDeviceSchema(self, device_label: str) -> DeviceSchema:
         """Return JSON-schema describing device `device_label` and its properties.


### PR DESCRIPTION
This is a GUI-agnostic helper class that is designed to fix cases like https://github.com/pymmcore-plus/pymmcore-widgets/issues/410, where we need to:

1. accumulate relative calls to a particular target value (as might be done when clicking on a move stage relative button multiple times before it has settled).
2. Possibly override the accumulated relative calls with an absolute setpoint, midstream.
3. Have multiple listeners be notified when it has reached a target and is idle (e.g. to snap an image)

It establishes a low level abstract class that generally implements the pattern in a device/value agnostic way, then adds a few concrete classes for StageDevice and XYStageDevice.

the primary public API is `CMMCorePlus.getDeviceBatcher`  (@marktsuchida, your opinions on API naming or other things very welcome here).

Below is an example of what this PR enables in pymmcore-widgets:


https://github.com/user-attachments/assets/75661234-4b48-40a3-9399-7fe674641df9

