### PR TITLE
refactor: rename Camera to CameraDevice

### DIFF
--- a/examples/unicore_camera.py
+++ b/examples/unicore_camera.py
@@ -16,7 +16,7 @@ from typing import Callable
 import numpy as np
 from numpy.typing import DTypeLike
 
-from pymmcore_plus.experimental.unicore import Camera, UniMMCore
+from pymmcore_plus.experimental.unicore import CameraDevice, UniMMCore
 
 _START_TIME: float = time.time()
 
@@ -93,7 +93,7 @@ def make_cool_image(
     return image  # type: ignore[no-any-return]
 
 
-class MyCamera(Camera):
+class MyCamera(CameraDevice):
     _exposure: float = 10.0
 
     def get_exposure(self) -> float:

--- a/examples/unicore_hamamatsu.py
+++ b/examples/unicore_hamamatsu.py
@@ -30,7 +30,7 @@ from typing import Callable
 import numpy as np
 from numpy.typing import DTypeLike
 
-from pymmcore_plus.experimental.unicore import Camera, UniMMCore
+from pymmcore_plus.experimental.unicore import CameraDevice, UniMMCore
 
 dll = dc.dcamapi
 
@@ -43,7 +43,7 @@ PIXEL_TYPE_TO_DTYPE: dict[int, np.dtype] = {
 # -------- Here is our actual Device Adaptor for pymmcore_plus.unicore.Camera
 
 
-class HamaCam(Camera):
+class HamaCam(CameraDevice):
     def initialize(self) -> None:
         """Initialize the camera."""
         if count := dc.dcamapi_init():

--- a/src/pymmcore_plus/experimental/unicore/__init__.py
+++ b/src/pymmcore_plus/experimental/unicore/__init__.py
@@ -1,5 +1,5 @@
 from .core._unicore import UniMMCore
-from .devices._camera import Camera
+from .devices._camera import CameraDevice
 from .devices._device import Device
 from .devices._properties import PropertyInfo, pymm_property
 from .devices._slm import SLMDevice
@@ -7,7 +7,7 @@ from .devices._stage import StageDevice, XYStageDevice, XYStepperStageDevice
 from .devices._state import StateDevice
 
 __all__ = [
-    "Camera",
+    "CameraDevice",
     "Device",
     "PropertyInfo",
     "SLMDevice",

--- a/src/pymmcore_plus/experimental/unicore/core/_unicore.py
+++ b/src/pymmcore_plus/experimental/unicore/core/_unicore.py
@@ -25,7 +25,7 @@ from pymmcore_plus.core import Keyword as KW
 from pymmcore_plus.core._constants import PixelType
 from pymmcore_plus.experimental.unicore._device_manager import PyDeviceManager
 from pymmcore_plus.experimental.unicore._proxy import create_core_proxy
-from pymmcore_plus.experimental.unicore.devices._camera import Camera
+from pymmcore_plus.experimental.unicore.devices._camera import CameraDevice
 from pymmcore_plus.experimental.unicore.devices._device import Device
 from pymmcore_plus.experimental.unicore.devices._slm import SLMDevice
 from pymmcore_plus.experimental.unicore.devices._stage import XYStageDevice, _BaseStage
@@ -678,11 +678,11 @@ class UniMMCore(CMMCorePlus):
 
     # --------------------------------------------------------------------- utils
 
-    def _py_camera(self, cameraLabel: str | None = None) -> Camera | None:
+    def _py_camera(self, cameraLabel: str | None = None) -> CameraDevice | None:
         """Return the *Python* Camera for ``label`` (or current), else ``None``."""
         label = cameraLabel or self.getCameraDevice()
         if label in self._pydevices:
-            return self._pydevices.get_device_of_type(label, Camera)
+            return self._pydevices.get_device_of_type(label, CameraDevice)
         return None
 
     def setCameraDevice(self, cameraLabel: DeviceLabel | str) -> None:
@@ -751,7 +751,7 @@ class UniMMCore(CMMCorePlus):
     # ---------------------------------------------------------------- sequence common
 
     def _start_sequence(
-        self, cam: Camera, n_images: int | None, stop_on_overflow: bool
+        self, cam: CameraDevice, n_images: int | None, stop_on_overflow: bool
     ) -> None:
         """Initialise _seq state and call cam.start_sequence."""
         shape, dtype = cam.shape(), np.dtype(cam.dtype())
@@ -1031,7 +1031,7 @@ class UniMMCore(CMMCorePlus):
 
         return self._seq_buffer.size_bytes // bytes_per_frame
 
-    def _predicted_bytes_per_frame(self, cam: Camera) -> int:
+    def _predicted_bytes_per_frame(self, cam: CameraDevice) -> int:
         # Estimate capacity based on camera settings and circular buffer size
         shape, dtype = cam.shape(), np.dtype(cam.dtype())
         return int(np.prod(shape) * dtype.itemsize)

--- a/src/pymmcore_plus/experimental/unicore/devices/_camera.py
+++ b/src/pymmcore_plus/experimental/unicore/devices/_camera.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from numpy.typing import DTypeLike
 
 
-class Camera(Device):
+class CameraDevice(Device):
     # mandatory methods for Camera device adapters
 
     _TYPE: ClassVar[Literal[DeviceType.Camera]] = DeviceType.Camera

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -10,7 +10,7 @@ import pytest
 import useq
 
 from pymmcore_plus import CMMCorePlus
-from pymmcore_plus.experimental.unicore import Camera
+from pymmcore_plus.experimental.unicore import CameraDevice
 from pymmcore_plus.experimental.unicore.core._sequence_buffer import SequenceBuffer
 from pymmcore_plus.experimental.unicore.core._unicore import UniMMCore
 
@@ -147,7 +147,7 @@ DTYPE = np.uint16
 FRAME = np.ones(FRAME_SHAPE, dtype=DTYPE)
 
 
-class MyCamera(Camera):
+class MyCamera(CameraDevice):
     def get_exposure(self) -> float:
         return 100.0
 

--- a/tests/unicore/test_camera.py
+++ b/tests/unicore/test_camera.py
@@ -8,7 +8,7 @@ import pytest
 
 import pymmcore_plus._pymmcore as pymmcore
 from pymmcore_plus.core._constants import Keyword
-from pymmcore_plus.experimental.unicore import Camera
+from pymmcore_plus.experimental.unicore import CameraDevice
 from pymmcore_plus.experimental.unicore.core._unicore import UniMMCore
 
 if TYPE_CHECKING:
@@ -24,7 +24,7 @@ DTYPE = np.uint16
 FRAME = np.random.randint(0, 65535, size=FRAME_SHAPE, dtype=DTYPE)
 
 
-class MyCamera(Camera):
+class MyCamera(CameraDevice):
     """Example Camera device."""
 
     _exposure: float = 100.0


### PR DESCRIPTION
CC @hinderling, if you had happened to start using this yet, I meant to call this class CameraDevice and not just Camera.  Will be releasing this shortly and will break your code if you already used the name Camera