### PR TITLE
feat: support property names in ipython  tab autocompletion

### DIFF
--- a/tests/test_ipy_completions.py
+++ b/tests/test_ipy_completions.py
@@ -123,6 +123,31 @@ def test_device_completions(
     assert completions == expect
 
 
+@pytest.mark.parametrize(
+    "method_name, dev_label",
+    [
+        ("getProperty", "Camera"),
+        ("getProperty", "XY"),
+        ("getProperty", "Objective"),
+        ("getAllowedPropertyValues", "Camera"),
+        ("getPropertyFromCache", "Camera"),
+        ("getPropertyLowerLimit", "Camera"),
+        ("getPropertySequenceMaxLength", "Camera"),
+        ("getPropertyType", "Z"),
+        ("hasProperty", "XY"),
+    ],
+)
+def test_property_completions(
+    shell_core: CMMCorePlus, method_name: str, dev_label: str
+) -> None:
+    """Test that the pymmcore_plus IPython completions work."""
+
+    completions = _get_completions(f"{CORE_NAME}.{method_name}('{dev_label}', ")
+    expect = set(shell_core.getDevicePropertyNames(dev_label))
+
+    assert completions == expect
+
+
 def test_device_completions_without_jedi(
     shell_core: CMMCorePlus, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Continuing with #482  ... this supports suggesting appropriate property names given a context where you've already entered the name of a device:

<img width="919" height="183" alt="Screenshot 2025-07-10 at 12 07 50 PM" src="https://github.com/user-attachments/assets/82be1860-0fea-44a9-91bd-9713657b9e08" />
<img width="658" height="181" alt="Screenshot 2025-07-10 at 12 08 07 PM" src="https://github.com/user-attachments/assets/10e0bef8-9666-45b0-be2f-ec5eec5ab898" />
