### PR TITLE
fix: reset core configuration to handle non-programmatic changes

### DIFF
--- a/src/pymmcore_plus/mda/_engine.py
+++ b/src/pymmcore_plus/mda/_engine.py
@@ -168,6 +168,11 @@ class MDAEngine(PMDAEngine):
             core = CMMCorePlus.instance()
             self._mmcore_ref = weakref.ref(core)
 
+        # just in case a non-programmatic changes have been made in the meantime
+        # https://github.com/pymmcore-plus/pymmcore-plus/issues/503
+        core._last_config = ("", "")  # noqa: SLF001
+        core._last_xy_position.clear()  # noqa: SLF001
+
         self._update_config_device_props()
         # get if the autofocus is engaged at the start of the sequence
         self._af_was_engaged = core.isContinuousFocusLocked()


### PR DESCRIPTION
fixes #503

This should fix a bug in which a manual (non-programmatic) change to the state of the microscope (something like filter position on the microscope or stage position with the joystick) don't get corrected when starting a second MDA.

The problem arose due to stale cached values (which were there to prevent "excess" calls that slow the system down during an MDA).

