### PR TITLE
ci: replace macos 13 in GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           - os: macos-15-intel
             python-version: "3.12"
             add-group: "PySide6"
-          - os: macos-15-intel
+          - os: macos-latest
             python-version: "3.11"
             add-group: "PyQt6"
           - os: windows-latest


### PR DESCRIPTION
This pull request updates the GitHub Actions CI workflow to use the newer [`macos-15-intel`](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/) runner instead of `macos-13`.


closes #505.