### PR TITLE
fix: update macOS version in CI configuration to macos-15-intel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           - os: windows-latest
             python-version: "3.9"
             add-group: "PySide2"
-          - os: macos-13
+          - os: macos-15-intel
             python-version: "3.12"
             add-group: "PySide6"
           - os: macos-latest
@@ -42,7 +42,7 @@ jobs:
           - os: windows-latest
             python-version: "3.10"
             nano: "nano"
-          - os: macos-13
+          - os: macos-15-intel
             python-version: "3.12"
             nano: "nano"
 


### PR DESCRIPTION
This pull request updates the GitHub Actions CI workflow to use the newer [`macos-15-intel`](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/) runner instead of `macos-13`.

closes #505.