### PR TITLE
fix: fix a bug when creating one plate metadata

### DIFF
--- a/src/pymmcore_plus/metadata/_ome.py
+++ b/src/pymmcore_plus/metadata/_ome.py
@@ -494,10 +494,12 @@ def _build_ome_plate(
                 well_acquisition_map[base_well_name] = []
             well_acquisition_map[base_well_name].append(acquisition_index)
 
-    for (row, col), name, pos in zip(
-        plate_plan.selected_well_indices,
-        plate_plan.selected_well_names,
-        plate_plan.selected_well_positions,
+    for well_index, ((row, col), name, pos) in enumerate(
+        zip(
+            plate_plan.selected_well_indices,
+            plate_plan.selected_well_names,
+            plate_plan.selected_well_positions,
+        )
     ):
         # get all acquisition indices for this well
         acquisition_indices = well_acquisition_map.get(name, [])
@@ -521,6 +523,7 @@ def _build_ome_plate(
 
         wells.append(
             Well(
+                id=f"Well:{well_index}",
                 row=row,
                 column=col,
                 well_samples=well_samples,
@@ -528,6 +531,7 @@ def _build_ome_plate(
         )
 
     return Plate(
+        id="Plate:0",
         name=plate_plan.plate.name,
         rows=plate_plan.plate.rows,
         columns=plate_plan.plate.columns,

--- a/src/pymmcore_plus/metadata/_ome.py
+++ b/src/pymmcore_plus/metadata/_ome.py
@@ -480,11 +480,19 @@ def _build_ome_plate(
     # create a mapping from well name to acquisition indices
     well_acquisition_map: dict[str, list[int]] = {}
     for acquisition_index, position in enumerate(plate_plan.image_positions):
-        well_name = position.name
-        if well_name is not None:
-            if well_name not in well_acquisition_map:
-                well_acquisition_map[well_name] = []
-            well_acquisition_map[well_name].append(acquisition_index)
+        position_name = position.name
+        if position_name is not None:
+            # Extract base well name by removing FOV suffix (e.g., "A1_0000" -> "A1")
+            # This handles cases where well_points_plan creates multiple FOVs per well
+            if "_" in position_name:
+                # Try to split on underscore and take the first part
+                base_well_name = position_name.split("_")[0]
+            else:
+                base_well_name = position_name
+
+            if base_well_name not in well_acquisition_map:
+                well_acquisition_map[base_well_name] = []
+            well_acquisition_map[base_well_name].append(acquisition_index)
 
     for (row, col), name, pos in zip(
         plate_plan.selected_well_indices,

--- a/tests/test_metadata_to_ome.py
+++ b/tests/test_metadata_to_ome.py
@@ -44,7 +44,7 @@ PLATE_SEQ_FOVS = useq.MDASequence(
         plate=useq.WellPlate.from_str("96-well"),
         a1_center_xy=(0, 0),
         selected_wells=((0, 0, 0), (0, 1, 2)),
-        well_points_plan=useq.GridRowsColumns(rows=2, columns=2),
+        well_points_plan=useq.GridRowsColumns(rows=1, columns=2),
     ),
     z_plan=useq.ZRangeAround(range=3.0, step=1.0),
     channels=(
@@ -101,8 +101,7 @@ def _get_expected_images(seq: useq.MDASequence) -> int:
 
 
 @pytest.mark.parametrize(
-    # "seq", [BASIC_SEQ, PLATE_SEQ, PLATE_SEQ_FOVS, GRID_SEQ, SEQ_WITH_SUBSEQ_GRID]
-    "seq", [PLATE_SEQ, PLATE_SEQ_FOVS]
+    "seq", [BASIC_SEQ, PLATE_SEQ, PLATE_SEQ_FOVS, GRID_SEQ, SEQ_WITH_SUBSEQ_GRID]
 )
 def test_ome_generation(seq: useq.MDASequence) -> None:
     mmc = CMMCorePlus()
@@ -149,6 +148,10 @@ def test_ome_generation(seq: useq.MDASequence) -> None:
         )
         # Total WellSamples should equal total image positions (including FOVs)
         assert total_well_samples == len(plan)
+
+        # assert the well ids are correct
+        for idx, well in enumerate(plate.wells):
+            assert well.id == f"Well:{idx}"
 
 
 def test_ome_generation_from_events() -> None:

--- a/tests/test_metadata_to_ome.py
+++ b/tests/test_metadata_to_ome.py
@@ -141,7 +141,14 @@ def test_ome_generation(seq: useq.MDASequence) -> None:
         plate = ome.plates[0]
         assert plate.rows == plan.plate.rows
         assert plate.columns == plan.plate.columns
-        assert len(plate.wells) == len(plan)
+
+        # Count total WellSamples across all wells
+        total_well_samples = sum(
+            len(well.well_samples) if well.well_samples else 0
+            for well in plate.wells
+        )
+        # Total WellSamples should equal total image positions (including FOVs)
+        assert total_well_samples == len(plan)
 
 
 def test_ome_generation_from_events() -> None:

--- a/tests/test_metadata_to_ome.py
+++ b/tests/test_metadata_to_ome.py
@@ -38,6 +38,21 @@ PLATE_SEQ = useq.MDASequence(
     ),
 )
 
+PLATE_SEQ_FOVS = useq.MDASequence(
+    axis_order="pcz",
+    stage_positions=useq.WellPlatePlan(
+        plate=useq.WellPlate.from_str("96-well"),
+        a1_center_xy=(0, 0),
+        selected_wells=((0, 0, 0), (0, 1, 2)),
+        well_points_plan=useq.GridRowsColumns(rows=2, columns=2),
+    ),
+    z_plan=useq.ZRangeAround(range=3.0, step=1.0),
+    channels=(
+        useq.Channel(config="DAPI", exposure=20),
+        useq.Channel(config="FITC", exposure=30),
+    ),
+)
+
 GRID_SEQ = useq.MDASequence(
     time_plan=useq.TIntervalLoops(interval=0.5, loops=2),
     stage_positions=(
@@ -85,7 +100,10 @@ def _get_expected_images(seq: useq.MDASequence) -> int:
     return expected_images
 
 
-@pytest.mark.parametrize("seq", [BASIC_SEQ, PLATE_SEQ, GRID_SEQ, SEQ_WITH_SUBSEQ_GRID])
+@pytest.mark.parametrize(
+    # "seq", [BASIC_SEQ, PLATE_SEQ, PLATE_SEQ_FOVS, GRID_SEQ, SEQ_WITH_SUBSEQ_GRID]
+    "seq", [PLATE_SEQ, PLATE_SEQ_FOVS]
+)
 def test_ome_generation(seq: useq.MDASequence) -> None:
     mmc = CMMCorePlus()
     mmc.loadSystemConfiguration("tests/local_config.cfg")


### PR DESCRIPTION
if we run a sequence with a `useq.WellPlatePlan` a plate with multiple fovs per well, the `Plate` object is not correctly generated since it is missing the `WellSample` (fovs).

e.g. if a `useq.WellPlatePlan` as a `well_points_plan` arguments has a grid:

```python
stage_positions=useq.WellPlatePlan(
     plate=useq.WellPlate.from_str("96-well"),
     a1_center_xy=(0, 0),
     selected_wells=((0, 0, 0), (0, 1, 2)),
     well_points_plan=useq.GridRowsColumns(rows=1, columns=2),
)
```
the plate xml is missing the `WellSample` and looks looks like this:

```xml
  <Plate ID="Plate:0" Name="96-well" WellOriginX="0.0" WellOriginXUnit="µm" WellOriginY="0.0" WellOriginYUnit="µm" Rows="8" Columns="12">
    <Well ID="Well:0" Column="0" Row="0"/>
    <Well ID="Well:1" Column="1" Row="0"/>
    <Well ID="Well:2" Column="2" Row="0"/>
  </Plate>
```

with the fix it will have the 2 fovs (`WellSample`) per well.

```xml
  <Plate ID="Plate:0" Name="96-well" WellOriginX="0.0" WellOriginXUnit="µm" WellOriginY="0.0" WellOriginYUnit="µm" Rows="8" Columns="12">
    <Well ID="Well:0" Column="0" Row="0">
      <WellSample ID="WellSample:0" PositionX="0.0" PositionXUnit="µm" PositionY="0.0" PositionYUnit="µm" Index="0">
        <ImageRef ID="Image:0"/>
      </WellSample>
      <WellSample ID="WellSample:1" PositionX="0.0" PositionXUnit="µm" PositionY="0.0" PositionYUnit="µm" Index="1">
        <ImageRef ID="Image:1"/>
      </WellSample>
    </Well>
    <Well ID="Well:1" Column="1" Row="0">
      <WellSample ID="WellSample:2" PositionX="9000.0" PositionXUnit="µm" PositionY="0.0" PositionYUnit="µm" Index="2">
        <ImageRef ID="Image:2"/>
      </WellSample>
      <WellSample ID="WellSample:3" PositionX="9000.0" PositionXUnit="µm" PositionY="0.0" PositionYUnit="µm" Index="3">
        <ImageRef ID="Image:3"/>
      </WellSample>
    </Well>
    <Well ID="Well:2" Column="2" Row="0">
      <WellSample ID="WellSample:4" PositionX="18000.0" PositionXUnit="µm" PositionY="0.0" PositionYUnit="µm" Index="4">
        <ImageRef ID="Image:4"/>
      </WellSample>
      <WellSample ID="WellSample:5" PositionX="18000.0" PositionXUnit="µm" PositionY="0.0" PositionYUnit="µm" Index="5">
        <ImageRef ID="Image:5"/>
      </WellSample>
    </Well>
  </Plate>
```
