### PR TITLE
feat: add back creation of device objects prior to loading

### DIFF
--- a/src/pymmcore_plus/core/_device.py
+++ b/src/pymmcore_plus/core/_device.py
@@ -35,6 +35,12 @@ class Device:
         Device label assigned to this device.
     mmcore : CMMCorePlus
         CMMCorePlus instance that owns this device.
+    device_type : DeviceType or Device subclass, optional
+        The type of device to create. If not specified, the type will be inferred
+        from the core if the device is already loaded. If the device is not loaded,
+        an error will be raised. This parameter is mainly intended for usage when
+        calling from `CMMCorePlus.getDeviceObject()`.  Otherwise, prefer using
+        `[SpecificDeviceSubclass].create()`.
 
     Examples
     --------
@@ -57,14 +63,39 @@ class Device:
     propertyChanged: PSignalInstance
 
     @classmethod
-    def create(cls, device_label: str, mmcore: CMMCorePlus) -> Self:
-        sub_cls = cls.get_subclass(device_label, mmcore)
+    def create(
+        cls,
+        device_label: str,
+        mmcore: CMMCorePlus,
+        device_type: type[Device] | DeviceType = DeviceType.Any,
+    ) -> Self:
+        if device_type in {DeviceType.Any, DeviceType.Unknown}:
+            try:
+                sub_cls = cls.get_subclass(device_label, mmcore)
+            except RuntimeError as e:
+                raise RuntimeError(
+                    f"Could not determine device type for {device_label}. "
+                    "If you are preloading a device object, "
+                    "please specify `device_type` as a `pymmcore_plus.DeviceType`."
+                ) from e
+        else:
+            if isinstance(device_type, type) and issubclass(device_type, Device):
+                sub_cls = device_type
+            elif isinstance(device_type, DeviceType):
+                sub_cls = _TYPE_MAP[device_type]
+            else:
+                raise TypeError(
+                    f"Invalid device_type: {device_type!r}.  Must be a "
+                    "pymmcore_plus `DeviceType` or `Device` subclass."
+                )
+
         # make sure it's an error to call this class method on a subclass with
         # a non-matching type
-        if issubclass(sub_cls, cls):
-            return sub_cls(device_label, mmcore)
-        dev_type = mmcore.getDeviceType(device_label).name
-        raise TypeError(f"Cannot cast {dev_type} {device_label!r} to {cls}")
+        if not issubclass(sub_cls, cls):
+            dev_type = mmcore.getDeviceType(device_label).name
+            raise TypeError(f"Cannot cast {dev_type} {device_label!r} to {cls}")
+
+        return sub_cls(device_label, mmcore)
 
     @classmethod
     def get_subclass(cls, device_label: str, mmcore: CMMCorePlus) -> type[Device]:

--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -1268,18 +1268,7 @@ class CMMCorePlus(pymmcore.CMMCore):
             }
         }
         """
-        dev = _device.Device.create(device_label, mmcore=self)
-        if (isinstance(device_type, type) and not isinstance(dev, device_type)) or (
-            isinstance(device_type, DeviceType)
-            and device_type not in {DeviceType.Any, DeviceType.Unknown}
-            and dev.type() != device_type
-        ):
-            raise TypeError(
-                f"{device_type!r} requested but device with label "
-                f"{device_label!r} is a {dev.type()}."
-            )
-
-        return dev
+        return _device.Device.create(device_label, mmcore=self, device_type=device_type)
 
     def getConfigGroupObject(
         self, group_name: str, allow_missing: bool = False


### PR DESCRIPTION
this returns a feature that was there before #437 and fixes #522 

There is one gotcha that this exposes, and there's very little we can do about it:

```python
from pymmcore_plus import CMMCorePlus, DeviceType

core = CMMCorePlus()

# Pre-create a Camera device object for a label that will be loaded as Stage
not_cam = core.getDeviceObject("FutureStage", device_type=DeviceType.Camera)
assert not not_cam.isLoaded()

# Now load it as a Stage
core.loadDevice("FutureStage", "DemoCamera", "DStage")
core.initializeDevice("FutureStage")

# there's very little we can do to resolve this mismatch at this point...
assert not_cam.type() == DeviceType.Camera  # Thinks it's a Camera due to init
not_cam.exposure = 20  # raises RuntimeError
```

so @jacopoabramo ... be aware of that gotcha