### PR TITLE
feat: add ipy completion for loadDevice

### DIFF
--- a/tests/test_ipy_completions.py
+++ b/tests/test_ipy_completions.py
@@ -151,6 +151,19 @@ def test_config_completions(shell_core: CMMCorePlus) -> None:
     assert completions == expect
 
 
+def test_load_device_adapter_completions(shell_core: CMMCorePlus) -> None:
+    completions = _get_completions(f"{CORE_NAME}.loadDevice('MyLabel', ")
+    expect = set(shell_core.getDeviceAdapterNames())
+    assert completions == expect
+
+
+def test_load_device_name_completions(shell_core: CMMCorePlus) -> None:
+    adapter = "DemoCamera"
+    completions = _get_completions(f"{CORE_NAME}.loadDevice('MyLabel', '{adapter}', ")
+    expect = set(shell_core.getAvailableDevices(adapter))
+    assert completions == expect
+
+
 def test_install_script() -> None:
     # CREATE a new ipython shell instance
     from IPython.testing.globalipapp import get_ipython


### PR DESCRIPTION
adds a couple more conveniences to the IPython completer, that fill in:

1. the name of valid device adapter libraries when using `loadDevice`

    <img width="727" height="124" alt="image" src="https://github.com/user-attachments/assets/fcdc5593-8bc2-4e76-bd3f-3503d1e9e84b" />

2. the name of valid device names in that library in the third argument:

    <img width="1109" height="127" alt="image" src="https://github.com/user-attachments/assets/8caa29f5-9616-4c43-8e33-4b1e6c01c74d" />
