### PR TITLE
fix: Fix inverted condition and empty label in UniMMCore.getROI()

### DIFF
--- a/src/pymmcore_plus/experimental/unicore/core/_unicore.py
+++ b/src/pymmcore_plus/experimental/unicore/core/_unicore.py
@@ -1442,10 +1442,11 @@ class UniMMCore(CMMCorePlus):
     def getROI(self, label: DeviceLabel | str) -> list[int]: ...
     def getROI(self, label: DeviceLabel | str = "") -> list[int]:
         """Get the current region of interest (ROI) for the camera."""
-        if self._py_camera(label) is None:  # pragma: no cover
+        if self._py_camera(label) is not None:  # pragma: no cover
             raise NotImplementedError(
                 "getROI is not yet implemented for Python cameras."
             )
+        label = label or self.getCameraDevice()
         return super().getROI(label)
 
     def clearROI(self) -> None:


### PR DESCRIPTION
The condition `_py_camera(label) is None` was inverted compared to the sibling methods (`clearROI`, `_do_set_roi`), causing `super().getROI()` to be called when a Python camera exists (`RuntimeError`) and `NotImplementedError` when no Python camera exists.

Also resolve an empty label to the current camera device before calling `super().getROI()`, since the C++ overload rejects empty strings.