### PR TITLE
fix: stop acquisition thread in unloadAllDevices

### DIFF
--- a/src/pymmcore_plus/experimental/unicore/core/_unicore.py
+++ b/src/pymmcore_plus/experimental/unicore/core/_unicore.py
@@ -316,6 +316,12 @@ class UniMMCore(CMMCorePlus):
         self._pydevices.unload(label)
 
     def unloadAllDevices(self) -> None:
+        # Stop any in-flight sequence acquisition before clearing devices,
+        # otherwise the acquisition thread would keep running against unloaded objects.
+        if self._acquisition_thread is not None and self._acquisition_thread.is_alive():
+            self._stop_event.set()
+            self._acquisition_thread.join(timeout=2.0)
+            self._acquisition_thread = None
         self._pydevices.unload_all()
         super().unloadAllDevices()
 


### PR DESCRIPTION
Fixes a bug when loading a new .cfg in napari-micromanger, while live-mode is running. When `unloadAllDevices()` is called (e.g. before loading a new config), any in-flight sequence acquisition thread keeps running against the objects it holds, which can cause crashes or stale state. Stop and join the thread before clearing devices.

