### PR TITLE
test: add unit test for Unicore unloadAllDevices and do further cleanup

### DIFF
--- a/src/pymmcore_plus/experimental/unicore/core/_unicore.py
+++ b/src/pymmcore_plus/experimental/unicore/core/_unicore.py
@@ -103,12 +103,19 @@ class _CoreDevice:
         self.reset_current()
 
     def reset_current(self) -> None:
+        """Set all current device labels to None."""
         self._pycurrent.update(CURRENT)
 
     def current(self, keyword: Keyword) -> PyDeviceLabel | None:
+        """Return the current device label for the given keyword, or None if not set."""
         return self._pycurrent[keyword]
 
     def set_current(self, keyword: Keyword, label: str | None) -> None:
+        """Set the current device label for the given keyword.
+
+        If label is None, current is cleared (set to None).
+        If label is a string, it is set as the current device for the keyword.
+        """
         self._pycurrent[keyword] = cast("PyDeviceLabel", label)
         self._state_cache[(KW.CoreDevice, keyword)] = label
 
@@ -310,19 +317,55 @@ class UniMMCore(CMMCorePlus):
         """Returns True if the specified device label corresponds to a Python device."""
         return label in self._pydevices
 
+    def _cleanup_sequence_state(self, only_label: str | None = None) -> None:
+        """Stop and clean up python-side sequence acquisition threads and state.
+
+        if `only_label` is provided, only clean up state associated with that device
+        label, otherwise clean up any/all sequence state.
+        """
+        if (
+            only_label is not None
+            and self._acquisition_thread is not None
+            and self._acquisition_thread.label != only_label
+        ):
+            return
+
+        self._stop_acquisition_thread()
+        self._stop_event.clear()
+        self._seq_buffer.clear()
+        self._current_image_buffer = None
+
+    def _cleanup_pydevice_state(self, label: str) -> None:
+        """Clean UniCore-managed state associated with one unloaded py-device."""
+        for keyword in CURRENT:
+            if self._pycore.current(keyword) == label:
+                self._pycore.set_current(keyword, None)
+
+        self._state_cache.clear_device(label)
+
+        for group_name, group in list(self._py_config_groups.items()):
+            for preset_name, config in list(group.items()):
+                to_clear = [k for k in config if k[0] == label]
+                for key in to_clear:
+                    config.pop(key, None)
+                if not config:
+                    group.pop(preset_name, None)
+            if not group:
+                self._py_config_groups.pop(group_name, None)
+
     def unloadDevice(self, label: DeviceLabel | str) -> None:
         if label not in self._pydevices:  # pragma: no cover
             return super().unloadDevice(label)
+        self._cleanup_sequence_state(label)
         self._pydevices.unload(label)
+        self._cleanup_pydevice_state(label)
 
     def unloadAllDevices(self) -> None:
-        # Stop any in-flight sequence acquisition before clearing devices,
-        # otherwise the acquisition thread would keep running against unloaded objects.
-        if self._acquisition_thread is not None and self._acquisition_thread.is_alive():
-            self._stop_event.set()
-            self._acquisition_thread.join(timeout=2.0)
-            self._acquisition_thread = None
+        self._cleanup_sequence_state()
         self._pydevices.unload_all()
+        self._pycore.reset_current()
+        self._py_config_groups.clear()
+        self._state_cache.clear()
         super().unloadAllDevices()
 
     def initializeDevice(self, label: DeviceLabel | str) -> None:
@@ -1200,6 +1243,14 @@ class UniMMCore(CMMCorePlus):
         start_time = perf_counter_ns()
         self._acquisition_thread.start()
 
+    def _stop_acquisition_thread(self, timeout: float | None = 2) -> None:
+        """Stop and join the python acquisition thread, if present."""
+        if self._acquisition_thread is None:
+            return
+        self._stop_event.set()
+        self._acquisition_thread.join(timeout=timeout)
+        self._acquisition_thread = None
+
     # ------------------------------------------------- startSequenceAcquisition
 
     # startSequenceAcquisition
@@ -1227,11 +1278,7 @@ class UniMMCore(CMMCorePlus):
     def _do_stop_sequence_acquisition(self, cameraLabel: str) -> None:
         if self._py_camera(cameraLabel) is None:  # pragma: no cover
             pymmcore.CMMCore.stopSequenceAcquisition(self, cameraLabel)
-
-        if self._acquisition_thread is not None:
-            self._stop_event.set()
-            self._acquisition_thread.join()
-            self._acquisition_thread = None
+        self._stop_acquisition_thread()
 
     # ------------------------------------------------------------------ queries
     @overload
@@ -2533,6 +2580,17 @@ class ThreadSafeConfig(MutableMapping["DevPropTuple", Any]):
     def __repr__(self) -> str:
         with self._lock:
             return f"{self.__class__.__name__}({self._store!r})"
+
+    def clear(self) -> None:
+        with self._lock:
+            self._store.clear()
+
+    def clear_device(self, label: str) -> None:
+        """Remove all entries for a given device label under a single lock."""
+        with self._lock:
+            keys = [k for k in self._store if k[0] == label]
+            for key in keys:
+                del self._store[key]
 
 
 # Threading ------------------------------------------------------


### PR DESCRIPTION
this follows up on #554 and makes sure all traces of python devices are cleared from unicore-specific caches and config when unloading the device.  and adds a test to cover #554 