### PR TITLE
feat: replace qtbot with anybot for signal-backend agnostic tests.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import os
+import time
+from contextlib import contextmanager
 from unittest.mock import patch
 
 import pymmcore_plus._pymmcore
@@ -16,7 +18,9 @@ from pymmcore_plus.core.events import CMMCoreSignaler
 from pymmcore_plus.mda.events import MDASignaler
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Callable, Iterator
+
+    from pymmcore_plus.core.events._protocol import PSignalInstance
 
 try:
     from pymmcore_plus.core.events import QCoreSignaler
@@ -75,6 +79,70 @@ def caplog(caplog: pytest.LogCaptureFixture) -> Iterator[pytest.LogCaptureFixtur
         logger.removeHandler(caplog.handler)
 
 
+class PsygnalBot:
+    """Lightweight replacement for qtbot's signal-waiting API."""
+
+    @contextmanager
+    def waitSignal(self, signal: PSignalInstance, **kwargs: Any) -> Iterator[None]:
+        with self.waitSignals([signal], **kwargs):
+            yield
+
+    @contextmanager
+    def waitSignals(
+        self,
+        signals: list[PSignalInstance],
+        *,
+        timeout: int = 5000,
+        check_params_cbs: list[Callable[..., bool]] | None = None,
+        order: str | None = None,
+    ) -> Iterator[None]:
+        received: list[int] = []
+        slots: list[Callable] = []
+        for i, sig in enumerate(signals):
+            pcb = check_params_cbs[i] if check_params_cbs else None
+
+            def _slot(
+                *a: Any,
+                _i: int = i,
+                _pcb: Callable[..., bool] | None = pcb,
+            ) -> None:
+                if not _pcb or _pcb(*a):
+                    received.append(_i)
+
+            slots.append(_slot)
+            sig.connect(_slot)
+        try:
+            yield
+        finally:
+            self.waitUntil(
+                lambda: len(received) >= len(signals),
+                timeout=timeout,
+            )
+            for sig, slot in zip(signals, slots, strict=False):
+                sig.disconnect(slot)
+            if order == "strict":
+                assert received == list(range(len(signals)))
+
+    def waitUntil(self, callback: Callable[[], bool], *, timeout: int = 5000) -> None:
+        deadline = time.monotonic() + timeout / 1000
+        while time.monotonic() < deadline:
+            if callback():
+                return
+            time.sleep(0.01)
+        raise TimeoutError(f"Condition not met within {timeout}ms")
+
+    @contextmanager
+    def capture_exceptions(self) -> Iterator[list]:
+        yield []
+
+
+@pytest.fixture
+def anybot(request: pytest.FixtureRequest, core: pymmcore_plus.CMMCorePlus) -> Any:
+    if isinstance(core._events, CMMCoreSignaler):
+        return PsygnalBot()
+    return request.getfixturevalue("qtbot")
+
+
 def pytest_collection_modifyitems(session, config, items):
     last_items = []
     first_items = []
@@ -87,22 +155,3 @@ def pytest_collection_modifyitems(session, config, items):
         else:
             other_items.append(item)
     items[:] = first_items + other_items + last_items
-
-
-# requires psutil
-# @pytest.fixture(autouse=True)
-# def monitor_file_descriptors():
-#     import psutil
-
-#     process = psutil.Process(os.getpid())
-#     before_fds = process.num_fds()
-
-#     yield
-
-#     if _mmcore_plus._instance:
-#         _mmcore_plus._instance.__del__()
-#         _mmcore_plus._instance = None
-
-#     after_fds = process.num_fds()
-#     if after_fds > before_fds:
-#         print(f"File descriptors leaked: {after_fds} > {before_fds}")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,7 +2,7 @@ import os
 import re
 from collections.abc import Callable, Mapping
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 from unittest.mock import MagicMock, call, patch
 
 import numpy as np
@@ -23,14 +23,13 @@ from pymmcore_plus.core.events import CMMCoreSignaler
 from pymmcore_plus.mda import MDAEngine
 from pymmcore_plus.mda._runner import RunState
 
-if TYPE_CHECKING:
-    from pytestqt.qtbot import QtBot
+_sig_types: tuple[type, ...] = (psygnal.SignalInstance,)
 
 try:
-    from qtpy.QtCore import QObject
     from qtpy.QtCore import SignalInstance as QSignalInstance
+
+    _sig_types = (*_sig_types, QSignalInstance)
 except ImportError:
-    QObject = None
     QSignalInstance = None
 
 
@@ -39,12 +38,9 @@ def test_core(core: CMMCorePlus) -> None:
     assert isinstance(core, pymmcore.CMMCore)
     # because the fixture tries to find micromanager, this should be populated
     assert core.getDeviceAdapterSearchPaths()
-    assert isinstance(
-        core.events.propertyChanged, (psygnal.SignalInstance, QSignalInstance)
-    )
-    assert isinstance(
-        core.mda.events.frameReady, (psygnal.SignalInstance, QSignalInstance)
-    )
+
+    assert isinstance(core.events.propertyChanged, _sig_types)
+    assert isinstance(core.mda.events.frameReady, _sig_types)
     assert core.mda.status.phase == RunState.IDLE
     assert not core.mda.is_paused()
 
@@ -86,10 +82,7 @@ def test_load_system_config(core: CMMCorePlus) -> None:
     )
 
 
-@pytest.mark.skipif(QObject is None, reason="Qt not available.")
-def test_cb_exceptions(core: CMMCorePlus, caplog: Any, qtbot: "QtBot") -> None:
-    if not isinstance(core.events, QObject):
-        pytest.skip(reason="Skip cb exceptions on psygnal.")
+def test_cb_exceptions(core: CMMCorePlus, caplog: Any, anybot: Any) -> None:
 
     @core.events.propertyChanged.connect
     def _raze():
@@ -98,14 +91,14 @@ def test_cb_exceptions(core: CMMCorePlus, caplog: Any, qtbot: "QtBot") -> None:
     # using this to avoid our setProperty override... which would immediately
     # raise the exception (we want it to be raised deeper)
     if isinstance(core.events, CMMCoreSignaler):
-        pymmcore.CMMCore.setProperty(core, "Camera", "Binning", 2)
-        msg = caplog.records[0].message
-        assert msg.startswith(
-            "Exception occurred in MMCorePlus callback 'propertyChanged'"
-        )
+        with caplog.at_level("ERROR", logger="pymmcore-plus"):
+            pymmcore.CMMCore.setProperty(core, "Camera", "Binning", 2)
+            anybot.waitUntil(lambda: caplog.records)
+        expected = "Exception occurred in MMCorePlus callback 'propertyChanged'"
+        assert expected in caplog.text
     else:
-        with qtbot.capture_exceptions() as exceptions:
-            with qtbot.waitSignal(core.events.propertyChanged):
+        with anybot.capture_exceptions() as exceptions:
+            with anybot.waitSignal(core.events.propertyChanged):
                 pymmcore.CMMCore.setProperty(core, "Camera", "Binning", 2)
         assert len(exceptions) == 1
         assert str(exceptions[0][1]) == "Boom"
@@ -125,8 +118,7 @@ def test_new_position_methods(core: CMMCorePlus) -> None:
     assert round(z2, 2) == z1 + 1
 
 
-@pytest.mark.skipif(QObject is None, reason="Qt not available.")
-def test_mda(core: CMMCorePlus, qtbot: "QtBot") -> None:
+def test_mda(core: CMMCorePlus, anybot: Any) -> None:
     """Test signal emission during MDA"""
     mda = MDASequence(
         time_plan={"interval": 0.1, "loops": 2},
@@ -148,7 +140,7 @@ def test_mda(core: CMMCorePlus, qtbot: "QtBot") -> None:
     core.events.stagePositionChanged.connect(stage_mock)
     core.events.exposureChanged.connect(exp_mock)
 
-    with qtbot.waitSignal(core.mda._signals.sequenceFinished):
+    with anybot.waitSignal(core.mda._signals.sequenceFinished):
         core.mda.run(mda)
     assert fr_mock.call_count == len(list(mda))
     for event, _call in zip(mda, fr_mock.call_args_list, strict=False):
@@ -173,7 +165,7 @@ def test_mda(core: CMMCorePlus, qtbot: "QtBot") -> None:
     sf_mock.assert_called_once_with(mda)
     # device adapter will have slightly different position than requested
     # round Y,X to 1 decimal place for comparison
-    qtbot.waitUntil(lambda: xystage_mock.call_count >= 2)
+    anybot.waitUntil(lambda: xystage_mock.call_count >= 2)
     xy_moves = [
         (round(y, 1), round(x, 1))
         for ((dev, y, x), kwargs) in xystage_mock.call_args_list
@@ -195,12 +187,8 @@ def test_mda(core: CMMCorePlus, qtbot: "QtBot") -> None:
     )
 
 
-@pytest.mark.skipif(QObject is None, reason="Qt not available.")
-def test_mda_pause_cancel(qtbot: "QtBot") -> None:
+def test_mda_pause_cancel(core: CMMCorePlus, anybot: Any) -> None:
     """Test signal emission during MDA with cancelation"""
-    core = CMMCorePlus()
-    core.loadSystemConfiguration()
-
     mda = MDASequence(
         time_plan={"interval": 0.25, "loops": 10},
         stage_positions=[(1, 1, 1)],
@@ -232,7 +220,7 @@ def test_mda_pause_cancel(qtbot: "QtBot") -> None:
         elif _fcount == 2:
             core.mda.cancel()
 
-    with qtbot.waitSignal(core.mda._signals.sequenceFinished):
+    with anybot.waitSignal(core.mda._signals.sequenceFinished):
         core.run_mda(mda)
 
     ss_mock.assert_called_once()
@@ -242,8 +230,7 @@ def test_mda_pause_cancel(qtbot: "QtBot") -> None:
     sf_mock.assert_called_once_with(mda)
 
 
-@pytest.mark.skipif(QObject is None, reason="Qt not available.")
-def test_register_mda_engine(core: CMMCorePlus, qtbot: "QtBot") -> None:
+def test_register_mda_engine(core: CMMCorePlus, anybot: Any) -> None:
     orig_engine = core.mda.engine
     assert orig_engine and orig_engine.mmcore is core
 
@@ -260,7 +247,7 @@ def test_register_mda_engine(core: CMMCorePlus, qtbot: "QtBot") -> None:
         core.register_mda_engine(new_engine)
     core.mda._state = RunState.IDLE
 
-    with qtbot.waitSignal(core.events.mdaEngineRegistered):
+    with anybot.waitSignal(core.events.mdaEngineRegistered):
         core.register_mda_engine(new_engine)
     assert core.mda.engine is new_engine
 
@@ -273,8 +260,7 @@ def test_register_mda_engine(core: CMMCorePlus, qtbot: "QtBot") -> None:
     registered_mock.assert_called_once_with(new_engine, orig_engine)
 
 
-@pytest.mark.skipif(QObject is None, reason="Qt not available.")
-def test_not_concurrent_mdas(core: CMMCorePlus, qtbot: "QtBot") -> None:
+def test_not_concurrent_mdas(core: CMMCorePlus) -> None:
     mda = MDASequence(
         time_plan={"interval": 0.1, "loops": 2},
         stage_positions=[(1, 1, 1)],
@@ -501,8 +487,7 @@ def test_setContext(core: CMMCorePlus) -> None:
     assert core.getAutoShutter()
 
 
-@pytest.mark.skipif(QObject is None, reason="Qt not available.")
-def test_snap_signals(core: CMMCorePlus, qtbot: "QtBot") -> None:
+def test_snap_signals(core: CMMCorePlus, anybot: Any) -> None:
     assert core.getAutoShutter()
 
     def shutter_is(state: bool) -> Callable:
@@ -511,7 +496,7 @@ def test_snap_signals(core: CMMCorePlus, qtbot: "QtBot") -> None:
 
         return _check
 
-    with qtbot.waitSignals(
+    with anybot.waitSignals(
         [core.events.propertyChanged, core.events.propertyChanged],
         check_params_cbs=[shutter_is(True), shutter_is(False)],
         order="strict",

--- a/tests/test_mda.py
+++ b/tests/test_mda.py
@@ -20,18 +20,8 @@ if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
 
     from pytest import LogCaptureFixture
-    from pytestqt.qtbot import QtBot
 
     from pymmcore_plus.mda import MDAEngine
-
-try:
-    import pytestqt
-except ImportError:
-    pytestqt = None
-
-SKIP_NO_PYTESTQT = pytest.mark.skipif(
-    pytestqt is None, reason="pytest-qt not installed"
-)
 
 
 def test_mda_waiting(core: CMMCorePlus) -> None:
@@ -91,8 +81,7 @@ class BrokenEngine:
     def exec_event(self, event): ...
 
 
-@SKIP_NO_PYTESTQT
-def test_mda_failures(core: CMMCorePlus, qtbot: QtBot) -> None:
+def test_mda_failures(core: CMMCorePlus, anybot: Any) -> None:
     mda = MDASequence(
         channels=["Cy5"],
         time_plan={"interval": 1.5, "loops": 2},
@@ -107,7 +96,7 @@ def test_mda_failures(core: CMMCorePlus, qtbot: QtBot) -> None:
     core.mda.events.frameReady.connect(cb)
 
     if isinstance(core.mda.events, MDASignaler):
-        with qtbot.waitSignal(core.mda.events.sequenceFinished):
+        with anybot.waitSignal(core.mda.events.sequenceFinished):
             core.mda.run(mda)
 
     assert not core.mda.is_running()
@@ -120,11 +109,11 @@ def test_mda_failures(core: CMMCorePlus, qtbot: QtBot) -> None:
     # we should fail gracefully
     with patch.object(core.mda, "_engine", BrokenEngine()):
         if isinstance(core.mda.events, MDASignaler):
-            with qtbot.waitSignal(core.mda.events.sequenceFinished):
+            with anybot.waitSignal(core.mda.events.sequenceFinished):
                 with pytest.raises(ValueError):
                     core.mda.run(mda)
         else:
-            with qtbot.waitSignal(core.mda.events.sequenceFinished):
+            with anybot.waitSignal(core.mda.events.sequenceFinished):
                 with pytest.raises(ValueError):
                     core.mda.run(mda)
         assert not core.mda.is_running()
@@ -138,10 +127,9 @@ def test_mda_failures(core: CMMCorePlus, qtbot: QtBot) -> None:
 AFPlan = {"autofocus_device_name": "Z", "autofocus_motor_offset": 25, "axes": ("p",)}
 
 
-@SKIP_NO_PYTESTQT
-def test_autofocus(core: CMMCorePlus, qtbot: QtBot, mock_fullfocus) -> None:
+def test_autofocus(core: CMMCorePlus, anybot: Any, mock_fullfocus: Any) -> None:
     mda = MDASequence(stage_positions=[{"z": 0}], autofocus_plan=AFPlan)
-    with qtbot.waitSignal(core.mda.events.sequenceFinished):
+    with anybot.waitSignal(core.mda.events.sequenceFinished):
         core.mda.run(mda)
 
     engine = cast("MDAEngine", core.mda._engine)
@@ -149,10 +137,7 @@ def test_autofocus(core: CMMCorePlus, qtbot: QtBot, mock_fullfocus) -> None:
     assert engine._z_correction[0] == 50
 
 
-@SKIP_NO_PYTESTQT
-def test_autofocus_relative_z_plan(
-    core: CMMCorePlus, qtbot: QtBot, mock_fullfocus: Any
-) -> None:
+def test_autofocus_relative_z_plan(core: CMMCorePlus, mock_fullfocus: Any) -> None:
     # setting both z pos and autofocus offset to 25 because core does not have a
     # demo AF stage with both `State` and `Offset` properties.
     mda = MDASequence(
@@ -178,8 +163,7 @@ def test_autofocus_relative_z_plan(
     assert core.mda.engine._z_correction == {0: 50.0}  # saved the correction
 
 
-@SKIP_NO_PYTESTQT
-def test_autofocus_retries(core: CMMCorePlus, qtbot: QtBot, mock_fullfocus_failure):
+def test_autofocus_retries(core: CMMCorePlus, mock_fullfocus_failure: Any) -> None:
     # mock_autofocus sets z=100
     # setting both z pos and autofocus offset to 25 because core does not have a
     # demo AF stage with both `State` and `Offset` properties.
@@ -198,8 +182,7 @@ def test_autofocus_retries(core: CMMCorePlus, qtbot: QtBot, mock_fullfocus_failu
     assert core.getZPosition() == 25
 
 
-@SKIP_NO_PYTESTQT
-def test_set_mda_fov(core: CMMCorePlus, qtbot: QtBot):
+def test_set_mda_fov(core: CMMCorePlus) -> None:
     """Test that the fov size is updated."""
     mda = MDASequence(
         channels=["FITC"],
@@ -235,10 +218,9 @@ SEQS = [
 ]
 
 
-@SKIP_NO_PYTESTQT
 @pytest.mark.parametrize("seq", SEQS)
 def test_mda_iterable_of_events(
-    core: CMMCorePlus, seq: Iterable[MDAEvent], qtbot: QtBot
+    core: CMMCorePlus, seq: Iterable[MDAEvent], anybot: Any
 ) -> None:
     if seq == "event_generator()":  # type: ignore
         seq = event_generator()
@@ -247,7 +229,7 @@ def test_mda_iterable_of_events(
     core.mda.events.sequenceStarted.connect(start_mock)
     core.mda.events.frameReady.connect(frame_mock)
 
-    with qtbot.waitSignal(core.mda.events.sequenceFinished):
+    with anybot.waitSignal(core.mda.events.sequenceFinished):
         core.mda.run(seq)
 
     assert start_mock.call_count == 1
@@ -386,21 +368,12 @@ def test_engine_protocol(core: CMMCorePlus) -> None:
         core.mda.set_engine(object())  # type: ignore
 
 
-@SKIP_NO_PYTESTQT
-def test_runner_cancel(qtbot: QtBot) -> None:
-    # not using the parametrized fixture because we only want to test Qt here.
-    # see https://github.com/pymmcore-plus/pymmcore-plus/issues/95 and
-    # https://github.com/pymmcore-plus/pymmcore-plus/pull/98
-    # for what we're trying to avoid
-    core = CMMCorePlus()
-    core.loadSystemConfiguration()
-    core.mda.engine.use_hardware_sequencing = False
-
+def test_runner_cancel(core: CMMCorePlus, anybot: Any) -> None:
     engine = MagicMock(wraps=core.mda.engine)
     core.mda.set_engine(engine)
     event1 = MDAEvent()
     core.run_mda([event1, MDAEvent(min_start_time=10)])
-    with qtbot.waitSignal(core.mda.events.sequenceCanceled):
+    with anybot.waitSignal(core.mda.events.sequenceCanceled):
         time.sleep(0.1)
         core.mda.cancel()
 
@@ -408,31 +381,22 @@ def test_runner_cancel(qtbot: QtBot) -> None:
     engine.setup_event.assert_called_once_with(event1)  # not twice
 
 
-@SKIP_NO_PYTESTQT
-def test_runner_pause(qtbot: QtBot) -> None:
-    # not using the parametrized fixture because we only want to test Qt here.
-    # see https://github.com/pymmcore-plus/pymmcore-plus/issues/95 and
-    # https://github.com/pymmcore-plus/pymmcore-plus/pull/98
-    # for what we're trying to avoid
-    core = CMMCorePlus()
-    core.loadSystemConfiguration()
-    core.mda.engine.use_hardware_sequencing = False
-
+def test_runner_pause(core: CMMCorePlus, anybot: Any) -> None:
     engine = MagicMock(wraps=core.mda.engine)
     core.mda.set_engine(engine)
-    with qtbot.waitSignal(core.mda.events.frameReady):
+    with anybot.waitSignal(core.mda.events.frameReady):
         thread = core.run_mda([MDAEvent(), MDAEvent(min_start_time=2)])
     engine.setup_event.assert_called_once()  # not twice
 
-    with qtbot.waitSignal(core.mda.events.sequencePauseToggled):
+    with anybot.waitSignal(core.mda.events.sequencePauseToggled):
         core.mda.set_paused(True)
     time.sleep(1)
-    with qtbot.waitSignal(core.mda.events.sequencePauseToggled):
+    with anybot.waitSignal(core.mda.events.sequencePauseToggled):
         core.mda.set_paused(False)
 
     assert core.mda._paused_time > 0
 
-    with qtbot.waitSignal(core.mda.events.sequenceFinished):
+    with anybot.waitSignal(core.mda.events.sequenceFinished):
         thread.join()
     assert engine.setup_event.call_count == 2
     engine.teardown_sequence.assert_called_once()


### PR DESCRIPTION
this unskips any of the tests that we had skipped when using the psygnal backend (for lack of a qtbot replacement)