### PR TITLE
ci: use no version for setup-mm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,15 +69,7 @@ jobs:
           uv pip install pymmcore-nano
           uv pip uninstall pymmcore
 
-      - name: Get pymmcore version (env)
-        shell: bash
-        run: |
-          ver=$(uv run python -c 'from pymmcore_plus import _pymmcore;print(_pymmcore.version_info.device_interface)')
-          echo "PYMM_VERSION=$ver" >> $GITHUB_ENV
-
       - uses: pymmcore-plus/setup-mm-test-adapters@main
-        with:
-          version: ${{ env.PYMM_VERSION }}
 
       - run: uv run coverage run -p -m pytest -v --color=yes ${{ matrix.resolution == 'lowest-direct' && '-W ignore' || '' }}
 
@@ -129,16 +121,7 @@ jobs:
           uv pip install ./pymmcore-plus
           uv pip list
 
-      - name: Get pymmcore version (env)
-        shell: bash
-        run: |
-          ver=$(uv run python -c 'from pymmcore_plus import _pymmcore;print(_pymmcore.version_info.device_interface)')
-          echo "PYMM_VERSION=$ver" >> $GITHUB_ENV
-
-      - name: Setup MM test adapters
-        uses: pymmcore-plus/setup-mm-test-adapters@main
-        with:
-          version: ${{ env.PYMM_VERSION }}
+      - uses: pymmcore-plus/setup-mm-test-adapters@main
 
       - run: uv run pytest -v --color=yes -W ignore
 
@@ -180,16 +163,7 @@ jobs:
           uv pip install ./pymmcore-plus
           uv pip list
 
-      - name: Get pymmcore version (env)
-        shell: bash
-        run: |
-          ver=$(uv run python -c 'from pymmcore_plus import _pymmcore;print(_pymmcore.version_info.device_interface)')
-          echo "PYMM_VERSION=$ver" >> $GITHUB_ENV
-
-      - name: Setup MM test adapters
-        uses: pymmcore-plus/setup-mm-test-adapters@main
-        with:
-          version: ${{ env.PYMM_VERSION }}
+      - uses: pymmcore-plus/setup-mm-test-adapters@main
 
       - run: uv run pytest -v --color=yes -W ignore
 
@@ -207,16 +181,7 @@ jobs:
       - name: install
         run: uv sync --no-dev --group test-codspeed
 
-      - name: Get pymmcore version (env)
-        shell: bash
-        run: |
-          ver=$(uv run python -c 'from pymmcore_plus import _pymmcore;print(_pymmcore.version_info.device_interface)')
-          echo "PYMM_VERSION=$ver" >> $GITHUB_ENV
-
-      - name: Setup MM test adapters
-        uses: pymmcore-plus/setup-mm-test-adapters@main
-        with:
-          version: ${{ env.PYMM_VERSION }}
+      - uses: pymmcore-plus/setup-mm-test-adapters@main
 
       - name: Run benchmarks
         uses: CodSpeedHQ/action@v4


### PR DESCRIPTION
`pymmcore-plus/setup-mm-test-adapters` will now just pick the appropriate device adapters for the version of pymmcore[-nano] installed.  so we can simplify setup