### PR TITLE
 fix: ensure sink is cleared before early return in _coerce_outputs

### DIFF
--- a/src/pymmcore_plus/mda/_runner.py
+++ b/src/pymmcore_plus/mda/_runner.py
@@ -392,8 +392,8 @@ class MDARunner:
         """
         error = None
         sequence = events if isinstance(events, MDASequence) else GeneratorMDASequence()
-        # also creates self._sink if output is a str|Path|AcquisitionSettings
-        handlers = self._coerce_outputs(output, overwrite=overwrite)
+        handlers, sink = self._coerce_outputs(output, overwrite=overwrite)
+        self._sink = sink
         with self._handlers_connected(handlers):
             # NOTE: it's important that `_prepare_to_run` and `_finish_run` are
             # called inside the context manager, since the `mda_listeners_connected`
@@ -459,34 +459,36 @@ class MDARunner:
         """
         return time.perf_counter() - self._t0
 
+    @staticmethod
     def _coerce_outputs(
-        self,
         output: SingleOutput | Sequence[SingleOutput] | None,
         overwrite: bool = False,
-    ) -> list[SupportsFrameReady]:
-        """Normalize and validate output into a list of frameReady handlers.
+    ) -> tuple[list[SupportsFrameReady], SinkProtocol | None]:
+        """Normalize and validate output into a list of frameReady handlers, and a sink.
 
-        Also sets self._sink if a path or AcquisitionSettings is provided.
+        Returns
+        -------
+        tuple[list[SupportsFrameReady], SinkProtocol | None]
+            A tuple of (handlers, sink).
         """
-        # reset sink from any previous run so a new run can set a fresh one
-        self._sink = None
+        sink: SinkProtocol | None = None
+        handlers: list[SupportsFrameReady] = []
 
         if output is None:
-            return []
+            return handlers, sink
 
         if isinstance(output, (str, Path)) or not isinstance(output, Sequence):
             output = [output]
 
-        handlers: list[SupportsFrameReady] = []
         for item in output:
             if isinstance(item, (str, Path, AcquisitionSettings)):
-                if self._sink is not None:
+                if sink is not None:
                     raise NotImplementedError(
                         "Only one AcquisitionSettings object or path may be provided "
                         "as output.  Open a feature request if you would like to see "
                         "support for multiple data sinks."
                     )
-                self._sink = _OmeWritersSink.from_output(item, overwrite=overwrite)
+                sink = _OmeWritersSink.from_output(item, overwrite=overwrite)
             else:
                 if not callable(getattr(item, "frameReady", None)):
                     raise TypeError(
@@ -494,7 +496,7 @@ class MDARunner:
                         f"Got {item} with type {type(item)}."
                     )
                 handlers.append(item)
-        return handlers
+        return handlers, sink
 
     def _handlers_connected(
         self, handlers: Sequence[SupportsFrameReady]

--- a/tests/test_mda.py
+++ b/tests/test_mda.py
@@ -554,21 +554,6 @@ def test_restore_initial_state_enabled_by_default(
         assert abs(final_z - changed_z) < 0.1
 
 
-def _sink_injected(runner: Any) -> MagicMock:
-    """Inject a mock sink into an MDARunner for the duration of a run."""
-    sink = MagicMock()
-    sink.get_view.return_value = None
-    real_coerce = runner._coerce_outputs
-
-    def _coerce_with_sink(output: object = None, overwrite: bool = False) -> list:
-        handlers = real_coerce(output, overwrite=overwrite)
-        runner._sink = sink
-        return handlers
-
-    runner._coerce_outputs = _coerce_with_sink
-    return sink
-
-
 def test_skip_event_from_setup(core: CMMCorePlus) -> None:
     """SkipEvent raised in setup_event skips exec and notifies the sink."""
     exec_mock = Mock()
@@ -591,8 +576,11 @@ def test_skip_event_from_setup(core: CMMCorePlus) -> None:
         MDAEvent(index={"t": 2}),
     ]
 
-    sink = _sink_injected(core.mda)
-    with patch.object(core.mda, "_engine", SkippingEngine()):
+    sink = MagicMock()
+    with (
+        patch.object(core.mda, "_engine", SkippingEngine()),
+        patch.object(core.mda, "_coerce_outputs", return_value=([], sink)),
+    ):
         core.mda.run(events)
 
     # exec_event should have been called for events 0 and 2, but not 1
@@ -614,8 +602,11 @@ def test_skip_event_multi_frame(core: CMMCorePlus) -> None:
         def exec_event(self, event: MDAEvent) -> Iterable:
             return ()
 
-    sink = _sink_injected(core.mda)
-    with patch.object(core.mda, "_engine", SkippingEngine()):
+    sink = MagicMock()
+    with (
+        patch.object(core.mda, "_engine", SkippingEngine()),
+        patch.object(core.mda, "_coerce_outputs", return_value=([], sink)),
+    ):
         core.mda.run([MDAEvent()])
 
     sink.skip.assert_called_once_with(frames=5)
@@ -637,8 +628,11 @@ def test_none_payload_calls_skip(core: CMMCorePlus) -> None:
             yield None  # one frame failed
             yield (MagicMock(), event, {"runner_time_ms": 0})
 
-    sink = _sink_injected(core.mda)
-    with patch.object(core.mda, "_engine", PartialEngine()):
+    sink = MagicMock()
+    with (
+        patch.object(core.mda, "_engine", PartialEngine()),
+        patch.object(core.mda, "_coerce_outputs", return_value=([], sink)),
+    ):
         core.mda.run([MDAEvent()])
 
     assert sink.append.call_count == 2

--- a/tests/test_mda_output.py
+++ b/tests/test_mda_output.py
@@ -154,27 +154,3 @@ def test_run_with_event_iterator(core: CMMCorePlus) -> None:
     view = core.mda.get_view()
     assert view is not None
     assert view.shape[:-2] == (3,)
-
-
-def test_sink_cleared_on_run_without_output(core: CMMCorePlus, tmp_path: Path) -> None:
-    """Test that the sink is always cleared at the start of a run.
-
-    The sink must be cleared even if the new run doesn't specify an output, otherwise
-    the sink from the previous run would still be set and the new run would try to
-    reuse it, which would fail if the previous sink had a file-based output because
-    the file already exists.
-    """
-    runner = core.mda
-    seq = useq.MDASequence(time_plan=useq.TIntervalLoops(interval=0.1, loops=2))
-    out = tmp_path / "first.ome.tiff"
-
-    # First run: write to a file - this sets runner._sink
-    runner.run(seq, output=out)
-    assert out.exists()
-    assert runner._sink is not None
-
-    # Second run: no output - sink must be cleared before the run starts,
-    # otherwise _prepare_to_run would call self._sink.setup() on the stale
-    # sink and raise FileExistsError because the file already exists.
-    runner.run(seq)  # must not raise
-    assert runner._sink is None

--- a/tests/test_multicam_save.py
+++ b/tests/test_multicam_save.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from math import prod
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -94,21 +94,6 @@ def test_multicam_ome_sink_with_channels(
     assert prod(view.shape[:-2]) == expected
 
 
-def _sink_injected(runner: Any) -> MagicMock:
-    """Inject a mock sink into an MDARunner for the duration of a run."""
-    sink = MagicMock()
-    sink.get_view.return_value = None
-    real_coerce = runner._coerce_outputs
-
-    def _coerce_with_sink(output: object = None, overwrite: bool = False) -> list:
-        handlers = real_coerce(output, overwrite=overwrite)
-        runner._sink = sink
-        return handlers
-
-    runner._coerce_outputs = _coerce_with_sink
-    return sink
-
-
 def test_multicam_skip_event_multiplier(multicam_core: CMMCorePlus) -> None:
     """SkipEvent.num_frames should be multiplied by n_cameras for the sink."""
     real_engine = multicam_core.mda.engine
@@ -125,8 +110,11 @@ def test_multicam_skip_event_multiplier(multicam_core: CMMCorePlus) -> None:
         def exec_event(self, event: useq.MDAEvent) -> tuple:
             return ()
 
-    sink = _sink_injected(multicam_core.mda)
-    with patch.object(multicam_core.mda, "_engine", SkippingEngine()):
+    sink = MagicMock()
+    with (
+        patch.object(multicam_core.mda, "_engine", SkippingEngine()),
+        patch.object(multicam_core.mda, "_coerce_outputs", return_value=([], sink)),
+    ):
         multicam_core.mda.run([useq.MDAEvent()])
 
     n_cameras = multicam_core.getNumberOfCameraChannels()


### PR DESCRIPTION
@tlambert03 I think  I found a bug in the runner...

If you run the following code:

```py
import useq
from pymmcore_plus import CMMCorePlus

out = "first.ome.tiff"
seq = useq.MDASequence(time_plan=useq.TIntervalLoops(interval=0.1, loops=2))

mmcore = CMMCorePlus()
mmcore.loadSystemConfiguration()
runner = mmcore.mda

# First run: write to a file - this sets runner._sink
runner.run(seq, output=out)
assert out.exists()
assert runner._sink is not None

# Second run: no output - should sink be cleared before the run starts?
runner.run(seq)
```

you will get a `FileExistsError` because the sink from the previous run is not reset because in `_coerce_outputs` we [currently have](https://github.com/pymmcore-plus/pymmcore-plus/blob/676eade8130b1372ab30b47d4c87baffdb923c5c/src/pymmcore_plus/mda/_runner.py#L462):

```py
    def _coerce_outputs(
        self,
        output: SingleOutput | Sequence[SingleOutput] | None,
        overwrite: bool = False,
    ) -> list[SupportsFrameReady]:
        """Normalize and validate output into a list of frameReady handlers.

        Also sets self._sink if a path or AcquisitionSettings is provided.
        """
        if output is None:
            return []

        # reset sink from any previous run so a new run can set a fresh one
        self._sink = None
        ...
```
Since `output=None` in the second run, we return `[]` before clearing `self._sink`.
<br>

To fix this I simply moved `self._sink = None` before the `if output is None` guard so that the sink from a previous run is always cleared, even when the next run has no output.

I've added `test_sink_cleared_on_run_without_output` to expose this bug and I also had to update the tests that inject mock sinks to work with the new reset order (not sure if this is the best approach).