### PR TITLE
fix: block channelGroupChanged signal during setChannelGroup

### DIFF
--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -2206,7 +2206,8 @@ class CMMCorePlus(pymmcore.CMMCore):
         ...and send a channelGroupChanged signal.
         """
         if self.getChannelGroup() != channelGroup:
-            super().setChannelGroup(channelGroup)
+            with _blockSignal(self.events, self.events.channelGroupChanged):
+                super().setChannelGroup(channelGroup)
             self.events.channelGroupChanged.emit(channelGroup)
 
     def setFocusDevice(self, focusLabel: str) -> None:


### PR DESCRIPTION
`CMMCorePlus.setChannelGroup` was double-emitting `channelGroupChanged`

1. Via C++ callback relay (onChannelGroupChanged → relay → channelGroupChanged.emit)
2. Via explicit Python emit in `CMMCorePlus` at https://github.com/pymmcore-plus/pymmcore-plus/blob/079ae35076ed28e77cd9b149a86c5c5736c0a2d5/src/pymmcore_plus/core/_mmcore_plus.py#L2210


On Windows, the C++ callback could arrive asynchronously/delayed, causing the test's reset_mock() race, occasionally resulting in 

```pytb
    >       channel_group_changed_mock.assert_not_called()                                                                                                                                        
                                                                                                                                                                                                  
    tests\00_unicore\test_unicore.py:459:                                                                                                                                                         
    _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _                                                                                                               
                                                                                                                                                                                                  
    self = <MagicMock id='2878555171744'>                                                                                                                                                         
                                                                                                                                                                                                  
        def assert_not_called(self):                                                                                                                                                              
            """assert that the mock was never called.                                                                                                                                             
            """                                                                                                                                                                                   
            if self.call_count != 0:                                                                                                                                                              
                msg = ("Expected '%s' to not have been called. Called %s times.%s"                                                                                                                
                       % (self._mock_name or 'mock',                                                                                                                                              
                          self.call_count,                                                                                                                                                        
                          self._calls_repr()))                                                                                                                                                    
    >           raise AssertionError(msg)                                                                                                                                                         
    E           AssertionError: Expected 'mock' to not have been called. Called 1 times.                                                                                                          
    E           Calls: [call('channel')].                                                                                                                                                         
                                                                                                                                                                                                  
    C:\hostedtoolcache\windows\Python\3.13.12\x64\Lib\unittest\mock.py:940: AssertionError                                                                                                        
    =========================== short test summary info ===========================                                                                                                               
    FAILED tests/00_unicore/test_unicore.py::test_config_group_channel_groups - AssertionError: Expected 'mock' to not have been called. Called 1 times.                                          
    Calls: [call('channel')].         
```