### PR TITLE
fix: stop continuous sequence acquisition before starting MDA

### DIFF
--- a/src/pymmcore_plus/mda/_engine.py
+++ b/src/pymmcore_plus/mda/_engine.py
@@ -170,7 +170,7 @@ class MDAEngine(PMDAEngine):
             core = CMMCorePlus.instance()
             self._mmcore_ref = weakref.ref(core)
 
-        # stop any "continous sequence acquisition" (live mode) that may be running.
+        # stop any "continuous sequence acquisition" (live mode) that may be running.
         if core.isSequenceRunning():
             core.stopSequenceAcquisition()
 


### PR DESCRIPTION
Stop any running continuous sequence acquisition (live mode - `core.startContinuousSequenceAcquisition`) when initializing `MDAEngine`, so the MDA can start safely without conflicting with an active live view.

Not sure if this is the best place for this (maybe should be in the `MDAWidget` or in `pymmcore-gui`), but this ensures all MDA runs are safe regardless of the caller.