### PR TITLE
feat: Add optional rich logging via PYMM_LOG_RICH env var

### DIFF
--- a/docs/env_var.md
+++ b/docs/env_var.md
@@ -13,6 +13,7 @@ The following environment variables may be used to configure pymmcore-plus globa
 | **`PYMM_PARALLEL_INIT`**  | Enable/disable parallel device initialization  |  Enabled    |
 | **`PYMM_LOG_LEVEL`**                       | pymmcore-plus [logging](./guides/logging.md) level.  | `'INFO'`    |
 | **`PYMM_LOG_FILE`**   | Logfile location. | `pymmcore_plus.log` in the pymmcore-plus [log directory](./guides/logging.md#customizing-logging) |
+| **`PYMM_LOG_RICH`**   | Use [rich](https://rich.readthedocs.io/) for stderr logging (requires `rich` to be installed). | `"0"` (disabled) |
 | **`MICROMANAGER_PATH`**   | Override location of Micro-Manager directory (with device adapters) | User-directory, described [here](./install.md#set-the-active-micro-manager-installation)   |
 | **`PYMM_SIGNALS_BACKEND`** | The event backend to use. Must be one of `'qt'`, `'psygnal'`, or `'auto'`  | `auto` (Qt if `QApplication` exists, otherwise psygnal) |
 | **`PYMM_DISABLE_IPYTHON_COMPLETIONS`**  | Disable [Tab autocompletion for IPython](./guides/ipython_completion.md)  | `"0"`  (enabled) |

--- a/docs/env_var.md
+++ b/docs/env_var.md
@@ -13,7 +13,7 @@ The following environment variables may be used to configure pymmcore-plus globa
 | **`PYMM_PARALLEL_INIT`**  | Enable/disable parallel device initialization  |  Enabled    |
 | **`PYMM_LOG_LEVEL`**                       | pymmcore-plus [logging](./guides/logging.md) level.  | `'INFO'`    |
 | **`PYMM_LOG_FILE`**   | Logfile location. | `pymmcore_plus.log` in the pymmcore-plus [log directory](./guides/logging.md#customizing-logging) |
-| **`PYMM_LOG_RICH`**   | Use [rich](https://rich.readthedocs.io/) for stderr logging (requires `rich` to be installed). | `"0"` (disabled) |
+| **`PYMM_LOG_RICH`**   | Use [rich](https://rich.readthedocs.io/) for stderr logging (requires `rich` to be installed). Adds some formatting overhead ([#449](https://github.com/pymmcore-plus/pymmcore-plus/issues/449)). | `"0"` (disabled) |
 | **`MICROMANAGER_PATH`**   | Override location of Micro-Manager directory (with device adapters) | User-directory, described [here](./install.md#set-the-active-micro-manager-installation)   |
 | **`PYMM_SIGNALS_BACKEND`** | The event backend to use. Must be one of `'qt'`, `'psygnal'`, or `'auto'`  | `auto` (Qt if `QApplication` exists, otherwise psygnal) |
 | **`PYMM_DISABLE_IPYTHON_COMPLETIONS`**  | Disable [Tab autocompletion for IPython](./guides/ipython_completion.md)  | `"0"`  (enabled) |

--- a/docs/guides/logging.md
+++ b/docs/guides/logging.md
@@ -16,6 +16,7 @@ You may also configure logging using the following environment variables:
 | -------------- | ------------------------------------------------------ | --------------------- |
 | PYMM_LOG_LEVEL | INFO                                                   | The log level.        |
 | PYMM_LOG_FILE  | `pymmcore_plus.log` in the pymmcore-plus log directory | The logfile location. |
+| PYMM_LOG_RICH  | `0` (disabled)                                         | Use [rich](https://rich.readthedocs.io/) for stderr logging (requires `rich`). Set to `1`, `true`, or `yes` to enable. |
 
 !!! tip "pymmcore-plus log directory"
 

--- a/docs/guides/logging.md
+++ b/docs/guides/logging.md
@@ -16,7 +16,7 @@ You may also configure logging using the following environment variables:
 | -------------- | ------------------------------------------------------ | --------------------- |
 | PYMM_LOG_LEVEL | INFO                                                   | The log level.        |
 | PYMM_LOG_FILE  | `pymmcore_plus.log` in the pymmcore-plus log directory | The logfile location. |
-| PYMM_LOG_RICH  | `0` (disabled)                                         | Use [rich](https://rich.readthedocs.io/) for stderr logging (requires `rich`). Set to `1`, `true`, or `yes` to enable. |
+| PYMM_LOG_RICH  | `0` (disabled)                                         | Use [rich](https://rich.readthedocs.io/) for stderr logging (requires `rich`). Set to `1`, `true`, or `yes` to enable. Note: adds some formatting overhead ([#449](https://github.com/pymmcore-plus/pymmcore-plus/issues/449)). |
 
 !!! tip "pymmcore-plus log directory"
 

--- a/src/pymmcore_plus/_logger.py
+++ b/src/pymmcore_plus/_logger.py
@@ -79,6 +79,8 @@ def configure_logging(
     - `PYMM_LOG_LEVEL` - The log level for `stderr` logging. By default `INFO`.
     - `PYMM_LOG_FILE` - The path to the log file.  If set to `0`, `false`, `no`,
         or `none`, logging to file will be disabled.
+    - `PYMM_LOG_RICH` - If set to `1`, `true`, or `yes`, use `rich` for stderr
+        logging (requires `rich` to be installed).
 
 
     !!! note
@@ -118,8 +120,20 @@ def configure_logging(
 
     # automatically log to stderr
     if log_to_stderr and sys.stderr:
-        stderr_handler = logging.StreamHandler(sys.stderr)
-        stderr_handler.setFormatter(CustomFormatter())
+        # use rich for stderr logging if PYMM_LOG_RICH is set and rich is installed
+        stderr_handler: logging.Handler | None = None
+        if os.getenv("PYMM_LOG_RICH", "").lower() in ("1", "true", "yes"):
+            try:
+                from rich.logging import RichHandler
+
+                stderr_handler = RichHandler()
+            except ImportError:
+                pass
+
+        if stderr_handler is None:
+            stderr_handler = logging.StreamHandler(sys.stderr)
+            stderr_handler.setFormatter(CustomFormatter())
+
         stderr_handler.setLevel(stderr_level)
         logger.addHandler(stderr_handler)
 

--- a/src/pymmcore_plus/_logger.py
+++ b/src/pymmcore_plus/_logger.py
@@ -80,7 +80,8 @@ def configure_logging(
     - `PYMM_LOG_FILE` - The path to the log file.  If set to `0`, `false`, `no`,
         or `none`, logging to file will be disabled.
     - `PYMM_LOG_RICH` - If set to `1`, `true`, or `yes`, use `rich` for stderr
-        logging (requires `rich` to be installed).
+        logging (requires `rich` to be installed). Note: rich formatting adds
+        some overhead; see https://github.com/pymmcore-plus/pymmcore-plus/issues/449.
 
 
     !!! note


### PR DESCRIPTION
I actually enjoyed the rich logging :D Would you be open to bringing it back as an optional feature via en environmental variable?

Re-introduce rich logging support as an opt-in feature controlled by the
PYMM_LOG_RICH environment variable. When set to 1/true/yes and rich is
installed, stderr logging uses RichHandler instead of the plain formatter.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>