### PR TITLE
refactor: delegate per-device timeout to upstream MMCore #914

### DIFF
--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -261,6 +261,9 @@ class CMMCorePlus(pymmcore.CMMCore):
         self._last_config: tuple[str, str] = ("", "")
         # last position set by setXYPosition, None means currentXYStageDevice
         self._last_xy_position: dict[str | None, tuple[float, float]] = {}
+        # per-device timeout overrides (label → ms).  Consulted by
+        # waitForDevice / waitForSystem when no per-call timeout_ms is given.
+        self._device_timeouts: dict[str, float] = {}
 
         self._mm_path = mm_path or find_micromanager()
         if not adapter_paths and self._mm_path:
@@ -529,6 +532,110 @@ class CMMCorePlus(pymmcore.CMMCore):
         enum is more interpretable than the raw `int` returned by `pymmcore`
         """
         return DeviceInitializationState(super().getDeviceInitializationState(label))
+
+    def setDeviceTimeoutMs(self, label: str, timeout_ms: float | None) -> None:
+        """Set or clear a per-device timeout override for :meth:`waitForDevice`.
+
+        :sparkles: *This method is new in `CMMCorePlus`.*
+
+        When set, :meth:`waitForDevice` and :meth:`waitForSystem` will use this
+        value instead of the global :meth:`getTimeoutMs` for the given device.
+        The global :meth:`setTimeoutMs` is unaffected and continues to apply to
+        all devices without a per-device override.
+
+        Parameters
+        ----------
+        label : str
+            Device label.
+        timeout_ms : float | None
+            Timeout in milliseconds, or ``None`` to clear the override and
+            fall back to the global :meth:`getTimeoutMs`.
+        """
+        if timeout_ms is None:
+            self._device_timeouts.pop(label, None)
+        else:
+            self._device_timeouts[label] = timeout_ms
+
+    def getDeviceTimeoutMs(self, label: str) -> float | None:
+        """Return the per-device timeout override, or ``None`` if not set.
+
+        :sparkles: *This method is new in `CMMCorePlus`.*
+
+        See :meth:`setDeviceTimeoutMs` for details.
+        """
+        return self._device_timeouts.get(label)
+
+    def waitForDevice(
+        self,
+        label: DeviceLabel | str,
+        *,
+        timeout_ms: float | None = None,
+    ) -> None:
+        """Block until ``label`` reports not-busy, or raise :class:`TimeoutError`.
+
+        **Why Override?** To allow a per-call timeout override without touching
+        the global :meth:`setTimeoutMs`. Devices with unreliable ``Busy()`` flags
+        (for example, DMD or XY-stage adapters that report busy forever) cause
+        :meth:`waitForSystem` to eat the full global timeout on every event. A
+        per-call override — and especially ``timeout_ms=0`` — lets callers
+        fast-fail on known-bad devices without a class-wide skip list.
+
+        The timeout resolution order is:
+        1. ``timeout_ms`` kwarg (if passed)
+        2. Per-device override from :meth:`setDeviceTimeoutMs` (if set)
+        3. Global :meth:`getTimeoutMs` (C++ fast path)
+
+        Parameters
+        ----------
+        label : str
+            Device label.
+        timeout_ms : float, optional
+            Per-call timeout override in milliseconds. ``None`` (default)
+            consults the per-device registry, then the global timeout.
+            ``0`` means "check :meth:`deviceBusy` once and raise
+            :class:`TimeoutError` immediately if still busy".
+
+        Raises
+        ------
+        TimeoutError
+            If a per-call or per-device timeout is active and the device is
+            still busy when the deadline expires. (When falling through to the
+            C++ path, the base class raises ``RuntimeError`` on timeout.)
+        """
+        if timeout_ms is None:
+            timeout_ms = self._device_timeouts.get(str(label))
+        if timeout_ms is None:
+            return super().waitForDevice(label)
+
+        # Core pseudo-device is never busy.
+        if str(label) == Keyword.CoreDevice:
+            return
+
+        # Python-side polling loop with 10 ms cadence (matches MMCore's
+        # pollingIntervalMs_).
+        poll_interval_s = 0.010
+        deadline = time.monotonic() + timeout_ms / 1000.0
+        while True:
+            if not self.deviceBusy(label):
+                return
+            if time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"waitForDevice({label!r}) timed out after {timeout_ms} ms"
+                )
+            time.sleep(poll_interval_s)
+
+    def waitForSystem(self) -> None:
+        """Wait for all loaded devices to become non-busy.
+
+        **Why Override?** The C++ ``waitForSystem`` applies the global
+        :meth:`getTimeoutMs` uniformly to every device. This override iterates
+        :meth:`getLoadedDevices` in Python and calls :meth:`waitForDevice` per
+        device, so per-device timeouts registered via :meth:`setDeviceTimeoutMs`
+        are honoured automatically. Devices without a per-device override still
+        use the global timeout via the C++ fast path.
+        """
+        for label in self.getLoadedDevices():
+            self.waitForDevice(label)
 
     # config overrides
 

--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -530,41 +530,6 @@ class CMMCorePlus(pymmcore.CMMCore):
         """
         return DeviceInitializationState(super().getDeviceInitializationState(label))
 
-    def setDeviceTimeoutMs(self, label: str, timeout_ms: float | None) -> None:
-        """Set or clear a per-device timeout override for :meth:`waitForDevice`.
-
-        **Why Override?** Adds a ``None``-clears convenience over the C++
-        ``setDeviceTimeoutMs`` / ``unsetDeviceTimeout`` pair, so callers can
-        toggle a per-device override with a single method.
-
-        Parameters
-        ----------
-        label : str
-            Device label.
-        timeout_ms : float | None
-            Timeout in milliseconds (must be positive), or ``None`` to clear
-            the override and fall back to the global :meth:`getTimeoutMs`.
-        """
-        # TODO: drop type: ignores once pymmcore stubs ship #914.
-        if timeout_ms is None:
-            super().unsetDeviceTimeout(label)  # type: ignore[misc]
-        else:
-            super().setDeviceTimeoutMs(label, int(timeout_ms))  # type: ignore[misc]
-
-    def getDeviceTimeoutMs(self, label: str) -> float | None:
-        """Return the per-device timeout override, or ``None`` if not set.
-
-        **Why Override?** The C++ ``getDeviceTimeoutMs`` always returns the
-        *effective* timeout (override if set, else the global timeout). This
-        override returns ``None`` when no per-device override is registered,
-        making "is there an override?" answerable from a single call.
-
-        See :meth:`setDeviceTimeoutMs` for details.
-        """
-        if not super().hasDeviceTimeout(label):  # type: ignore[misc]
-            return None
-        return cast("float", super().getDeviceTimeoutMs(label))  # type: ignore[misc]
-
     # config overrides
 
     @overload

--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -261,9 +261,6 @@ class CMMCorePlus(pymmcore.CMMCore):
         self._last_config: tuple[str, str] = ("", "")
         # last position set by setXYPosition, None means currentXYStageDevice
         self._last_xy_position: dict[str | None, tuple[float, float]] = {}
-        # per-device timeout overrides (label → ms).  Consulted by
-        # waitForDevice / waitForSystem when no per-call timeout_ms is given.
-        self._device_timeouts: dict[str, float] = {}
 
         self._mm_path = mm_path or find_micromanager()
         if not adapter_paths and self._mm_path:
@@ -536,106 +533,37 @@ class CMMCorePlus(pymmcore.CMMCore):
     def setDeviceTimeoutMs(self, label: str, timeout_ms: float | None) -> None:
         """Set or clear a per-device timeout override for :meth:`waitForDevice`.
 
-        :sparkles: *This method is new in `CMMCorePlus`.*
-
-        When set, :meth:`waitForDevice` and :meth:`waitForSystem` will use this
-        value instead of the global :meth:`getTimeoutMs` for the given device.
-        The global :meth:`setTimeoutMs` is unaffected and continues to apply to
-        all devices without a per-device override.
+        **Why Override?** Adds a ``None``-clears convenience over the C++
+        ``setDeviceTimeoutMs`` / ``unsetDeviceTimeout`` pair, so callers can
+        toggle a per-device override with a single method.
 
         Parameters
         ----------
         label : str
             Device label.
         timeout_ms : float | None
-            Timeout in milliseconds, or ``None`` to clear the override and
-            fall back to the global :meth:`getTimeoutMs`.
+            Timeout in milliseconds (must be positive), or ``None`` to clear
+            the override and fall back to the global :meth:`getTimeoutMs`.
         """
+        # TODO: drop type: ignores once pymmcore stubs ship #914.
         if timeout_ms is None:
-            self._device_timeouts.pop(label, None)
+            super().unsetDeviceTimeout(label)  # type: ignore[misc]
         else:
-            self._device_timeouts[label] = timeout_ms
+            super().setDeviceTimeoutMs(label, int(timeout_ms))  # type: ignore[misc]
 
     def getDeviceTimeoutMs(self, label: str) -> float | None:
         """Return the per-device timeout override, or ``None`` if not set.
 
-        :sparkles: *This method is new in `CMMCorePlus`.*
+        **Why Override?** The C++ ``getDeviceTimeoutMs`` always returns the
+        *effective* timeout (override if set, else the global timeout). This
+        override returns ``None`` when no per-device override is registered,
+        making "is there an override?" answerable from a single call.
 
         See :meth:`setDeviceTimeoutMs` for details.
         """
-        return self._device_timeouts.get(label)
-
-    def waitForDevice(
-        self,
-        label: DeviceLabel | str,
-        *,
-        timeout_ms: float | None = None,
-    ) -> None:
-        """Block until ``label`` reports not-busy, or raise :class:`TimeoutError`.
-
-        **Why Override?** To allow a per-call timeout override without touching
-        the global :meth:`setTimeoutMs`. Devices with unreliable ``Busy()`` flags
-        (for example, DMD or XY-stage adapters that report busy forever) cause
-        :meth:`waitForSystem` to eat the full global timeout on every event. A
-        per-call override — and especially ``timeout_ms=0`` — lets callers
-        fast-fail on known-bad devices without a class-wide skip list.
-
-        The timeout resolution order is:
-        1. ``timeout_ms`` kwarg (if passed)
-        2. Per-device override from :meth:`setDeviceTimeoutMs` (if set)
-        3. Global :meth:`getTimeoutMs` (C++ fast path)
-
-        Parameters
-        ----------
-        label : str
-            Device label.
-        timeout_ms : float, optional
-            Per-call timeout override in milliseconds. ``None`` (default)
-            consults the per-device registry, then the global timeout.
-            ``0`` means "check :meth:`deviceBusy` once and raise
-            :class:`TimeoutError` immediately if still busy".
-
-        Raises
-        ------
-        TimeoutError
-            If a per-call or per-device timeout is active and the device is
-            still busy when the deadline expires. (When falling through to the
-            C++ path, the base class raises ``RuntimeError`` on timeout.)
-        """
-        if timeout_ms is None:
-            timeout_ms = self._device_timeouts.get(str(label))
-        if timeout_ms is None:
-            return super().waitForDevice(label)
-
-        # Core pseudo-device is never busy.
-        if str(label) == Keyword.CoreDevice:
-            return
-
-        # Python-side polling loop with 10 ms cadence (matches MMCore's
-        # pollingIntervalMs_).
-        poll_interval_s = 0.010
-        deadline = time.monotonic() + timeout_ms / 1000.0
-        while True:
-            if not self.deviceBusy(label):
-                return
-            if time.monotonic() >= deadline:
-                raise TimeoutError(
-                    f"waitForDevice({label!r}) timed out after {timeout_ms} ms"
-                )
-            time.sleep(poll_interval_s)
-
-    def waitForSystem(self) -> None:
-        """Wait for all loaded devices to become non-busy.
-
-        **Why Override?** The C++ ``waitForSystem`` applies the global
-        :meth:`getTimeoutMs` uniformly to every device. This override iterates
-        :meth:`getLoadedDevices` in Python and calls :meth:`waitForDevice` per
-        device, so per-device timeouts registered via :meth:`setDeviceTimeoutMs`
-        are honoured automatically. Devices without a per-device override still
-        use the global timeout via the C++ fast path.
-        """
-        for label in self.getLoadedDevices():
-            self.waitForDevice(label)
+        if not super().hasDeviceTimeout(label):  # type: ignore[misc]
+            return None
+        return cast("float", super().getDeviceTimeoutMs(label))  # type: ignore[misc]
 
     # config overrides
 

--- a/src/pymmcore_plus/experimental/unicore/_device_manager.py
+++ b/src/pymmcore_plus/experimental/unicore/_device_manager.py
@@ -10,7 +10,7 @@ from pymmcore_plus.core._constants import DeviceInitializationState, DeviceType
 from .devices._device_base import Device
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Callable, Iterable, Iterator
 
     from pymmcore import DeviceLabel
 
@@ -74,25 +74,27 @@ class PyDeviceManager:
                 )
             time.sleep(polling_interval)
 
-    def wait_for_device_type(
-        self, dev_type: int, timeout_ms: float = 5000, *, parallel: bool = True
+    def wait_for_each(
+        self,
+        labels: Iterable[str],
+        get_timeout: Callable[[str], float],
     ) -> None:
-        if not (labels := self.get_labels_of_type(dev_type)):
-            return  # pragma: no cover
-        if not parallel:
-            for lbl in labels:
-                self.wait_for(lbl, timeout_ms)
-        else:
-            # Wait for all python devices of the given type in parallel
-            # it's critical that this be a list comprehension,
-            # not a generator expression, otherwise the executor may be shut down
-            # before any tasks are actually submitted
-            with ThreadPoolExecutor() as executor:
-                futures = [
-                    executor.submit(self.wait_for, lbl, timeout_ms) for lbl in labels
-                ]
-                for future in as_completed(futures):
-                    future.result()  # Raises any exceptions from wait_for_device
+        """Wait for each label in parallel; ``get_timeout(label)`` per device.
+
+        Raises any exception (including :class:`TimeoutError`) raised by
+        :meth:`wait_for` for any label.
+        """
+        # Materialise labels — list comp matters: a generator expression can
+        # outlive the executor scope and submit nothing.
+        labels = list(labels)
+        if not labels:
+            return
+        with ThreadPoolExecutor() as executor:
+            futures = [
+                executor.submit(self.wait_for, lbl, get_timeout(lbl)) for lbl in labels
+            ]
+            for future in as_completed(futures):
+                future.result()
 
     def get_initialization_state(self, label: str) -> DeviceInitializationState:
         """Return the initialization state of the device with the given label."""

--- a/src/pymmcore_plus/experimental/unicore/core/_unicore.py
+++ b/src/pymmcore_plus/experimental/unicore/core/_unicore.py
@@ -673,10 +673,20 @@ class UniMMCore(CMMCorePlus):
         with self._pydevices[label] as dev:
             return dev.busy()
 
-    def waitForDevice(self, label: DeviceLabel | str) -> None:
+    def waitForDevice(
+        self,
+        label: DeviceLabel | str,
+        *,
+        timeout_ms: float | None = None,
+    ) -> None:
         if label not in self._pydevices:  # pragma: no cover
-            return super().waitForDevice(label)
-        self._pydevices.wait_for(label, self.getTimeoutMs())
+            return super().waitForDevice(label, timeout_ms=timeout_ms)
+        if timeout_ms is None:
+            timeout_ms = self.getDeviceTimeoutMs(str(label))
+        effective_timeout = (
+            timeout_ms if timeout_ms is not None else self.getTimeoutMs()
+        )
+        self._pydevices.wait_for(label, effective_timeout)
 
     def waitForConfig(self, group: str, configName: str) -> None:
         # Get config data (merged from C++ and Python)
@@ -698,9 +708,21 @@ class UniMMCore(CMMCorePlus):
     def systemBusy(self) -> bool:
         return self.deviceTypeBusy(DeviceType.AnyType)
 
-    # probably only needed because C++ method is not virtual
     def waitForSystem(self) -> None:
-        self.waitForDeviceType(DeviceType.AnyType)
+        # C++ devices: serial, with per-device registry support.
+        for label in super().getLoadedDevices():
+            self.waitForDevice(label)
+        # Python devices: parallel, with per-device registry support.
+        py_labels = list(self._pydevices)
+        if py_labels:
+            from concurrent.futures import ThreadPoolExecutor, as_completed
+
+            with ThreadPoolExecutor() as executor:
+                futures = [
+                    executor.submit(self.waitForDevice, lbl) for lbl in py_labels
+                ]
+                for future in as_completed(futures):
+                    future.result()
 
     def waitForDeviceType(self, devType: int) -> None:
         super().waitForDeviceType(devType)

--- a/src/pymmcore_plus/experimental/unicore/core/_unicore.py
+++ b/src/pymmcore_plus/experimental/unicore/core/_unicore.py
@@ -153,7 +153,7 @@ class UniMMCore(CMMCorePlus):
         self._py_config_groups: ConfigGroups = {}
         # Per-device timeout overrides for Python devices. C++ devices use the
         # C++ registry (CMMCore::setDeviceTimeoutMs) directly via super().
-        self._pydevice_timeouts: dict[str, float] = {}
+        self._pydevice_timeouts: dict[str, int] = {}
 
         super().__init__(*args, **kwargs)
 
@@ -372,6 +372,7 @@ class UniMMCore(CMMCorePlus):
                 self._pycore.set_current(keyword, None)
 
         self._state_cache.clear_device(label)
+        self._pydevice_timeouts.pop(label, None)
 
         for group_name, group in list(self._py_config_groups.items()):
             for preset_name, config in list(group.items()):
@@ -395,6 +396,7 @@ class UniMMCore(CMMCorePlus):
         self._pydevices.unload_all()
         self._pycore.reset_current()
         self._py_config_groups.clear()
+        self._pydevice_timeouts.clear()
         self._state_cache.clear()
 
     def unloadAllDevices(self) -> None:
@@ -676,39 +678,42 @@ class UniMMCore(CMMCorePlus):
         with self._pydevices[label] as dev:
             return dev.busy()
 
+    # Per-device timeout dispatch: Python labels use the unicore-local dict,
+    # C++ labels delegate to super(). The `type: ignore[misc]` markers can be
+    # dropped once pymmcore stubs ship #914.
     def setDeviceTimeoutMs(self, label: str, timeout_ms: int) -> None:
         if label not in self._pydevices:
-            # TODO: drop type: ignore once pymmcore stubs ship #914.
             super().setDeviceTimeoutMs(label, timeout_ms)  # type: ignore[misc]
             return
         if timeout_ms <= 0:
             raise RuntimeError("Device timeout must be positive")
-        self._pydevice_timeouts[str(label)] = float(timeout_ms)
+        self._pydevice_timeouts[label] = timeout_ms
 
     def getDeviceTimeoutMs(self, label: str) -> int:
         """Return the effective timeout for ``label`` (override or global)."""
         if label not in self._pydevices:
-            # TODO: drop type: ignore once pymmcore stubs ship #914.
             return cast("int", super().getDeviceTimeoutMs(label))  # type: ignore[misc]
-        return int(self._pydevice_timeouts.get(str(label), self.getTimeoutMs()))
+        timeout_ms = self._pydevice_timeouts.get(label)
+        return timeout_ms if timeout_ms is not None else self.getTimeoutMs()
 
     def hasDeviceTimeout(self, label: str) -> bool:
         if label not in self._pydevices:
-            # TODO: drop type: ignore once pymmcore stubs ship #914.
             return cast("bool", super().hasDeviceTimeout(label))  # type: ignore[misc]
-        return str(label) in self._pydevice_timeouts
+        return label in self._pydevice_timeouts
 
     def unsetDeviceTimeout(self, label: str) -> None:
         if label not in self._pydevices:
-            # TODO: drop type: ignore once pymmcore stubs ship #914.
             super().unsetDeviceTimeout(label)  # type: ignore[misc]
             return
-        self._pydevice_timeouts.pop(str(label), None)
+        self._pydevice_timeouts.pop(label, None)
 
     def waitForDevice(self, label: DeviceLabel | str) -> None:
         if label not in self._pydevices:
-            return super().waitForDevice(label)
-        timeout_ms = self._pydevice_timeouts.get(str(label), self.getTimeoutMs())
+            super().waitForDevice(label)
+            return
+        timeout_ms = self._pydevice_timeouts.get(label)
+        if timeout_ms is None:
+            timeout_ms = self.getTimeoutMs()
         self._pydevices.wait_for(label, timeout_ms)
 
     def waitForConfig(self, group: str, configName: str) -> None:

--- a/src/pymmcore_plus/experimental/unicore/core/_unicore.py
+++ b/src/pymmcore_plus/experimental/unicore/core/_unicore.py
@@ -676,20 +676,21 @@ class UniMMCore(CMMCorePlus):
         with self._pydevices[label] as dev:
             return dev.busy()
 
-    def setDeviceTimeoutMs(self, label: str, timeout_ms: float | None) -> None:
+    def setDeviceTimeoutMs(self, label: str, timeout_ms: int) -> None:
         if label not in self._pydevices:
-            return super().setDeviceTimeoutMs(label, timeout_ms)
-        if timeout_ms is None:
-            self._pydevice_timeouts.pop(str(label), None)
-        elif timeout_ms <= 0:
+            # TODO: drop type: ignore once pymmcore stubs ship #914.
+            super().setDeviceTimeoutMs(label, timeout_ms)  # type: ignore[misc]
+            return
+        if timeout_ms <= 0:
             raise RuntimeError("Device timeout must be positive")
-        else:
-            self._pydevice_timeouts[str(label)] = float(timeout_ms)
+        self._pydevice_timeouts[str(label)] = float(timeout_ms)
 
-    def getDeviceTimeoutMs(self, label: str) -> float | None:
+    def getDeviceTimeoutMs(self, label: str) -> int:
+        """Return the effective timeout for ``label`` (override or global)."""
         if label not in self._pydevices:
-            return super().getDeviceTimeoutMs(label)
-        return self._pydevice_timeouts.get(str(label))
+            # TODO: drop type: ignore once pymmcore stubs ship #914.
+            return cast("int", super().getDeviceTimeoutMs(label))  # type: ignore[misc]
+        return int(self._pydevice_timeouts.get(str(label), self.getTimeoutMs()))
 
     def hasDeviceTimeout(self, label: str) -> bool:
         if label not in self._pydevices:

--- a/src/pymmcore_plus/experimental/unicore/core/_unicore.py
+++ b/src/pymmcore_plus/experimental/unicore/core/_unicore.py
@@ -151,6 +151,9 @@ class UniMMCore(CMMCorePlus):
         # Groups and presets are ALWAYS also created in C++ (via super() calls).
         # This dict only stores (device, property) -> value for Python devices.
         self._py_config_groups: ConfigGroups = {}
+        # Per-device timeout overrides for Python devices. C++ devices use the
+        # C++ registry (CMMCore::setDeviceTimeoutMs) directly via super().
+        self._pydevice_timeouts: dict[str, float] = {}
 
         super().__init__(*args, **kwargs)
 
@@ -673,20 +676,39 @@ class UniMMCore(CMMCorePlus):
         with self._pydevices[label] as dev:
             return dev.busy()
 
-    def waitForDevice(
-        self,
-        label: DeviceLabel | str,
-        *,
-        timeout_ms: float | None = None,
-    ) -> None:
-        if label not in self._pydevices:  # pragma: no cover
-            return super().waitForDevice(label, timeout_ms=timeout_ms)
+    def setDeviceTimeoutMs(self, label: str, timeout_ms: float | None) -> None:
+        if label not in self._pydevices:
+            return super().setDeviceTimeoutMs(label, timeout_ms)
         if timeout_ms is None:
-            timeout_ms = self.getDeviceTimeoutMs(str(label))
-        effective_timeout = (
-            timeout_ms if timeout_ms is not None else self.getTimeoutMs()
-        )
-        self._pydevices.wait_for(label, effective_timeout)
+            self._pydevice_timeouts.pop(str(label), None)
+        elif timeout_ms <= 0:
+            raise RuntimeError("Device timeout must be positive")
+        else:
+            self._pydevice_timeouts[str(label)] = float(timeout_ms)
+
+    def getDeviceTimeoutMs(self, label: str) -> float | None:
+        if label not in self._pydevices:
+            return super().getDeviceTimeoutMs(label)
+        return self._pydevice_timeouts.get(str(label))
+
+    def hasDeviceTimeout(self, label: str) -> bool:
+        if label not in self._pydevices:
+            # TODO: drop type: ignore once pymmcore stubs ship #914.
+            return cast("bool", super().hasDeviceTimeout(label))  # type: ignore[misc]
+        return str(label) in self._pydevice_timeouts
+
+    def unsetDeviceTimeout(self, label: str) -> None:
+        if label not in self._pydevices:
+            # TODO: drop type: ignore once pymmcore stubs ship #914.
+            super().unsetDeviceTimeout(label)  # type: ignore[misc]
+            return
+        self._pydevice_timeouts.pop(str(label), None)
+
+    def waitForDevice(self, label: DeviceLabel | str) -> None:
+        if label not in self._pydevices:
+            return super().waitForDevice(label)
+        timeout_ms = self._pydevice_timeouts.get(str(label), self.getTimeoutMs())
+        self._pydevices.wait_for(label, timeout_ms)
 
     def waitForConfig(self, group: str, configName: str) -> None:
         # Get config data (merged from C++ and Python)
@@ -709,9 +731,8 @@ class UniMMCore(CMMCorePlus):
         return self.deviceTypeBusy(DeviceType.AnyType)
 
     def waitForSystem(self) -> None:
-        # C++ devices: serial, with per-device registry support.
-        for label in super().getLoadedDevices():
-            self.waitForDevice(label)
+        # C++ devices: per-device registry honoured by C++ itself.
+        super().waitForSystem()
         # Python devices: parallel, with per-device registry support.
         py_labels = list(self._pydevices)
         if py_labels:

--- a/src/pymmcore_plus/experimental/unicore/core/_unicore.py
+++ b/src/pymmcore_plus/experimental/unicore/core/_unicore.py
@@ -711,10 +711,7 @@ class UniMMCore(CMMCorePlus):
         if label not in self._pydevices:
             super().waitForDevice(label)
             return
-        timeout_ms = self._pydevice_timeouts.get(label)
-        if timeout_ms is None:
-            timeout_ms = self.getTimeoutMs()
-        self._pydevices.wait_for(label, timeout_ms)
+        self._pydevices.wait_for(label, self._pydevice_timeout(label))
 
     def waitForConfig(self, group: str, configName: str) -> None:
         # Get config data (merged from C++ and Python)
@@ -736,24 +733,21 @@ class UniMMCore(CMMCorePlus):
     def systemBusy(self) -> bool:
         return self.deviceTypeBusy(DeviceType.AnyType)
 
+    def _pydevice_timeout(self, label: str) -> int:
+        timeout_ms = self._pydevice_timeouts.get(label)
+        return timeout_ms if timeout_ms is not None else self.getTimeoutMs()
+
     def waitForSystem(self) -> None:
         # C++ devices: per-device registry honoured by C++ itself.
         super().waitForSystem()
-        # Python devices: parallel, with per-device registry support.
-        py_labels = list(self._pydevices)
-        if py_labels:
-            from concurrent.futures import ThreadPoolExecutor, as_completed
-
-            with ThreadPoolExecutor() as executor:
-                futures = [
-                    executor.submit(self.waitForDevice, lbl) for lbl in py_labels
-                ]
-                for future in as_completed(futures):
-                    future.result()
+        # Python devices: parallel, per-device timeout from registry/global.
+        self._pydevices.wait_for_each(self._pydevices, self._pydevice_timeout)
 
     def waitForDeviceType(self, devType: int) -> None:
         super().waitForDeviceType(devType)
-        self._pydevices.wait_for_device_type(devType, self.getTimeoutMs())
+        self._pydevices.wait_for_each(
+            self._pydevices.get_labels_of_type(devType), self._pydevice_timeout
+        )
 
     def deviceTypeBusy(self, devType: int) -> bool:
         if super().deviceTypeBusy(devType):

--- a/tests/00_unicore/test_unicore.py
+++ b/tests/00_unicore/test_unicore.py
@@ -294,11 +294,121 @@ def test_waiting():
     assert not core.deviceTypeBusy(DeviceType.Any)
     assert not core.systemBusy()
 
-    core.setTimeoutMs(500)
-    pydev_mock = MagicMock(wraps=core._pydevices)
-    core._pydevices = pydev_mock
-    core.waitForSystem()
-    pydev_mock.wait_for_device_type.assert_called_once_with(DeviceType.Any, 500)
+
+class _StuckBusyDevice(GenericDevice):
+    """Python device whose Busy() flag is perpetually True."""
+
+    def busy(self) -> bool:
+        return True
+
+
+def test_wait_for_device_timeout_pydevice():
+    """UniMMCore.waitForDevice forwards ``timeout_ms`` to the python-device
+    manager, overriding the global ``getTimeoutMs()`` for just this call."""
+    import time as _t
+
+    core = UniMMCore()
+    core.loadPyDevice(PYDEV, _StuckBusyDevice())
+    core.initializeDevice(PYDEV)
+
+    # Sanity: global timeout is high, but the per-call override should
+    # bound wall time well below it.
+    core.setTimeoutMs(10_000)
+
+    # timeout_ms=0 on a busy Python device raises almost immediately.
+    t0 = _t.monotonic()
+    with pytest.raises(TimeoutError):
+        core.waitForDevice(PYDEV, timeout_ms=0)
+    assert _t.monotonic() - t0 < 0.5
+
+    # Small but non-zero timeout still raises, but only after ~timeout_ms.
+    t0 = _t.monotonic()
+    with pytest.raises(TimeoutError):
+        core.waitForDevice(PYDEV, timeout_ms=50)
+    elapsed = _t.monotonic() - t0
+    assert 0.030 <= elapsed <= 1.0, f"elapsed={elapsed:.3f}s"
+    # And we did NOT wait the full global 10 s.
+    assert elapsed < 1.0
+
+
+def _spy_wait_for(core):
+    """Context manager that patches PyDeviceManager.wait_for to record calls.
+
+    Yields a list of ``(label, timeout_ms)`` tuples observed.
+    """
+    from contextlib import contextmanager
+    from unittest.mock import patch
+
+    @contextmanager
+    def _ctx():
+        mgr_cls = type(core._pydevices)
+        real = mgr_cls.wait_for
+        seen: list[tuple[str, float]] = []
+
+        def _spy(self, label, timeout_ms=5000, polling_interval=0.01):
+            seen.append((label, timeout_ms))
+            return real(self, label, timeout_ms, polling_interval=polling_interval)
+
+        with patch.object(mgr_cls, "wait_for", _spy):
+            yield seen
+
+    return _ctx()
+
+
+def test_wait_for_device_timeout_pydevice_forwarded_to_wait_for():
+    """The per-call ``timeout_ms`` is what's passed into
+    ``PyDeviceManager.wait_for`` — not the stale global ``getTimeoutMs()``."""
+    core = UniMMCore()
+    core.loadPyDevice(PYDEV, MyDevice())
+    core.initializeDevice(PYDEV)
+    core.setTimeoutMs(5_000)
+
+    with _spy_wait_for(core) as seen:
+        core.waitForDevice(PYDEV, timeout_ms=123)
+        assert seen == [(PYDEV, 123)]
+
+        seen.clear()
+        core.waitForDevice(PYDEV)
+        assert seen == [(PYDEV, 5_000)]
+
+
+def test_wait_for_device_registry_pydevice():
+    """Per-device timeout registry is consulted for Python devices in UniMMCore."""
+    core = UniMMCore()
+    core.loadPyDevice(PYDEV, MyDevice())
+    core.initializeDevice(PYDEV)
+    core.setTimeoutMs(5_000)
+    core.setDeviceTimeoutMs(PYDEV, 200)
+
+    with _spy_wait_for(core) as seen:
+        core.waitForDevice(PYDEV)
+        assert seen == [(PYDEV, 200)]
+
+        seen.clear()
+        core.waitForDevice(PYDEV, timeout_ms=42)
+        assert seen == [(PYDEV, 42)]
+
+        seen.clear()
+        core.setDeviceTimeoutMs(PYDEV, None)
+        core.waitForDevice(PYDEV)
+        assert seen == [(PYDEV, 5_000)]
+
+
+def test_wait_for_system_registry_unicore():
+    """UniMMCore.waitForSystem honours per-device registry for Python devices."""
+    import time as _t
+
+    core = UniMMCore()
+    core.loadPyDevice(PYDEV, _StuckBusyDevice())
+    core.initializeDevice(PYDEV)
+    core.setTimeoutMs(10_000)
+    core.setDeviceTimeoutMs(PYDEV, 50)
+
+    t0 = _t.monotonic()
+    with pytest.raises(TimeoutError):
+        core.waitForSystem()
+    elapsed = _t.monotonic() - t0
+    assert elapsed < 1.0, f"elapsed={elapsed:.3f}s"
 
 
 def test_define_config_groups():

--- a/tests/00_unicore/test_unicore.py
+++ b/tests/00_unicore/test_unicore.py
@@ -383,6 +383,24 @@ def test_pydevice_timeout_must_be_positive():
         core.setDeviceTimeoutMs(PYDEV, -10)
 
 
+def test_wait_for_device_type_registry_unicore():
+    """UniMMCore.waitForDeviceType honours per-device registry for Python devices."""
+    import time as _t
+
+    core = UniMMCore()
+    core.loadPyDevice(PYDEV, _StuckBusyDevice())
+    core.initializeDevice(PYDEV)
+    core.setTimeoutMs(10_000)
+    core.setDeviceTimeoutMs(PYDEV, 50)
+
+    pydev_type = core.getDeviceType(PYDEV)
+    t0 = _t.monotonic()
+    with pytest.raises(TimeoutError):
+        core.waitForDeviceType(pydev_type)
+    elapsed = _t.monotonic() - t0
+    assert elapsed < 1.0, f"elapsed={elapsed:.3f}s"
+
+
 def test_wait_for_system_registry_unicore():
     """UniMMCore.waitForSystem honours per-device registry for Python devices."""
     import time as _t

--- a/tests/00_unicore/test_unicore.py
+++ b/tests/00_unicore/test_unicore.py
@@ -312,6 +312,8 @@ def _spy_wait_for(core):
 
     @contextmanager
     def _ctx():
+        # Patch the class — PyDeviceManager uses __slots__ so instance patching
+        # raises "attribute is read-only".
         mgr_cls = type(core._pydevices)
         real = mgr_cls.wait_for
         seen: list[tuple[str, float]] = []
@@ -352,6 +354,22 @@ def test_wait_for_device_registry_pydevice():
     core.unsetDeviceTimeout(PYDEV)
     assert core.hasDeviceTimeout(PYDEV) is False
     assert core.getDeviceTimeoutMs(PYDEV) == 5_000
+
+
+def test_pydevice_timeout_cleared_on_unload():
+    """Override is dropped when the device is unloaded, not silently inherited."""
+    core = UniMMCore()
+    core.loadPyDevice(PYDEV, MyDevice())
+    core.initializeDevice(PYDEV)
+
+    core.setDeviceTimeoutMs(PYDEV, 250)
+    assert core.hasDeviceTimeout(PYDEV) is True
+
+    core.unloadDevice(PYDEV)
+    # Reload under the same label; override must not survive.
+    core.loadPyDevice(PYDEV, MyDevice())
+    core.initializeDevice(PYDEV)
+    assert core.hasDeviceTimeout(PYDEV) is False
 
 
 def test_pydevice_timeout_must_be_positive():

--- a/tests/00_unicore/test_unicore.py
+++ b/tests/00_unicore/test_unicore.py
@@ -333,30 +333,25 @@ def test_wait_for_device_registry_pydevice():
     core.initializeDevice(PYDEV)
     core.setTimeoutMs(5_000)
 
-    # No override yet → falls back to global timeout.
-    assert core.getDeviceTimeoutMs(PYDEV) is None
+    # No override yet → effective timeout is the global.
     assert core.hasDeviceTimeout(PYDEV) is False
+    assert core.getDeviceTimeoutMs(PYDEV) == 5_000
     with _spy_wait_for(core) as seen:
         core.waitForDevice(PYDEV)
         assert seen == [(PYDEV, 5_000)]
 
     # With override registered.
     core.setDeviceTimeoutMs(PYDEV, 200)
-    assert core.getDeviceTimeoutMs(PYDEV) == 200
     assert core.hasDeviceTimeout(PYDEV) is True
+    assert core.getDeviceTimeoutMs(PYDEV) == 200
     with _spy_wait_for(core) as seen:
         core.waitForDevice(PYDEV)
         assert seen == [(PYDEV, 200)]
 
-    # Clearing via setDeviceTimeoutMs(label, None).
-    core.setDeviceTimeoutMs(PYDEV, None)
-    assert core.getDeviceTimeoutMs(PYDEV) is None
-    assert core.hasDeviceTimeout(PYDEV) is False
-
     # Clearing via unsetDeviceTimeout.
-    core.setDeviceTimeoutMs(PYDEV, 200)
     core.unsetDeviceTimeout(PYDEV)
     assert core.hasDeviceTimeout(PYDEV) is False
+    assert core.getDeviceTimeoutMs(PYDEV) == 5_000
 
 
 def test_pydevice_timeout_must_be_positive():

--- a/tests/00_unicore/test_unicore.py
+++ b/tests/00_unicore/test_unicore.py
@@ -302,35 +302,6 @@ class _StuckBusyDevice(GenericDevice):
         return True
 
 
-def test_wait_for_device_timeout_pydevice():
-    """UniMMCore.waitForDevice forwards ``timeout_ms`` to the python-device
-    manager, overriding the global ``getTimeoutMs()`` for just this call."""
-    import time as _t
-
-    core = UniMMCore()
-    core.loadPyDevice(PYDEV, _StuckBusyDevice())
-    core.initializeDevice(PYDEV)
-
-    # Sanity: global timeout is high, but the per-call override should
-    # bound wall time well below it.
-    core.setTimeoutMs(10_000)
-
-    # timeout_ms=0 on a busy Python device raises almost immediately.
-    t0 = _t.monotonic()
-    with pytest.raises(TimeoutError):
-        core.waitForDevice(PYDEV, timeout_ms=0)
-    assert _t.monotonic() - t0 < 0.5
-
-    # Small but non-zero timeout still raises, but only after ~timeout_ms.
-    t0 = _t.monotonic()
-    with pytest.raises(TimeoutError):
-        core.waitForDevice(PYDEV, timeout_ms=50)
-    elapsed = _t.monotonic() - t0
-    assert 0.030 <= elapsed <= 1.0, f"elapsed={elapsed:.3f}s"
-    # And we did NOT wait the full global 10 s.
-    assert elapsed < 1.0
-
-
 def _spy_wait_for(core):
     """Context manager that patches PyDeviceManager.wait_for to record calls.
 
@@ -355,43 +326,48 @@ def _spy_wait_for(core):
     return _ctx()
 
 
-def test_wait_for_device_timeout_pydevice_forwarded_to_wait_for():
-    """The per-call ``timeout_ms`` is what's passed into
-    ``PyDeviceManager.wait_for`` — not the stale global ``getTimeoutMs()``."""
-    core = UniMMCore()
-    core.loadPyDevice(PYDEV, MyDevice())
-    core.initializeDevice(PYDEV)
-    core.setTimeoutMs(5_000)
-
-    with _spy_wait_for(core) as seen:
-        core.waitForDevice(PYDEV, timeout_ms=123)
-        assert seen == [(PYDEV, 123)]
-
-        seen.clear()
-        core.waitForDevice(PYDEV)
-        assert seen == [(PYDEV, 5_000)]
-
-
 def test_wait_for_device_registry_pydevice():
     """Per-device timeout registry is consulted for Python devices in UniMMCore."""
     core = UniMMCore()
     core.loadPyDevice(PYDEV, MyDevice())
     core.initializeDevice(PYDEV)
     core.setTimeoutMs(5_000)
-    core.setDeviceTimeoutMs(PYDEV, 200)
 
+    # No override yet → falls back to global timeout.
+    assert core.getDeviceTimeoutMs(PYDEV) is None
+    assert core.hasDeviceTimeout(PYDEV) is False
+    with _spy_wait_for(core) as seen:
+        core.waitForDevice(PYDEV)
+        assert seen == [(PYDEV, 5_000)]
+
+    # With override registered.
+    core.setDeviceTimeoutMs(PYDEV, 200)
+    assert core.getDeviceTimeoutMs(PYDEV) == 200
+    assert core.hasDeviceTimeout(PYDEV) is True
     with _spy_wait_for(core) as seen:
         core.waitForDevice(PYDEV)
         assert seen == [(PYDEV, 200)]
 
-        seen.clear()
-        core.waitForDevice(PYDEV, timeout_ms=42)
-        assert seen == [(PYDEV, 42)]
+    # Clearing via setDeviceTimeoutMs(label, None).
+    core.setDeviceTimeoutMs(PYDEV, None)
+    assert core.getDeviceTimeoutMs(PYDEV) is None
+    assert core.hasDeviceTimeout(PYDEV) is False
 
-        seen.clear()
-        core.setDeviceTimeoutMs(PYDEV, None)
-        core.waitForDevice(PYDEV)
-        assert seen == [(PYDEV, 5_000)]
+    # Clearing via unsetDeviceTimeout.
+    core.setDeviceTimeoutMs(PYDEV, 200)
+    core.unsetDeviceTimeout(PYDEV)
+    assert core.hasDeviceTimeout(PYDEV) is False
+
+
+def test_pydevice_timeout_must_be_positive():
+    """Match C++ behaviour: 0 and negative timeouts are rejected for pydevices."""
+    core = UniMMCore()
+    core.loadPyDevice(PYDEV, MyDevice())
+    core.initializeDevice(PYDEV)
+    with pytest.raises(RuntimeError, match="positive"):
+        core.setDeviceTimeoutMs(PYDEV, 0)
+    with pytest.raises(RuntimeError, match="positive"):
+        core.setDeviceTimeoutMs(PYDEV, -10)
 
 
 def test_wait_for_system_registry_unicore():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -118,6 +118,172 @@ def test_new_position_methods(core: CMMCorePlus) -> None:
     assert round(z2, 2) == z1 + 1
 
 
+def test_wait_for_device_default_path(core: CMMCorePlus) -> None:
+    """Without timeout_ms, delegates to base C++ waitForDevice (unchanged)."""
+    # Camera in the demo config is never busy — just make sure no kwarg works.
+    core.waitForDevice("Camera")
+
+
+def test_wait_for_device_custom_timeout_healthy(core: CMMCorePlus) -> None:
+    """Custom timeout on a not-busy device returns (near-)instantly."""
+    import time as _t
+
+    t0 = _t.monotonic()
+    core.waitForDevice("Camera", timeout_ms=1000)
+    # one Busy() check + return — well under one polling interval
+    assert _t.monotonic() - t0 < 0.05
+
+
+def test_wait_for_device_custom_timeout_busy_raises(
+    core: CMMCorePlus,
+) -> None:
+    """Stuck-busy device raises TimeoutError within [timeout_ms, +slack] ms."""
+    import time as _t
+
+    with patch.object(core, "deviceBusy", return_value=True):
+        t0 = _t.monotonic()
+        with pytest.raises(TimeoutError, match=r"timed out after 50"):
+            core.waitForDevice("Camera", timeout_ms=50)
+        elapsed = _t.monotonic() - t0
+
+    # Should be at least ~timeout_ms (minus one sleep granularity) and not
+    # wildly longer. Generous upper bound for CI jitter.
+    assert 0.030 <= elapsed <= 0.500, f"elapsed={elapsed:.3f}s"
+
+
+def test_wait_for_device_zero_timeout_healthy(core: CMMCorePlus) -> None:
+    """timeout_ms=0 on not-busy device: single Busy() check, returns."""
+    import time as _t
+
+    t0 = _t.monotonic()
+    core.waitForDevice("Camera", timeout_ms=0)
+    assert _t.monotonic() - t0 < 0.05
+
+
+def test_wait_for_device_zero_timeout_busy_fast_fails(
+    core: CMMCorePlus,
+) -> None:
+    """timeout_ms=0 on busy device: raises immediately without sleeping."""
+    import time as _t
+
+    with patch.object(core, "deviceBusy", return_value=True):
+        t0 = _t.monotonic()
+        with pytest.raises(TimeoutError):
+            core.waitForDevice("Camera", timeout_ms=0)
+        # A single deviceBusy() check + raise — no polling sleep.
+        assert _t.monotonic() - t0 < 0.05
+
+
+def test_wait_for_device_core_short_circuit(core: CMMCorePlus) -> None:
+    """The ``timeout_ms`` path short-circuits for the 'Core' pseudo-device,
+    matching C++ CMMCore::waitForDevice which returns immediately for
+    ``IsCoreDeviceLabel``."""
+    # Patch deviceBusy to explode if called — the short-circuit should
+    # mean we never reach it for 'Core'.
+    with patch.object(
+        core,
+        "deviceBusy",
+        side_effect=AssertionError("should not be called for Core"),
+    ):
+        core.waitForDevice("Core", timeout_ms=50)
+        core.waitForDevice("Core", timeout_ms=0)
+
+
+def test_wait_for_device_custom_timeout_becomes_free(
+    core: CMMCorePlus,
+) -> None:
+    """Device that clears Busy() mid-wait returns without raising."""
+    import time as _t
+
+    call_count = {"n": 0}
+    t0 = _t.monotonic()
+
+    def _busy(_label: str) -> bool:
+        call_count["n"] += 1
+        # Report busy for the first ~30 ms, then report free.
+        return (_t.monotonic() - t0) < 0.030
+
+    with patch.object(core, "deviceBusy", side_effect=_busy):
+        core.waitForDevice("Camera", timeout_ms=1000)
+
+    # We polled at least a couple of times, and it did eventually return.
+    assert call_count["n"] >= 2
+
+
+def test_device_timeout_registry(core: CMMCorePlus) -> None:
+    """setDeviceTimeoutMs / getDeviceTimeoutMs store per-device overrides
+    that are consulted by waitForDevice when no per-call kwarg is given."""
+    # Initially empty.
+    assert core.getDeviceTimeoutMs("Camera") is None
+
+    # Set and read back.
+    core.setDeviceTimeoutMs("Camera", 500)
+    assert core.getDeviceTimeoutMs("Camera") == 500
+
+    # waitForDevice uses the registry entry (Camera is not busy → returns).
+    core.waitForDevice("Camera")
+
+    # Clear with None.
+    core.setDeviceTimeoutMs("Camera", None)
+    assert core.getDeviceTimeoutMs("Camera") is None
+
+
+def test_device_timeout_registry_busy_raises(core: CMMCorePlus) -> None:
+    """A registry timeout triggers TimeoutError on a busy device even
+    without a per-call kwarg."""
+    import time as _t
+
+    core.setDeviceTimeoutMs("Camera", 50)
+    with patch.object(core, "deviceBusy", return_value=True):
+        t0 = _t.monotonic()
+        with pytest.raises(TimeoutError, match=r"timed out after 50"):
+            core.waitForDevice("Camera")  # no per-call kwarg
+        elapsed = _t.monotonic() - t0
+    assert 0.030 <= elapsed <= 0.500, f"elapsed={elapsed:.3f}s"
+
+
+def test_device_timeout_kwarg_overrides_registry(core: CMMCorePlus) -> None:
+    """Per-call kwarg takes precedence over the registry."""
+    core.setDeviceTimeoutMs("Camera", 0)  # registry says fast-fail
+    # Per-call gives 1 s — more than enough for a not-busy device.
+    core.waitForDevice("Camera", timeout_ms=1000)
+
+
+def test_set_timeout_ms_does_not_affect_registry(core: CMMCorePlus) -> None:
+    """Global setTimeoutMs is independent from per-device registry."""
+    core.setDeviceTimeoutMs("Camera", 123)
+    core.setTimeoutMs(9999)
+    assert core.getDeviceTimeoutMs("Camera") == 123
+    assert core.getTimeoutMs() == 9999
+
+
+def test_wait_for_system_uses_registry(core: CMMCorePlus) -> None:
+    """waitForSystem iterates devices Python-side so registry entries apply."""
+    # Track which labels go through the Python polling path.
+    python_path_labels: list[str] = []
+
+    def _spy_busy(label: str) -> bool:
+        python_path_labels.append(label)
+        return False  # not busy
+
+    # Set Camera to a registry override so it enters the Python polling path.
+    core.setDeviceTimeoutMs("Camera", 1000)
+    with patch.object(core, "deviceBusy", side_effect=_spy_busy):
+        core.waitForSystem()
+
+    # Camera went through the Python polling path (called deviceBusy).
+    assert "Camera" in python_path_labels
+
+
+def test_wait_for_system_propagates_timeout(core: CMMCorePlus) -> None:
+    """waitForSystem propagates TimeoutError if a device with a registry
+    entry exceeds its timeout."""
+    core.setDeviceTimeoutMs("Camera", 0)
+    with patch.object(core, "deviceBusy", return_value=True):
+        with pytest.raises(TimeoutError, match="Camera"):
+            core.waitForSystem()
+
+
 def test_mda(core: CMMCorePlus, anybot: Any) -> None:
     """Test signal emission during MDA"""
     mda = MDASequence(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -119,134 +119,42 @@ def test_new_position_methods(core: CMMCorePlus) -> None:
 
 
 def test_wait_for_device_default_path(core: CMMCorePlus) -> None:
-    """Without timeout_ms, delegates to base C++ waitForDevice (unchanged)."""
-    # Camera in the demo config is never busy — just make sure no kwarg works.
+    """Camera in the demo config is never busy — should return immediately."""
     core.waitForDevice("Camera")
-
-
-def test_wait_for_device_custom_timeout_healthy(core: CMMCorePlus) -> None:
-    """Custom timeout on a not-busy device returns (near-)instantly."""
-    import time as _t
-
-    t0 = _t.monotonic()
-    core.waitForDevice("Camera", timeout_ms=1000)
-    # one Busy() check + return — well under one polling interval
-    assert _t.monotonic() - t0 < 0.05
-
-
-def test_wait_for_device_custom_timeout_busy_raises(
-    core: CMMCorePlus,
-) -> None:
-    """Stuck-busy device raises TimeoutError within [timeout_ms, +slack] ms."""
-    import time as _t
-
-    with patch.object(core, "deviceBusy", return_value=True):
-        t0 = _t.monotonic()
-        with pytest.raises(TimeoutError, match=r"timed out after 50"):
-            core.waitForDevice("Camera", timeout_ms=50)
-        elapsed = _t.monotonic() - t0
-
-    # Should be at least ~timeout_ms (minus one sleep granularity) and not
-    # wildly longer. Generous upper bound for CI jitter.
-    assert 0.030 <= elapsed <= 0.500, f"elapsed={elapsed:.3f}s"
-
-
-def test_wait_for_device_zero_timeout_healthy(core: CMMCorePlus) -> None:
-    """timeout_ms=0 on not-busy device: single Busy() check, returns."""
-    import time as _t
-
-    t0 = _t.monotonic()
-    core.waitForDevice("Camera", timeout_ms=0)
-    assert _t.monotonic() - t0 < 0.05
-
-
-def test_wait_for_device_zero_timeout_busy_fast_fails(
-    core: CMMCorePlus,
-) -> None:
-    """timeout_ms=0 on busy device: raises immediately without sleeping."""
-    import time as _t
-
-    with patch.object(core, "deviceBusy", return_value=True):
-        t0 = _t.monotonic()
-        with pytest.raises(TimeoutError):
-            core.waitForDevice("Camera", timeout_ms=0)
-        # A single deviceBusy() check + raise — no polling sleep.
-        assert _t.monotonic() - t0 < 0.05
-
-
-def test_wait_for_device_core_short_circuit(core: CMMCorePlus) -> None:
-    """The ``timeout_ms`` path short-circuits for the 'Core' pseudo-device,
-    matching C++ CMMCore::waitForDevice which returns immediately for
-    ``IsCoreDeviceLabel``."""
-    # Patch deviceBusy to explode if called — the short-circuit should
-    # mean we never reach it for 'Core'.
-    with patch.object(
-        core,
-        "deviceBusy",
-        side_effect=AssertionError("should not be called for Core"),
-    ):
-        core.waitForDevice("Core", timeout_ms=50)
-        core.waitForDevice("Core", timeout_ms=0)
-
-
-def test_wait_for_device_custom_timeout_becomes_free(
-    core: CMMCorePlus,
-) -> None:
-    """Device that clears Busy() mid-wait returns without raising."""
-    import time as _t
-
-    call_count = {"n": 0}
-    t0 = _t.monotonic()
-
-    def _busy(_label: str) -> bool:
-        call_count["n"] += 1
-        # Report busy for the first ~30 ms, then report free.
-        return (_t.monotonic() - t0) < 0.030
-
-    with patch.object(core, "deviceBusy", side_effect=_busy):
-        core.waitForDevice("Camera", timeout_ms=1000)
-
-    # We polled at least a couple of times, and it did eventually return.
-    assert call_count["n"] >= 2
 
 
 def test_device_timeout_registry(core: CMMCorePlus) -> None:
-    """setDeviceTimeoutMs / getDeviceTimeoutMs store per-device overrides
-    that are consulted by waitForDevice when no per-call kwarg is given."""
-    # Initially empty.
-    assert core.getDeviceTimeoutMs("Camera") is None
+    """setDeviceTimeoutMs / getDeviceTimeoutMs / hasDeviceTimeout / unset.
 
-    # Set and read back.
+    Override returns ``None`` when not set, exposes the override when set,
+    and ``setDeviceTimeoutMs(label, None)`` clears it.
+    """
+    assert core.getDeviceTimeoutMs("Camera") is None
+    assert core.hasDeviceTimeout("Camera") is False
+
     core.setDeviceTimeoutMs("Camera", 500)
     assert core.getDeviceTimeoutMs("Camera") == 500
+    assert core.hasDeviceTimeout("Camera") is True
 
-    # waitForDevice uses the registry entry (Camera is not busy → returns).
-    core.waitForDevice("Camera")
-
-    # Clear with None.
     core.setDeviceTimeoutMs("Camera", None)
     assert core.getDeviceTimeoutMs("Camera") is None
+    assert core.hasDeviceTimeout("Camera") is False
 
 
-def test_device_timeout_registry_busy_raises(core: CMMCorePlus) -> None:
-    """A registry timeout triggers TimeoutError on a busy device even
-    without a per-call kwarg."""
-    import time as _t
-
-    core.setDeviceTimeoutMs("Camera", 50)
-    with patch.object(core, "deviceBusy", return_value=True):
-        t0 = _t.monotonic()
-        with pytest.raises(TimeoutError, match=r"timed out after 50"):
-            core.waitForDevice("Camera")  # no per-call kwarg
-        elapsed = _t.monotonic() - t0
-    assert 0.030 <= elapsed <= 0.500, f"elapsed={elapsed:.3f}s"
+def test_device_timeout_must_be_positive(core: CMMCorePlus) -> None:
+    """C++ rejects 0 and negative timeouts."""
+    with pytest.raises(RuntimeError, match="positive"):
+        core.setDeviceTimeoutMs("Camera", 0)
+    with pytest.raises(RuntimeError, match="positive"):
+        core.setDeviceTimeoutMs("Camera", -1)
 
 
-def test_device_timeout_kwarg_overrides_registry(core: CMMCorePlus) -> None:
-    """Per-call kwarg takes precedence over the registry."""
-    core.setDeviceTimeoutMs("Camera", 0)  # registry says fast-fail
-    # Per-call gives 1 s — more than enough for a not-busy device.
-    core.waitForDevice("Camera", timeout_ms=1000)
+def test_device_timeout_unknown_device_raises(core: CMMCorePlus) -> None:
+    """Operations on an unloaded label raise RuntimeError from C++."""
+    with pytest.raises(RuntimeError, match="No device with label"):
+        core.setDeviceTimeoutMs("NoSuchDevice", 100)
+    with pytest.raises(RuntimeError, match="No device with label"):
+        core.hasDeviceTimeout("NoSuchDevice")
 
 
 def test_set_timeout_ms_does_not_affect_registry(core: CMMCorePlus) -> None:
@@ -255,33 +163,6 @@ def test_set_timeout_ms_does_not_affect_registry(core: CMMCorePlus) -> None:
     core.setTimeoutMs(9999)
     assert core.getDeviceTimeoutMs("Camera") == 123
     assert core.getTimeoutMs() == 9999
-
-
-def test_wait_for_system_uses_registry(core: CMMCorePlus) -> None:
-    """waitForSystem iterates devices Python-side so registry entries apply."""
-    # Track which labels go through the Python polling path.
-    python_path_labels: list[str] = []
-
-    def _spy_busy(label: str) -> bool:
-        python_path_labels.append(label)
-        return False  # not busy
-
-    # Set Camera to a registry override so it enters the Python polling path.
-    core.setDeviceTimeoutMs("Camera", 1000)
-    with patch.object(core, "deviceBusy", side_effect=_spy_busy):
-        core.waitForSystem()
-
-    # Camera went through the Python polling path (called deviceBusy).
-    assert "Camera" in python_path_labels
-
-
-def test_wait_for_system_propagates_timeout(core: CMMCorePlus) -> None:
-    """waitForSystem propagates TimeoutError if a device with a registry
-    entry exceeds its timeout."""
-    core.setDeviceTimeoutMs("Camera", 0)
-    with patch.object(core, "deviceBusy", return_value=True):
-        with pytest.raises(TimeoutError, match="Camera"):
-            core.waitForSystem()
 
 
 def test_mda(core: CMMCorePlus, anybot: Any) -> None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -124,21 +124,23 @@ def test_wait_for_device_default_path(core: CMMCorePlus) -> None:
 
 
 def test_device_timeout_registry(core: CMMCorePlus) -> None:
-    """setDeviceTimeoutMs / getDeviceTimeoutMs / hasDeviceTimeout / unset.
+    """C++ per-device timeout API: set / get / has / unset.
 
-    Override returns ``None`` when not set, exposes the override when set,
-    and ``setDeviceTimeoutMs(label, None)`` clears it.
+    ``getDeviceTimeoutMs`` returns the *effective* timeout (override or
+    global). ``hasDeviceTimeout`` answers whether an override is registered.
     """
-    assert core.getDeviceTimeoutMs("Camera") is None
+    core.setTimeoutMs(5000)
     assert core.hasDeviceTimeout("Camera") is False
+    # No override → effective timeout is the global.
+    assert core.getDeviceTimeoutMs("Camera") == 5000
 
     core.setDeviceTimeoutMs("Camera", 500)
-    assert core.getDeviceTimeoutMs("Camera") == 500
     assert core.hasDeviceTimeout("Camera") is True
+    assert core.getDeviceTimeoutMs("Camera") == 500
 
-    core.setDeviceTimeoutMs("Camera", None)
-    assert core.getDeviceTimeoutMs("Camera") is None
+    core.unsetDeviceTimeout("Camera")
     assert core.hasDeviceTimeout("Camera") is False
+    assert core.getDeviceTimeoutMs("Camera") == 5000
 
 
 def test_device_timeout_must_be_positive(core: CMMCorePlus) -> None:
@@ -158,10 +160,11 @@ def test_device_timeout_unknown_device_raises(core: CMMCorePlus) -> None:
 
 
 def test_set_timeout_ms_does_not_affect_registry(core: CMMCorePlus) -> None:
-    """Global setTimeoutMs is independent from per-device registry."""
+    """Global setTimeoutMs is independent from per-device override."""
     core.setDeviceTimeoutMs("Camera", 123)
     core.setTimeoutMs(9999)
-    assert core.getDeviceTimeoutMs("Camera") == 123
+    assert core.hasDeviceTimeout("Camera") is True
+    assert core.getDeviceTimeoutMs("Camera") == 123  # override wins
     assert core.getTimeoutMs() == 9999
 
 


### PR DESCRIPTION
Originally proposed a Python-side per-device timeout registry. After [@marktsuchida](https://github.com/marktsuchida)'s feedback that the same logic belongs in C++, [mmCoreAndDevices#914](https://github.com/micro-manager/mmCoreAndDevices/pull/914) (mirrored in [mmcore@f003c35](https://github.com/micro-manager/mmcore/commit/f003c35)) shipped the upstream API. This PR is now a thin pymmcore-plus shim over it.

## Motivation

Different devices have very different expected response times, but `waitForDevice` / `waitForSystem` previously applied a single global timeout (`getTimeoutMs()`, default 5 s) to all of them. A motorised XY stage may legitimately need 10+ seconds for a long travel, while a filter wheel change should complete in <200 ms. If the filter wheel is stuck, you'd rather know in 200 ms than wait out the full global timeout.

## API

```python
core.setDeviceTimeoutMs("FilterWheel", 500)    # fail fast
core.setDeviceTimeoutMs("XY", 10_000)          # generous for long travel
core.getDeviceTimeoutMs("FilterWheel")         # → 500 (effective timeout)
core.getDeviceTimeoutMs("UnconfiguredDevice")  # → 5000 (global, no override)
core.hasDeviceTimeout("FilterWheel")           # → True (override registered?)
core.unsetDeviceTimeout("FilterWheel")         # clear → back to global

core.waitForSystem()  # FilterWheel gets 500 ms, XY gets 10 s, others get global
```

The per-call ``timeout_ms`` kwarg from the original proposal has been removed — set/unset is the single mechanism. Timeouts must be positive (`0`/negative raise `RuntimeError`); callers wanting fast-fail-once should call `deviceBusy()` directly.

## What pymmcore-plus does on top of #914

`CMMCorePlus` inherits the four-method API from `pymmcore.CMMCore` verbatim — no Pythonic wrappers. `UniMMCore` overrides the four methods to dispatch by label: Python-device labels use a unicore-local dict (C++ has no record of them); C++ labels delegate to `super()`. This is the only addition strictly necessary for mixed-device support.

## Note on aggregate waits ([mmCoreAndDevices#913](https://github.com/micro-manager/mmCoreAndDevices/issues/913))

`waitForSystem()` / `waitForConfig()` / `waitForDeviceType()` in C++ still loop `waitForDevice()` per device, so wall time can compound across busy devices. The per-device registry is honoured per call, but issue #913 (still open upstream) tracks deadlining the aggregate. We rely on `super().waitForSystem()` for C++ devices and preserve the existing parallel-wait behaviour for Python devices via `ThreadPoolExecutor` in `UniMMCore`.

## TODO before merge

**This PR is blocked on a pymmcore release that includes #914.** Until then, CI fails because the new C++ methods (`setDeviceTimeoutMs` / `getDeviceTimeoutMs` / `hasDeviceTimeout` / `unsetDeviceTimeout`) don't exist on the released `pymmcore` (≤12.2.2). Local testing was done against a source build of `pymmcore@main` with `subprojects/mmcore.wrap` repointed to a post-#914 mmcore commit (currently `8399a00`).

- [ ] Wait for a `pymmcore` release that ships #914.
- [ ] **Bump `pymmcore` minimum version in `pyproject.toml`** to that release. Currently allows `pymmcore>=11.10`.
- [ ] Drop the `# type: ignore[misc]` comments on `super().{set,get,has,unset}DeviceTimeout(...)` calls in `UniMMCore` once pymmcore stubs ship #914.

## Test plan

- [x] Registry CRUD: `setDeviceTimeoutMs` / `getDeviceTimeoutMs` (returns effective timeout) / `hasDeviceTimeout` / `unsetDeviceTimeout`
- [x] "Must be positive" rejects 0 and negative
- [x] Unknown-device labels raise `RuntimeError`
- [x] Global `setTimeoutMs` is independent from per-device registry
- [x] `UniMMCore` dispatches by label; per-device registry honoured for Python devices
- [x] `UniMMCore.waitForSystem` honours per-device registry for Python devices and propagates `TimeoutError`
- [x] Full local suite: 719 passed, 5 skipped, 1 xfailed against `pymmcore@main + mmcore@HEAD`


