### PR TITLE
fix: ensure data sink is closed on KeyboardInterrupt

### DIFF
--- a/src/pymmcore_plus/mda/_runner.py
+++ b/src/pymmcore_plus/mda/_runner.py
@@ -412,8 +412,9 @@ class MDARunner:
                 with self._lock:
                     if self._finish_reason is None:
                         self._finish_reason = FinishReason.ERRORED
-            with exceptions_logged():
-                self._finish_run(sequence)
+            finally:
+                with exceptions_logged():
+                    self._finish_run(sequence)
         if error is not None:
             raise error
 


### PR DESCRIPTION
## Summary

- Move `_finish_run` into a `finally` block so the data sink is always closed, even when the acquisition is interrupted with Ctrl+C

## Motivation

When a user interrupts a running acquisition with Ctrl+C, `KeyboardInterrupt` is raised. Since `KeyboardInterrupt` inherits from `BaseException` (not `Exception`), it bypasses the `except Exception` handler in `MDARunner.run()`. The `_finish_run` call — which is responsible for calling `sink.close()` — was positioned *after* the except block but not inside a `finally`, so it was skipped entirely on interrupt.

This left the `OMEStream` open, producing:
```
UserWarning: OMEStream was not closed before garbage collection.
Please use `with create_stream(...):` in a context manager or
call `stream.close()` before deletion.
```

The weakref finalizer in ome-writers still calls `backend.finalize()` as a safety net, but the warning is confusing and the cleanup path is less reliable than an explicit close.

## Change

One-line change: wrap the existing `_finish_run` call in `finally:` so it executes unconditionally — on normal completion, on `Exception`, and on `BaseException` (including `KeyboardInterrupt`).

## Test plan

- [x] Existing tests pass (no behavioral change for non-interrupt paths)
- [x] Manual: run an MDA, Ctrl+C during acquisition, confirm no "OMEStream was not closed" warning