### PR TITLE
feat: unified logging via MMCore

### DIFF
--- a/docs/env_var.md
+++ b/docs/env_var.md
@@ -11,9 +11,8 @@ The following environment variables may be used to configure pymmcore-plus globa
 | **`PYMM_BUFFER_SIZE_MB`**  | Circular buffer memory footprint in MB.  |  250 MB    |
 | **`PYMM_STRICT_INIT_CHECKS`**  | Enable/disable strict initialization checks  |  Enabled    |
 | **`PYMM_PARALLEL_INIT`**  | Enable/disable parallel device initialization  |  Enabled    |
-| **`PYMM_LOG_LEVEL`**                       | pymmcore-plus [logging](./guides/logging.md) level.  | `'INFO'`    |
+| **`PYMM_LOG_LEVEL`**                       | Threshold for stderr [logging](./guides/logging.md) records. | `'WARNING'`    |
 | **`PYMM_LOG_FILE`**   | Logfile location. | `pymmcore_plus.log` in the pymmcore-plus [log directory](./guides/logging.md#customizing-logging) |
-| **`PYMM_LOG_RICH`**   | Use [rich](https://rich.readthedocs.io/) for stderr logging (requires `rich` to be installed). Adds some formatting overhead ([#449](https://github.com/pymmcore-plus/pymmcore-plus/issues/449)). | `"0"` (disabled) |
 | **`MICROMANAGER_PATH`**   | Override location of Micro-Manager directory (with device adapters) | User-directory, described [here](./install.md#set-the-active-micro-manager-installation)   |
 | **`PYMM_SIGNALS_BACKEND`** | The event backend to use. Must be one of `'qt'`, `'psygnal'`, or `'auto'`  | `auto` (Qt if `QApplication` exists, otherwise psygnal) |
 | **`PYMM_DISABLE_IPYTHON_COMPLETIONS`**  | Disable [Tab autocompletion for IPython](./guides/ipython_completion.md)  | `"0"`  (enabled) |

--- a/docs/guides/logging.md
+++ b/docs/guides/logging.md
@@ -1,22 +1,46 @@
 # Logging
 
-By default, pymmcore-plus logs to the console at the `INFO` level and to a
-logfile in the pymmcore-plus application data directory at the `DEBUG` level.
-The logfile is named `pymmcore_plus.log` and is rotated at 40MB, with a maximum
-retention of 20 logfiles.
+pymmcore-plus routes Python log messages from the `pymmcore-plus` logger to the
+underlying CMMCore object via `CMMCore.log()`. CMMCore is the single sink: it
+writes records to the primary log file and (optionally) to stderr, applying
+its own level thresholds for each.
+
+By default, CMMCore writes log records to a logfile in the pymmcore-plus
+application data directory (`pymmcore_plus.log`), rotated at 40 MB with
+20-file retention, and to stderr at the `WARNING` threshold. Records emitted
+through Python's `pymmcore-plus` logger are forwarded to the same sink, so
+Python and C++ log lines share one chronological stream.
+
+These settings are applied to the underlying core every time a `CMMCorePlus`
+is instantiated. Note that compared to earlier pymmcore-plus versions, stderr
+now also receives MMCore's own C++ WARNING+ messages (previously only Python
+`pymmcore-plus.*` log records reached stderr). To silence stderr, call
+`configure_logging(log_to_stderr=False)` or `core.enableStderrLog(False)`.
+`PYMM_STDERR_LOG=1` forces stderr on.
+
+Python `pymmcore-plus` log records emitted before any `CMMCorePlus` exists
+are not captured -- they fall through to Python's standard `lastResort`
+handler. To capture pre-core records, attach your own handler to
+`logging.getLogger('pymmcore-plus')`.
+
+The `PYMM_LOG_LEVEL` and `PYMM_LOG_FILE` environment variables are read once
+when `pymmcore_plus` is imported; setting them after import has no effect.
+Use `configure_logging()` to change settings programmatically at any time.
 
 ## Customizing logging
 
-The [`pymmcore_plus.configure_logging`][] function allows you to customize the
-log level, logfile name, and logfile rotation settings.
+The [`pymmcore_plus.configure_logging`][] function lets you change the logfile
+path, level thresholds, stderr toggle, and rotation settings. Calls take
+effect immediately on the active core (if any) and on any core created later.
+Pass `log_to_stderr=False` to silence MMCore's stderr output (or
+`core.enableStderrLog(False)` after creation).
 
 You may also configure logging using the following environment variables:
 
 | Variable       | Default                                                | Description           |
 | -------------- | ------------------------------------------------------ | --------------------- |
-| PYMM_LOG_LEVEL | INFO                                                   | The log level.        |
+| PYMM_LOG_LEVEL | WARNING                                                | The **stderr** log level threshold. |
 | PYMM_LOG_FILE  | `pymmcore_plus.log` in the pymmcore-plus log directory | The logfile location. |
-| PYMM_LOG_RICH  | `0` (disabled)                                         | Use [rich](https://rich.readthedocs.io/) for stderr logging (requires `rich`). Set to `1`, `true`, or `yes` to enable. Note: adds some formatting overhead ([#449](https://github.com/pymmcore-plus/pymmcore-plus/issues/449)). |
 
 !!! tip "pymmcore-plus log directory"
 
@@ -31,10 +55,6 @@ You may also configure logging using the following environment variables:
 
     You can also use `mmcore logs --reveal` to open the log directory in your
     file manager.
-
-Note that both pymmcore-plus and the underlying CMMCore object will write to the log
-file. By default, [CMMCorePlus](../api/cmmcoreplus.md) will call `setPrimaryLogFile()`
-with the location of the pymmcore-plus logfile upon instantiation.
 
 ## Managing logs with the CLI
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ PyQt5 = ["PyQt5 >=5.15.4"]
 PyQt6 = ["PyQt6 >=6.4.2"]
 
 [dependency-groups]
-nano = ["pymmcore-nano >=12.2.0.75.1"]
+nano = ["pymmcore-nano >=12.4.0.75.0"]
 docs = [
     "mkdocs >=1.4",
     "mkdocs-material>=9.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "numpy >=1.26.0; python_version >= '3.12'",
     "numpy >=1.25.2",
     "psygnal >=0.10",
-    "pymmcore >=11.10.0.74.0",
+    "pymmcore >=12.4.0.75.0",
     "typing-extensions >=4",                    # not actually required at runtime
     "useq-schema>=0.9.2",
     # cli requirements included by default for now

--- a/src/pymmcore_plus/_cli.py
+++ b/src/pymmcore_plus/_cli.py
@@ -8,7 +8,7 @@ import time
 from contextlib import suppress
 from pathlib import Path
 from platform import system
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from pymmcore_plus.core._device import Device
 from pymmcore_plus.core._mmcore_plus import CMMCorePlus
@@ -26,6 +26,9 @@ import pymmcore_plus
 from pymmcore_plus._build import DEFAULT_PACKAGES, build
 from pymmcore_plus._logger import configure_logging
 from pymmcore_plus._util import USER_DATA_MM_PATH
+
+if TYPE_CHECKING:
+    import threading
 
 app = typer.Typer(name="mmcore", no_args_is_help=True)
 PLATFORM = system()
@@ -446,18 +449,21 @@ def use(
     typer.secho(f"using {result}", fg=typer.colors.BRIGHT_GREEN)
 
 
-def _tail_file(file_path: str | Path, interval: float = 0.1) -> None:
+def _tail_file(
+    file_path: "str | Path",
+    interval: float = 1.0,
+    stop_event: "threading.Event | None" = None,
+) -> None:
     with open(file_path) as file:
-        # Move the file pointer to the end
         while True:
-            # Read new lines
             new_lines = file.readlines()
             if new_lines:
-                # Display the last 'num_lines' lines
                 print("".join(new_lines), end="")
-
-            # Sleep for a short interval before checking again
-            time.sleep(1)
+            if stop_event is not None:  # for testing
+                if stop_event.wait(interval):
+                    return
+            else:
+                time.sleep(interval)
 
 
 @app.command()

--- a/src/pymmcore_plus/_logger.py
+++ b/src/pymmcore_plus/_logger.py
@@ -2,23 +2,28 @@ from __future__ import annotations
 
 import logging
 import os
-import sys
+import weakref
 from contextlib import contextmanager
-from logging.handlers import RotatingFileHandler
+from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING
+
+import pymmcore_plus._pymmcore as pymmcore
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
-__all__ = ["logger"]
+__all__ = ["MMCoreHandler", "configure_logging", "logger"]
 
 
 logger = logging.getLogger("pymmcore-plus")
+# All records pass to the handler; MMCore enforces the actual thresholds.
+logger.setLevel(logging.DEBUG)
 
 PYMM_LOG_FILE = os.getenv("PYMM_LOG_FILE", "")
 DEFAULT_LOG_LEVEL: str = os.getenv("PYMM_LOG_LEVEL", "WARNING").upper()
 
+LOG_FILE: Path | None
 if "PYTEST_RUNNING" in os.environ:
     LOG_FILE = None
 elif PYMM_LOG_FILE not in ("", "0", "false", "no", "none"):
@@ -29,35 +34,100 @@ else:
     LOG_FILE = USER_DATA_DIR / "logs" / "pymmcore-plus.log"
 
 
-class CustomFormatter(logging.Formatter):
-    dark_grey = "\x1b[38;5;240m"
-    grey = "\x1b[38;20m"
-    yellow = "\x1b[33;20m"
-    red = "\x1b[31;20m"
-    bold_red = "\x1b[31;1m"
-    reset = "\x1b[0m"
-    _format: str = (
-        "%(asctime)s - %(name)s - %(levelname)s - (%(filename)s:%(lineno)d) %(message)s"
-    )
-
-    FORMATS: ClassVar[dict[int, str]] = {
-        logging.DEBUG: dark_grey + _format + reset,
-        logging.INFO: grey + _format + reset,
-        logging.WARNING: yellow + _format + reset,
-        logging.ERROR: red + _format + reset,
-        logging.CRITICAL: bold_red + _format + reset,
-    }
-
-    def format(self, record: logging.LogRecord) -> str:
-        log_fmt = self.FORMATS.get(record.levelno)
-        formatter = logging.Formatter(log_fmt)
-        return formatter.format(record)
+_NAME_TO_MM: dict[str, int] = {
+    "TRACE": pymmcore.LogLevelTrace,
+    "DEBUG": pymmcore.LogLevelDebug,
+    "INFO": pymmcore.LogLevelInfo,
+    "WARNING": pymmcore.LogLevelWarning,
+    "ERROR": pymmcore.LogLevelError,
+    "CRITICAL": pymmcore.LogLevelCritical,
+}
 
 
-_FILE_FORMATTER = logging.Formatter(
-    "%(asctime)s.%(msecs)03d    tid0x%(thread)x [%(levelname)s,%(name)s] %(message)s",
-    datefmt="%Y-%m-%dT%H:%M:%S",
+def _to_mmcore_level(level: int | str) -> int:
+    """Convert a Python logging level (int or name) to an MMCore log level int."""
+    if isinstance(level, str):
+        upper = level.upper()
+        if upper in _NAME_TO_MM:
+            return _NAME_TO_MM[upper]
+        try:
+            level = int(level)
+        except ValueError as e:
+            raise ValueError(f"Unknown log level: {level!r}") from e
+    n = int(level)
+    if n < logging.DEBUG:
+        return pymmcore.LogLevelTrace
+    if n < logging.INFO:
+        return pymmcore.LogLevelDebug
+    if n < logging.WARNING:
+        return pymmcore.LogLevelInfo
+    if n < logging.ERROR:
+        return pymmcore.LogLevelWarning
+    if n < logging.CRITICAL:
+        return pymmcore.LogLevelError
+    return pymmcore.LogLevelCritical
+
+
+@dataclass(frozen=True)
+class _LogConfig:
+    file: Path | None
+    stderr_level: int | str
+    file_level: int | str
+    log_to_stderr: bool
+    file_rotation: int  # MB
+    file_retention: int
+
+
+_config: _LogConfig = _LogConfig(
+    file=LOG_FILE,
+    stderr_level=DEFAULT_LOG_LEVEL,
+    file_level=logging.DEBUG,
+    log_to_stderr=True,
+    file_rotation=40,
+    file_retention=20,
 )
+
+
+class MMCoreHandler(logging.Handler):
+    """Logging handler that forwards Python log records to ``CMMCore.log()``."""
+
+    def __init__(self, core: pymmcore.CMMCore) -> None:
+        super().__init__()
+        self._core_ref: weakref.ref[pymmcore.CMMCore] = weakref.ref(core)
+        # MMCore prepends timestamp/thread/level/name itself.
+        self.setFormatter(logging.Formatter("%(message)s"))
+
+    def emit(self, record: logging.LogRecord) -> None:
+        core = self._core_ref()
+        if core is None:
+            return
+        try:
+            msg = self.format(record)
+            mm_level = _to_mmcore_level(record.levelno)
+            core.log(msg, mm_level, record.name)
+        except Exception:
+            self.handleError(record)
+
+
+def _apply_config_to_core(core: pymmcore.CMMCore) -> None:
+    """Push the current ``_config`` to ``core``."""
+    cfg = _config
+    if cfg.file is not None:
+        Path(cfg.file).parent.mkdir(parents=True, exist_ok=True)
+        core.setPrimaryLogFile(str(cfg.file))
+    else:
+        core.setPrimaryLogFile("")
+    core.setPrimaryLogFileRotation(cfg.file_rotation * 1_000_000, cfg.file_retention)
+    core.setPrimaryLogLevel(_to_mmcore_level(cfg.file_level))
+    core.setStderrLogLevel(_to_mmcore_level(cfg.stderr_level))
+    core.enableStderrLog(cfg.log_to_stderr)
+
+
+def _attached_handler() -> MMCoreHandler | None:
+    for h in logger.handlers:
+        if isinstance(h, MMCoreHandler):
+            return h
+    return None
 
 
 def configure_logging(
@@ -70,94 +140,108 @@ def configure_logging(
 ) -> None:
     r"""Configure logging for pymmcore-plus.
 
-    This function is called automatically once when pymmcore-plus is imported,
-    to set up logging to stderr and a log file.  You can call it again to
-    change the logging settings.
+    All Python logs from the ``pymmcore-plus`` logger are forwarded to MMCore,
+    which is the single sink: it writes to the primary log file and (optionally)
+    to stderr, applying its own level thresholds for each.
 
-    You may also configure logging using the following environment variables:
+    Python logging is left unconfigured until a
+    :class:`~pymmcore_plus.CMMCorePlus` is instantiated. Records emitted before
+    that point fall through to Python's standard ``lastResort`` handler
+    (WARNING+ to stderr, unformatted). Applications that want richer pre-core
+    output should attach their own handler to ``logging.getLogger('pymmcore-plus')``.
 
-    - `PYMM_LOG_LEVEL` - The log level for `stderr` logging. By default `INFO`.
-    - `PYMM_LOG_FILE` - The path to the log file.  If set to `0`, `false`, `no`,
-        or `none`, logging to file will be disabled.
-    - `PYMM_LOG_RICH` - If set to `1`, `true`, or `yes`, use `rich` for stderr
-        logging (requires `rich` to be installed). Note: rich formatting adds
-        some overhead; see https://github.com/pymmcore-plus/pymmcore-plus/issues/449.
+    Calling this function does not change the level of the ``pymmcore-plus``
+    Python logger; the caller controls Python-side filtering, while MMCore
+    enforces the file and stderr thresholds independently.
 
+    Settings are applied to the underlying core every time a
+    :class:`~pymmcore_plus.CMMCorePlus` is instantiated (and immediately, if
+    one already exists). Module-level defaults match the pre-refactor Python
+    handler defaults (file at DEBUG, stderr at WARNING, rotation 40 MB / 20
+    files, stderr enabled).
 
-    !!! note
+    ``stderr_level`` is the *threshold* MMCore applies when stderr logging is
+    enabled; it does not enable stderr by itself. Stderr output is controlled
+    by ``log_to_stderr`` (and may be forced on via ``PYMM_STDERR_LOG=1`` or
+    ``core.enableStderrLog(True)``).
 
-        This function will clear all existing logging handlers and replace them
-        with new ones.  So be sure to pass all the settings you want to use each
-        time you call this function.
+    You may also configure logging using the following environment variables,
+    which are read once at ``pymmcore_plus._logger`` import time only;
+    setting them after import has no effect (use ``configure_logging()``
+    instead):
+
+    - `PYMM_LOG_LEVEL` - Threshold for **stderr** logging. By default `WARNING`.
+    - `PYMM_LOG_FILE` - Path to the log file. If set to `0`, `false`, `no`, or
+      `none`, file logging is disabled.
 
     Parameters
     ----------
     file : str | Path | None
-        Path to logfile. May also be set with MM_LOG_FILE environment variable.
-        If `None`, will not log to file.  By default, logs to:
+        Path to the primary log file. May also be set with the `PYMM_LOG_FILE`
+        environment variable. If `None`, file logging is disabled. By default,
+        logs to:
+
         Mac OS X:   ~/Library/Application Support/pymmcore-plus/logs
         Unix:       ~/.local/share/pymmcore-plus/logs
         Win:        C:\Users\<username>\AppData\Local\pymmcore-plus\pymmcore-plus\logs
     stderr_level : int | str
-        Level for stderr logging.
-        One of "TRACE", "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL",
-        or 5, 10, 20, 30, 40, or 50, respectively.
-        by default `"INFO"`.
+        Level threshold for stderr logging. One of "TRACE", "DEBUG", "INFO",
+        "WARNING", "ERROR", "CRITICAL". By default `"WARNING"` (or
+        `PYMM_LOG_LEVEL`). Note that this only sets the threshold; whether
+        MMCore writes to stderr is controlled separately by
+        ``PYMM_STDERR_LOG`` or ``core.enableStderrLog()``.
     file_level : int | str
-        Level for logging to file, by default `"TRACE"`
+        Level threshold for the primary log file. By default `"DEBUG"`.
     log_to_stderr : bool
-        Whether to log to stderr, by default True
+        Whether MMCore writes log records to stderr. Default ``True``.
+        ``PYMM_STDERR_LOG=1`` (read in ``CMMCorePlus.__init__``) overrides
+        this to ``True`` after ``configure_logging`` is applied.
     file_rotation : int
-        When to rollover to the next log file, in MegaBytes, by default `40`.
+        Roll over to the next log file at this size, in MB. By default `40`.
     file_retention : int
-        Maximum number of log files to retain, by default `20`
+        Maximum number of log files to retain. By default `20`.
     """
-    # logging.basicConfig(level=logging.DEBUG)
-    root_logger = logging.getLogger()
-    root_logger.setLevel(logging.DEBUG)
+    global _config
+    _config = _LogConfig(
+        file=Path(file) if file else None,
+        stderr_level=stderr_level,
+        file_level=file_level,
+        log_to_stderr=log_to_stderr,
+        file_rotation=file_rotation,
+        file_retention=file_retention,
+    )
 
-    for handler in logger.handlers:
-        logger.removeHandler(handler)
-
-    # automatically log to stderr
-    if log_to_stderr and sys.stderr:
-        # use rich for stderr logging if PYMM_LOG_RICH is set and rich is installed
-        stderr_handler: logging.Handler | None = None
-        if os.getenv("PYMM_LOG_RICH", "").lower() in ("1", "true", "yes"):
-            try:
-                from rich.logging import RichHandler
-
-                stderr_handler = RichHandler()
-            except ImportError:
-                pass
-
-        if stderr_handler is None:
-            stderr_handler = logging.StreamHandler(sys.stderr)
-            stderr_handler.setFormatter(CustomFormatter())
-
-        stderr_handler.setLevel(stderr_level)
-        logger.addHandler(stderr_handler)
-
-    # automatically log to file
-    if file:
-        log_file = Path(file)
-        log_file.parent.mkdir(parents=True, exist_ok=True)
-
-        # Create a rotating file handler with a maximum file size and backup count.
-        file_handler = RotatingFileHandler(
-            log_file, maxBytes=file_rotation * 1_000_000, backupCount=file_retention
-        )
-        file_handler.setLevel(file_level)
-        file_handler.setFormatter(_FILE_FORMATTER)
-        logger.addHandler(file_handler)
+    handler = _attached_handler()
+    if handler is not None:
+        core = handler._core_ref()  # noqa: SLF001
+        if core is not None:
+            _apply_config_to_core(core)
 
 
-def current_logfile(logger: logging.Logger) -> Path | None:
-    """Return the first RotatingFileHandler's baseFilename."""
-    for handler in logger.handlers:
-        if isinstance(handler, RotatingFileHandler):
-            return Path(handler.baseFilename)
-    return None
+def _attach_core(core: pymmcore.CMMCore) -> None:
+    """Attach an :class:`MMCoreHandler` forwarding ``logger`` records to ``core``.
+
+    Any pre-existing :class:`MMCoreHandler` is removed first. The current
+    :func:`configure_logging` settings are then pushed to ``core``, intentionally
+    overwriting whatever was previously set on it (file path, rotation, file
+    level, stderr level, stderr enable). Any tuning a user did directly on the
+    ``CMMCore`` object will be replaced.
+    """
+    for h in list(logger.handlers):
+        if isinstance(h, MMCoreHandler):
+            logger.removeHandler(h)
+    logger.addHandler(MMCoreHandler(core))
+    _apply_config_to_core(core)
+
+
+def current_logfile(logger: logging.Logger | None = None) -> Path | None:
+    """Return the configured primary log file path, if any.
+
+    .. deprecated:: 0.16
+        The ``logger`` parameter is unused and will be removed in a future
+        release. Call ``current_logfile()`` with no arguments.
+    """
+    return _config.file
 
 
 @contextmanager
@@ -167,6 +251,3 @@ def exceptions_logged() -> Iterator[None]:
         yield
     except Exception as e:
         logger.error(e)
-
-
-configure_logging()

--- a/src/pymmcore_plus/core/_mmcore_plus.py
+++ b/src/pymmcore_plus/core/_mmcore_plus.py
@@ -26,7 +26,7 @@ from typing_extensions import deprecated
 
 import pymmcore_plus._pymmcore as pymmcore
 from pymmcore_plus._discovery import find_micromanager
-from pymmcore_plus._logger import current_logfile, logger
+from pymmcore_plus._logger import _attach_core, logger
 from pymmcore_plus._util import print_tabular_data
 from pymmcore_plus.mda import MDAEngine, MDARunner, PMDAEngine
 from pymmcore_plus.metadata.functions import summary_metadata
@@ -216,6 +216,7 @@ class CMMCorePlus(pymmcore.CMMCore):
 
     def __init__(self, mm_path: str | None = None, adapter_paths: Sequence[str] = ()):
         super().__init__()
+        _attach_core(self)
         if os.getenv("PYMM_DEBUG_LOG", "0").lower() in ("1", "true"):
             self.enableDebugLog(True)
         if os.getenv("PYMM_STDERR_LOG", "0").lower() in ("1", "true"):
@@ -250,10 +251,7 @@ class CMMCorePlus(pymmcore.CMMCore):
                     parallel = False
             self.enableFeature("ParallelDeviceInitialization", parallel)
 
-        # TODO: test this on windows ... writing to the same file may be an issue there
-        if logfile := current_logfile(logger):
-            self.setPrimaryLogFile(str(logfile))
-            logger.debug("Initialized core %s", self)
+        logger.debug("Initialized core %s", repr(self))
 
         # some internal state, remembering the last arguments passed to various
         # functions.  These are subject to change: do not depend on externally

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,8 @@ from typing import TYPE_CHECKING, Any
 import pytest
 
 import pymmcore_plus
-from pymmcore_plus._logger import logger
+from pymmcore_plus import _logger
+from pymmcore_plus._logger import MMCoreHandler, logger
 from pymmcore_plus.core.events import CMMCoreSignaler
 from pymmcore_plus.mda.events import MDASignaler
 
@@ -31,6 +32,27 @@ except ImportError:
     PARAMS = ["psygnal"]
 
 logger.setLevel("CRITICAL")
+
+
+@pytest.fixture(autouse=True)
+def _restore_logger_state() -> Iterator[None]:
+    """Snapshot and restore pymmcore-plus logging state around every test.
+
+    Tests that invoke the CLI in-process (via ``CliRunner``) or call
+    ``configure_logging`` would otherwise leak ``_logger._config`` mutations
+    into later tests.
+    """
+    saved_level = logger.level
+    saved_config = _logger._config
+    saved_handlers = list(logger.handlers)
+    try:
+        yield
+    finally:
+        for h in list(logger.handlers):
+            if h not in saved_handlers and isinstance(h, MMCoreHandler):
+                logger.removeHandler(h)
+        _logger._config = saved_config
+        logger.setLevel(saved_level)
 
 
 @pytest.fixture(params=PARAMS, scope="function")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -327,35 +327,47 @@ def test_logs_clear_removes_all_log_files(
 
 
 def test_tail_file_streams_initial_and_appended_lines(
-    tmp_path: Path, capfd: pytest.CaptureFixture[str]
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    from threading import Event, Thread
+    from threading import Event, Lock, Thread
 
     from pymmcore_plus._cli import _tail_file
 
     log_file = tmp_path / "live.log"
     log_file.write_text("first\nsecond\n")
 
+    # capfd loses output written from non-main threads on macOS; collect via
+    # the print symbol _tail_file actually calls instead.
+    chunks: list[str] = []
+    lock = Lock()
+
+    def collector(*args: Any, **kwargs: Any) -> None:
+        with lock:
+            chunks.append("".join(str(a) for a in args))
+
+    monkeypatch.setattr(_cli, "print", collector)
+
+    def captured() -> str:
+        with lock:
+            return "".join(chunks)
+
     stop = Event()
     thread = Thread(target=_tail_file, args=(log_file, 0.02, stop))
     thread.start()
     try:
-        captured = ""
         deadline = time.monotonic() + 2.0
-        while time.monotonic() < deadline and "second" not in captured:
+        while time.monotonic() < deadline and "second" not in captured():
             time.sleep(0.02)
-            captured += capfd.readouterr().out
-        assert "first" in captured
-        assert "second" in captured
+        assert "first" in captured()
+        assert "second" in captured()
 
         with log_file.open("a") as fh:
             fh.write("third\n")
 
         deadline = time.monotonic() + 2.0
-        while time.monotonic() < deadline and "third" not in captured:
+        while time.monotonic() < deadline and "third" not in captured():
             time.sleep(0.02)
-            captured += capfd.readouterr().out
-        assert "third" in captured
+        assert "third" in captured()
     finally:
         stop.set()
         thread.join(timeout=2.0)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
 import json
-import os
 import platform
 import shutil
 import subprocess
 import time
-from multiprocessing import Process, Queue
 from pathlib import Path
-from time import sleep
 from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import MagicMock, Mock, patch
 
@@ -24,7 +21,6 @@ except ImportError:
 
 
 from pymmcore_plus import (
-    CMMCorePlus,
     __version__,
     _cli,
     _discovery,
@@ -281,68 +277,89 @@ def test_run_mda_channels() -> None:
     # SIGINT, results passed back via channel/queue
 
 
-# background process to test `logs --tail`
-def _background_tail(q: Queue, runner: Any, logfile: Path) -> None:
-    from os import getpid, kill
-    from signal import SIGINT
-    from threading import Timer
-
-    from pymmcore_plus import _logger
-
-    _logger.LOG_FILE = logfile
-
-    Timer(0.2, lambda: kill(getpid(), SIGINT)).start()
-    result = runner.invoke(app, ["logs", "--tail"], input="ctrl-c")
-    q.put(result.output)
-
-
-# make this test run last
-# the subprocess-based --tail check is flaky locally due to signal/timing issues,
-# so it's skipped outside CI.
-@pytest.mark.skipif(bool(not os.getenv("CI")), reason="flaky outside CI")
-@pytest.mark.run_last
-def test_cli_logs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    # create mock log file
-    TEST_LOG = tmp_path / "test.log"
-    monkeypatch.setattr(_logger, "LOG_FILE", TEST_LOG)
-    _logger.configure_logging(file=TEST_LOG)
-    assert _logger.current_logfile() == TEST_LOG
-
-    # instantiate core
-    core = CMMCorePlus()
-    assert core.getPrimaryLogFile() == str(TEST_LOG)
-    core.loadSystemConfiguration()
-    # it may take a moment for the log file to be written
-    time.sleep(0.2)
-    assert TEST_LOG.exists()
-    # run mmcore logs
-    result = runner.invoke(app, ["logs", "-n", "60"])
+def test_logs_no_log_file_when_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_logger, "LOG_FILE", None)
+    result = runner.invoke(app, ["logs"])
     assert result.exit_code == 0
-    assert "IFO,Core" in result.output  # this will come from CMMCore
+    assert "No log file" in result.stdout
 
-    # run mmcore logs --tail
-    # not sure how to kill the subprocess correctly on windows yet
-    if os.name != "nt":
-        q: Queue = Queue()
-        p = Process(target=_background_tail, args=(q, runner, TEST_LOG))
-        p.start()
-        try:
-            while p.is_alive():
-                sleep(0.1)
-            output = q.get()
-            assert "IFO,Core" in output
-        finally:
-            p.terminate()
-            p.join()  # Ensure the process is fully cleaned up
 
-    runner.invoke(app, ["logs", "--clear"])
-    if os.name != "nt":
-        # this is also not clearing the file on windows... perhaps due to
-        # in-use file?
-        assert not TEST_LOG.exists()
+def test_logs_no_log_file_when_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(_logger, "LOG_FILE", tmp_path / "missing.log")
+    result = runner.invoke(app, ["logs"])
+    assert result.exit_code == 0
+    assert "No log file" in result.stdout
 
-    # restore default config
-    _logger.configure_logging(file=None)
+
+def test_logs_n_returns_last_n_lines(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    log_file = tmp_path / "test.log"
+    log_file.write_text("alpha\nbeta\ngamma\ndelta\n")
+    monkeypatch.setattr(_logger, "LOG_FILE", log_file)
+
+    result = runner.invoke(app, ["logs", "-n", "2"])
+    assert result.exit_code == 0
+    assert "gamma" in result.stdout
+    assert "delta" in result.stdout
+    assert "alpha" not in result.stdout
+    assert "beta" not in result.stdout
+
+
+def test_logs_clear_removes_all_log_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    log_file = tmp_path / "primary.log"
+    log_file.write_text("primary\n")
+    other = tmp_path / "rotated.1.log"
+    other.write_text("rotated\n")
+    not_a_log = tmp_path / "keep.txt"
+    not_a_log.write_text("keep\n")
+    monkeypatch.setattr(_logger, "LOG_FILE", log_file)
+
+    result = runner.invoke(app, ["logs", "--clear"])
+    assert result.exit_code == 0
+    assert not log_file.exists()
+    assert not other.exists()
+    assert not_a_log.exists()
+
+
+def test_tail_file_streams_initial_and_appended_lines(
+    tmp_path: Path, capfd: pytest.CaptureFixture[str]
+) -> None:
+    from threading import Event, Thread
+
+    from pymmcore_plus._cli import _tail_file
+
+    log_file = tmp_path / "live.log"
+    log_file.write_text("first\nsecond\n")
+
+    stop = Event()
+    thread = Thread(target=_tail_file, args=(log_file, 0.02, stop))
+    thread.start()
+    try:
+        captured = ""
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline and "second" not in captured:
+            time.sleep(0.02)
+            captured += capfd.readouterr().out
+        assert "first" in captured
+        assert "second" in captured
+
+        with log_file.open("a") as fh:
+            fh.write("third\n")
+
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline and "third" not in captured:
+            time.sleep(0.02)
+            captured += capfd.readouterr().out
+        assert "third" in captured
+    finally:
+        stop.set()
+        thread.join(timeout=2.0)
+    assert not thread.is_alive(), "_tail_file did not stop on event"
 
 
 def test_cli_info() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -297,19 +297,16 @@ def _background_tail(q: Queue, runner: Any, logfile: Path) -> None:
 
 
 # make this test run last
-# this test is a bit of a mess, but it's the best I can do for now
-# the problem is that it leaves things in a state such that file descriptors are leaked
-# by pretty much every test that creates a core after it.
-@pytest.mark.skipif(bool(not os.getenv("CI")), reason="this is a crappy test")
+# the subprocess-based --tail check is flaky locally due to signal/timing issues,
+# so it's skipped outside CI.
+@pytest.mark.skipif(bool(not os.getenv("CI")), reason="flaky outside CI")
 @pytest.mark.run_last
-@pytest.mark.filterwarnings("ignore:unclosed file:ResourceWarning")
 def test_cli_logs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     # create mock log file
     TEST_LOG = tmp_path / "test.log"
     monkeypatch.setattr(_logger, "LOG_FILE", TEST_LOG)
     _logger.configure_logging(file=TEST_LOG)
-    assert _logger.current_logfile(_logger.logger) == TEST_LOG
-    assert TEST_LOG.exists()
+    assert _logger.current_logfile() == TEST_LOG
 
     # instantiate core
     core = CMMCorePlus()
@@ -317,14 +314,11 @@ def test_cli_logs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     core.loadSystemConfiguration()
     # it may take a moment for the log file to be written
     time.sleep(0.2)
+    assert TEST_LOG.exists()
     # run mmcore logs
     result = runner.invoke(app, ["logs", "-n", "60"])
     assert result.exit_code == 0
     assert "IFO,Core" in result.output  # this will come from CMMCore
-
-    # this one line depends critically on proper monkeypatching, and I can't get
-    # the monkeypatch to work without causing lots of leaked file handle problems.
-    # assert "Initialized" in result.output  # this will come from CMMCorePlus
 
     # run mmcore logs --tail
     # not sure how to kill the subprocess correctly on windows yet
@@ -347,11 +341,8 @@ def test_cli_logs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         # in-use file?
         assert not TEST_LOG.exists()
 
-    # cleanup all logging handlers
+    # restore default config
     _logger.configure_logging(file=None)
-    for handler in _logger.logger.handlers:
-        handler.close()
-        _logger.logger.removeHandler(handler)
 
 
 def test_cli_info() -> None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -604,6 +604,22 @@ def test_snap_rgb(core: CMMCorePlus) -> None:
 
 
 def test_env_vars(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    import logging
+
+    from pymmcore_plus import _logger
+
+    monkeypatch.setattr(
+        _logger,
+        "_config",
+        _logger._LogConfig(
+            file=None,
+            stderr_level=_logger.DEFAULT_LOG_LEVEL,
+            file_level=logging.DEBUG,
+            log_to_stderr=False,
+            file_rotation=40,
+            file_retention=20,
+        ),
+    )
     core = CMMCorePlus()
     assert not core.debugLogEnabled()
     assert not core.stderrLogEnabled()

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 import pymmcore_plus._pymmcore as pymmcore
-from pymmcore_plus import CMMCorePlus, _logger
+from pymmcore_plus import CMMCorePlus
 from pymmcore_plus._logger import (
     MMCoreHandler,
     _to_mmcore_level,
@@ -17,24 +17,7 @@ from pymmcore_plus._logger import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
     from pathlib import Path
-
-
-@pytest.fixture(autouse=True)
-def _restore_logger_state() -> Iterator[None]:
-    """Reset logger handlers, level, and ``_logger._config`` after each test."""
-    saved_level = logger.level
-    saved_config = _logger._config
-    saved_handlers = list(logger.handlers)
-    try:
-        yield
-    finally:
-        for h in list(logger.handlers):
-            if h not in saved_handlers and isinstance(h, MMCoreHandler):
-                logger.removeHandler(h)
-        _logger._config = saved_config
-        logger.setLevel(saved_level)
 
 
 def test_to_mmcore_level() -> None:

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import logging
+import time
+import weakref
+from typing import TYPE_CHECKING
+
+import pytest
+
+import pymmcore_plus._pymmcore as pymmcore
+from pymmcore_plus import CMMCorePlus, _logger
+from pymmcore_plus._logger import (
+    MMCoreHandler,
+    _to_mmcore_level,
+    configure_logging,
+    logger,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _restore_logger_state() -> Iterator[None]:
+    """Reset logger handlers, level, and ``_logger._config`` after each test."""
+    saved_level = logger.level
+    saved_config = _logger._config
+    saved_handlers = list(logger.handlers)
+    try:
+        yield
+    finally:
+        for h in list(logger.handlers):
+            if h not in saved_handlers and isinstance(h, MMCoreHandler):
+                logger.removeHandler(h)
+        _logger._config = saved_config
+        logger.setLevel(saved_level)
+
+
+def test_to_mmcore_level() -> None:
+    assert _to_mmcore_level("DEBUG") == pymmcore.LogLevelDebug
+    assert _to_mmcore_level("info") == pymmcore.LogLevelInfo
+    assert _to_mmcore_level("WARNING") == pymmcore.LogLevelWarning
+    assert _to_mmcore_level("Error") == pymmcore.LogLevelError
+    assert _to_mmcore_level("CRITICAL") == pymmcore.LogLevelCritical
+    assert _to_mmcore_level("TRACE") == pymmcore.LogLevelTrace
+    assert _to_mmcore_level(logging.DEBUG) == pymmcore.LogLevelDebug
+    assert _to_mmcore_level(logging.INFO) == pymmcore.LogLevelInfo
+    assert _to_mmcore_level(5) == pymmcore.LogLevelTrace  # python TRACE
+    assert _to_mmcore_level("10") == pymmcore.LogLevelDebug
+    assert _to_mmcore_level(25) == pymmcore.LogLevelInfo
+    assert _to_mmcore_level(35) == pymmcore.LogLevelWarning
+    assert _to_mmcore_level(0) == pymmcore.LogLevelTrace
+    assert _to_mmcore_level(100) == pymmcore.LogLevelCritical
+    with pytest.raises(ValueError):
+        _to_mmcore_level("BOGUS")
+
+
+def test_attach_core_replaces_handler(tmp_path: Path) -> None:
+    log_file = tmp_path / "a.log"
+    configure_logging(file=log_file)
+    CMMCorePlus()
+    assert sum(isinstance(h, MMCoreHandler) for h in logger.handlers) == 1
+
+    c2 = CMMCorePlus()
+    mm_handlers = [h for h in logger.handlers if isinstance(h, MMCoreHandler)]
+    assert len(mm_handlers) == 1
+    # Most recently created core gets the handler.
+    assert mm_handlers[0]._core_ref() is c2
+
+
+def test_log_routed_to_mmcore_file(tmp_path: Path) -> None:
+    log_file = tmp_path / "routed.log"
+    configure_logging(file=log_file, file_level="DEBUG", log_to_stderr=False)
+    logger.setLevel(logging.DEBUG)
+
+    core = CMMCorePlus()
+    assert core.getPrimaryLogFile() == str(log_file)
+
+    logger.info("hello from python")
+    logger.warning("watch out")
+    logger.debug("low-detail trace")
+    time.sleep(0.2)
+
+    contents = log_file.read_text().lower()
+    assert "[ifo,pymmcore-plus] hello from python" in contents
+    assert "[wrn,pymmcore-plus] watch out" in contents
+    assert "[dbg,pymmcore-plus] low-detail trace" in contents
+
+
+def test_configure_logging_updates_attached_core(tmp_path: Path) -> None:
+    first = tmp_path / "first.log"
+    second = tmp_path / "second.log"
+    configure_logging(file=first)
+    core = CMMCorePlus()
+    assert core.getPrimaryLogFile() == str(first)
+
+    configure_logging(file=second)
+    assert core.getPrimaryLogFile() == str(second)
+
+
+def test_handler_holds_weakref(tmp_path: Path) -> None:
+    log_file = tmp_path / "weak.log"
+    configure_logging(file=log_file)
+    core = CMMCorePlus()
+    handler = next(h for h in logger.handlers if isinstance(h, MMCoreHandler))
+    assert handler._core_ref() is core
+    assert isinstance(handler._core_ref, weakref.ref)
+
+
+def test_attach_core_sets_levels(tmp_path: Path) -> None:
+    log_file = tmp_path / "lvl.log"
+    configure_logging(
+        file=log_file,
+        stderr_level="ERROR",
+        file_level="DEBUG",
+        log_to_stderr=False,
+    )
+    core = CMMCorePlus()
+    assert core.getPrimaryLogLevel() == pymmcore.LogLevelDebug
+    assert core.getStderrLogLevel() == pymmcore.LogLevelError
+    assert not core.stderrLogEnabled()
+
+
+def test_default_config_matches_old_defaults() -> None:
+    core = CMMCorePlus()
+    assert core.getPrimaryLogLevel() == pymmcore.LogLevelDebug
+    assert core.getStderrLogLevel() == pymmcore.LogLevelWarning
+    assert core.stderrLogEnabled() is True
+
+
+def test_configure_logging_log_to_stderr_false_disables(tmp_path: Path) -> None:
+    configure_logging(file=tmp_path / "x.log", log_to_stderr=False)
+    core = CMMCorePlus()
+    assert not core.stderrLogEnabled()
+
+
+def test_configure_logging_file_none_clears_path(tmp_path: Path) -> None:
+    configure_logging(file=tmp_path / "x.log")
+    core = CMMCorePlus()
+    assert core.getPrimaryLogFile() == str(tmp_path / "x.log")
+    configure_logging(file=None)
+    assert core.getPrimaryLogFile() == ""


### PR DESCRIPTION
Closes #385.

This uses https://github.com/micro-manager/mmCoreAndDevices/pull/906 and https://github.com/micro-manager/mmCoreAndDevices/pull/909 to send all Python pymmcore-plus logging to `CMMCore.log()`, with log sinks and rotation handled by MMCore. We then no longer have the situation of two things writing to the same file; ordering is guaranteed.

`PYMM_LOG_RICH` is removed because there is no Python-side formatting any more (with apologies to @ieivanov #613). (MMCore now has a tiny bit of coloring for stderr but of course nothing like Rich. Not sure if there is anything that can be done here.)

Questions remain about what happens when there is more than one CMMCore, but I think that was already semi-broken?

If anything is logged to the `pymmcore-plus` logger before a `CMMCore` is created, it will use Python's defaults. I suppose we could try to preserve such log entries, but I don't think it's worth the trouble given typical use patterns.

`configure_logging()` can be called before creating a `CMMCore`, in which case its effects will only be seen once the `CMMCore` is created.

Bumps the required pymmcore version.

I'm leaving this as draft for now because I want to go over once more especially the docs and tests. @tlambert03, let me know if the general direction looks good.