### PR TITLE
fix: preserve user-provided fov_width/fov_height in grid plans

### DIFF
--- a/src/pymmcore_plus/mda/_engine.py
+++ b/src/pymmcore_plus/mda/_engine.py
@@ -278,19 +278,19 @@ class MDAEngine(PMDAEngine):
         fov_width = x_size * px_size
         fov_height = y_size * px_size
 
-        if sequence.grid_plan:
-            if sequence.grid_plan.fov_width is None:
-                sequence.grid_plan.fov_width = fov_width
-            if sequence.grid_plan.fov_height is None:
-                sequence.grid_plan.fov_height = fov_height
+        if gp := sequence.grid_plan:
+            if gp.fov_width is None:
+                gp.fov_width = fov_width
+            if gp.fov_height is None:
+                gp.fov_height = fov_height
 
         # set fov to any stage positions sequences
         for p in sequence.stage_positions:
-            if p.sequence and p.sequence.grid_plan:
-                if p.sequence.grid_plan.fov_width is None:
-                    p.sequence.grid_plan.fov_width = fov_width
-                if p.sequence.grid_plan.fov_height is None:
-                    p.sequence.grid_plan.fov_height = fov_height
+            if p.sequence and (gp := p.sequence.grid_plan):
+                if gp.fov_width is None:
+                    gp.fov_width = fov_width
+                if gp.fov_height is None:
+                    gp.fov_height = fov_height
 
     def setup_event(self, event: MDAEvent) -> None:
         """Set the system hardware (XY, Z, channel, exposure) as defined in the event.

--- a/src/pymmcore_plus/mda/_engine.py
+++ b/src/pymmcore_plus/mda/_engine.py
@@ -279,14 +279,18 @@ class MDAEngine(PMDAEngine):
         fov_height = y_size * px_size
 
         if sequence.grid_plan:
-            sequence.grid_plan.fov_width = fov_width
-            sequence.grid_plan.fov_height = fov_height
+            if sequence.grid_plan.fov_width is None:
+                sequence.grid_plan.fov_width = fov_width
+            if sequence.grid_plan.fov_height is None:
+                sequence.grid_plan.fov_height = fov_height
 
         # set fov to any stage positions sequences
         for p in sequence.stage_positions:
             if p.sequence and p.sequence.grid_plan:
-                p.sequence.grid_plan.fov_height = fov_height
-                p.sequence.grid_plan.fov_width = fov_width
+                if p.sequence.grid_plan.fov_width is None:
+                    p.sequence.grid_plan.fov_width = fov_width
+                if p.sequence.grid_plan.fov_height is None:
+                    p.sequence.grid_plan.fov_height = fov_height
 
     def setup_event(self, event: MDAEvent) -> None:
         """Set the system hardware (XY, Z, channel, exposure) as defined in the event.

--- a/tests/test_mda.py
+++ b/tests/test_mda.py
@@ -204,6 +204,35 @@ def test_set_mda_fov(core: CMMCorePlus) -> None:
     assert sub_grid.fov_width == sub_grid.fov_height == 256
 
 
+def test_mda_fov_preserves_user_values(core: CMMCorePlus) -> None:
+    """User-provided fov_width/fov_height must not be overwritten by the engine.
+
+    This matters when pixel size is uncalibrated, or when the physical FOV
+    differs from camera_size * pixel_size (e.g. oblique-plane geometry).
+    """
+    mda = MDASequence(
+        channels=["FITC"],
+        stage_positions=(
+            {"sequence": {"grid_plan": {"rows": 1, "columns": 1, "fov_width": 180}}},
+        ),
+        grid_plan={"rows": 1, "columns": 1, "fov_width": 180, "fov_height": 180},
+    )
+
+    global_grid = mda.grid_plan
+    sub_grid = mda.stage_positions[0].sequence.grid_plan  # type: ignore
+    assert global_grid and sub_grid
+
+    core.setProperty("Objective", "Label", "Nikon 20X Plan Fluor ELWD")
+    core.mda.engine.setup_sequence(mda)  # type: ignore
+
+    # user-provided values are preserved
+    assert global_grid.fov_width == 180
+    assert global_grid.fov_height == 180
+    assert sub_grid.fov_width == 180
+    # unset values are still filled in from camera ROI * pixel size
+    assert sub_grid.fov_height == 256
+
+
 def event_generator() -> Iterator[MDAEvent]:
     yield MDAEvent()
     yield MDAEvent()


### PR DESCRIPTION
## Summary

`MDAEngine.setup_sequence` currently overwrites `grid_plan.fov_width` and `grid_plan.fov_height` unconditionally with `camera_roi_pixels * pixel_size_um`, silently discarding values the user provided via YAML or programmatic construction.

This PR changes the behavior to only assign these fields when they are currently `None`, so the engine still fills in unset values but leaves user-provided values intact.

## Motivation

There are real cases where the engine's derived value is wrong:

- **Uncalibrated pixel size** — e.g. demo configs and many real configs ship with `PixelSizeUm = 1.0` as a placeholder. The user's YAML value is then the *correct* one, but it gets overwritten by `camera_size * 1.0 µm`.
- **Oblique-plane / light-sheet geometry** — the imaged sample area on the XY stage does not equal the camera footprint times the lateral pixel size. The user has to be able to specify the true XY-stage FOV.

Concrete example: a YAML config with `fov_width: 180`, `fov_height: 180`, `overlap: -10`, and a 1600×256 camera ROI (uncalibrated `PixelSizeUm = 1.0`). The user expects a step of 198 µm in both axes; before this PR they got 1760 µm in X and 281 µm in Y because the engine replaced `180` with `1600 * 1.1` and `256 * 1.1`.

## Changes

- `_update_grid_fov_sizes` only writes `fov_width`/`fov_height` when the existing value is `None`. Applies to both the top-level `grid_plan` and any per-position sub-sequences.
- New test `test_mda_fov_preserves_user_values` verifies user values are preserved while unset values are still filled in.

## Test plan

- [x] `tests/test_mda.py::test_set_mda_fov` still passes (existing fill-in-from-camera behavior intact when fov is `None`)
- [x] `tests/test_mda.py::test_mda_fov_preserves_user_values` passes (new — user-provided values kept; unset values filled in)
- [x] Verified end-to-end against a downstream MDA engine subclass: configured 180 µm fov + −10% overlap now produces the expected 198 µm step instead of `camera_size * 1.0`.