### PR TITLE
fix: close handlers and snapshot list in configure_logging cleanup

### DIFF
--- a/src/pymmcore_plus/_logger.py
+++ b/src/pymmcore_plus/_logger.py
@@ -116,8 +116,9 @@ def configure_logging(
     root_logger = logging.getLogger()
     root_logger.setLevel(logging.DEBUG)
 
-    for handler in logger.handlers:
+    for handler in list(logger.handlers):
         logger.removeHandler(handler)
+        handler.close()
 
     # automatically log to stderr
     if log_to_stderr and sys.stderr:


### PR DESCRIPTION
The handler-cleanup loop in configure_logging() had two intra-process bugs that surface when configure_logging() runs more than once in the same interpreter (uncommon in production, common in tests, notebooks with %autoreload, and on explicit reconfig calls):

1. Mutate-during-iteration: removeHandler mutates logger.handlers, so `for handler in logger.handlers: logger.removeHandler(handler)` skips every other element. With the typical [stderr, file] handler pair, the file handler is never actually removed, and the next call to configure_logging() stacks a fresh file handler on top of it. Every log message then writes twice to the file (verified locally).

2. Missing close(): handlers that do get removed keep their underlying file descriptors open. On POSIX rename-while-open is fine; on Windows the orphan FD can lock the rotation target so doRollover fails with PermissionError on the next rotation attempt.

Iterate a list snapshot and call handler.close() after detaching.

This does not address the cross-process case where multiple Python interpreters share the default log path - that needs per-PID log files (separate issue).