### PR TITLE
fix: a failing sequence teardown must not strand sequenceFinished

### DIFF
--- a/src/pymmcore_plus/mda/_engine.py
+++ b/src/pymmcore_plus/mda/_engine.py
@@ -627,8 +627,11 @@ class MDAEngine(PMDAEngine):
 
         # restore ROI
         if "roi" in self._initial_state:
-            core.clearROI()
-            core.setROI(*self._initial_state["roi"])
+            try:
+                core.clearROI()
+                core.setROI(*self._initial_state["roi"])
+            except Exception as e:
+                logger.warning("Failed to restore ROI: %s", e)
 
         core.waitForSystem()
         # clear the state after restoration

--- a/src/pymmcore_plus/mda/_runner.py
+++ b/src/pymmcore_plus/mda/_runner.py
@@ -746,7 +746,13 @@ class MDARunner:
                 logger.error("Error closing data sink: %s", e)
 
         if hasattr(self._engine, "teardown_sequence"):
-            self._engine.teardown_sequence(sequence)  # type: ignore
+            # Guarded like _sink.close() above: a failing teardown must not
+            # prevent sequenceFinished from being emitted or the runner from
+            # returning to IDLE.
+            try:
+                self._engine.teardown_sequence(sequence)  # type: ignore
+            except Exception as e:
+                logger.error("Error tearing down sequence: %s", e)
 
         if finish_reason == FinishReason.CANCELED:
             logger.warning("MDA Canceled: %s", sequence)

--- a/tests/test_mda.py
+++ b/tests/test_mda.py
@@ -459,6 +459,43 @@ def test_runner_pause(core: CMMCorePlus, anybot: Any) -> None:
     engine.teardown_sequence.assert_called_once()
 
 
+def test_teardown_failure_still_finishes(core: CMMCorePlus) -> None:
+    """A failing teardown must not strand sequenceFinished or wedge the runner."""
+    engine = MagicMock(wraps=core.mda.engine)
+    engine.teardown_sequence.side_effect = RuntimeError("teardown boom")
+    core.mda.set_engine(engine)
+
+    finished = Mock()
+    core.mda.events.sequenceFinished.connect(finished)
+
+    # synchronous run -- must not raise despite the failing teardown
+    core.mda.run([MDAEvent()])
+
+    engine.teardown_sequence.assert_called_once()
+    finished.assert_called_once()  # signal emitted, not stranded
+    assert core.mda._state == RunState.IDLE  # reset, not stuck in FINISHING
+
+    # the runner is not wedged: a second run still completes
+    finished.reset_mock()
+    core.mda.run([MDAEvent()])
+    finished.assert_called_once()
+
+
+def test_roi_restore_failure_does_not_break_teardown(core: CMMCorePlus) -> None:
+    """A camera that cannot restore its ROI must not abort engine teardown."""
+    engine = core.mda.engine
+    assert engine is not None
+    engine.restore_initial_state = True
+
+    seq = MDASequence(time_plan={"interval": 0, "loops": 1}, channels=["DAPI"])
+    engine.setup_sequence(seq)  # captures _initial_state, including "roi"
+    assert "roi" in engine._initial_state
+
+    with patch.object(core, "setROI", side_effect=RuntimeError("no ROI support")):
+        # must not raise despite setROI failing during restore
+        engine.teardown_sequence(seq)
+
+
 def test_reset_event_timer(core: CMMCorePlus) -> None:
     seq = [
         MDAEvent(min_start_time=0),


### PR DESCRIPTION
## Summary

`MDARunner._finish_run` calls `engine.teardown_sequence()` unguarded. If teardown raises, the exception propagates out of `_finish_run` **before** `sequenceFinished.emit()` and the `RunState.IDLE` reset. `_finish_run` is invoked as `with exceptions_logged(): self._finish_run(...)`, so the exception is swallowed into a single log line — the run looks successful to the caller, but:

- `sequenceFinished` is never emitted, stranding every listener (the `mda_listeners_connected` context manager — whose own comment notes it "expects to see both of those signals" — plus downstream UIs and user code);
- the runner stays stuck in `RunState.FINISHING` instead of returning to `IDLE`.

## Concrete trigger

A camera that doesn't support ROI. `MDAEngine` snapshots the ROI at sequence start via `getROI()` (guarded — and the unicore `CameraDevice` base defaults `get_roi` to the full frame, so it always succeeds) and restores it in teardown via `setROI()`. The ROI restore in `_restore_initial_state` was the **only unguarded restore step** — z / xy / exposure / config groups / autoshutter are each individually `try/except`ed. So a `setROI` that raises (a camera without ROI support — e.g. a `unicore` `CameraDevice` that doesn't override `set_roi`) aborts teardown and triggers the stranding above.

This was hit in practice: a `napari-micromanager` preview stopped updating on Snap after the first MDA, because napari-mm's `_NapariMDAHandler` never received `sequenceFinished` and so never cleared its `_mda_running` flag.

## Fix — defense in depth

- **`_runner.py`** — guard `teardown_sequence()` like the adjacent `_sink.close()` already is, so `sequenceFinished.emit()` and the `IDLE` reset always run regardless of any engine's teardown outcome.
- **`_engine.py`** — guard the ROI restore in `_restore_initial_state` like every other restore step, closing the capture/restore asymmetry.

The principle: the terminal `sequenceFinished` signal and the `RunState.IDLE` reset must not be reachable-only-if-teardown-succeeds. A failed teardown should be logged, not allowed to strand every observer.

## Tests

Two regression tests in `tests/test_mda.py`, both verified to fail without the fix (across the `qt` and `psygnal` signal backends):

- `test_teardown_failure_still_finishes` — an engine whose `teardown_sequence` raises: `sequenceFinished` is still emitted, the runner returns to `IDLE`, and a second run still completes (runner not wedged).
- `test_roi_restore_failure_does_not_break_teardown` — a camera whose `setROI` raises during restore: `teardown_sequence` does not propagate.

## Test plan

- [x] New regression tests fail on `main`, pass with the fix
- [x] `test_mda.py` teardown / restore / runner / roi subset — 34 passed
- [x] pre-commit (typos, ruff, ruff-format, mypy) clean