### PR TITLE
fix: restore TIFF singleton dimensions with reshape

### DIFF
--- a/src/pymmcore_plus/mda/handlers/_ome_tiff_writer.py
+++ b/src/pymmcore_plus/mda/handlers/_ome_tiff_writer.py
@@ -134,9 +134,8 @@ class OMETiffWriter(_5DWriterBase[np.memmap]):
         )
 
         # memory-mapped NumPy array of image data stored in TIFF file.
-        mmap = memmap(fname, dtype=dtype)
-        # This line is important, as tifffile.memmap appears to lose singleton dims
-        mmap.shape = shape
+        # tifffile.memmap omits singleton dimensions. Restore them with a view.
+        mmap = memmap(fname, dtype=dtype).reshape(shape)
 
         return mmap  # type: ignore
 


### PR DESCRIPTION
### Summary

The test suite treats the NumPy 2.5 deprecation warning for direct memory map shape assignment as an error. Restore TIFF singleton dimensions with reshape instead of direct shape assignment.

### Design

The OME-TIFF writer assigns the required shape directly to the memory map. The writer restores singleton dimensions with a memory-sharing reshape view.

The implementation changes [`src/pymmcore_plus/mda/handlers/_ome_tiff_writer.py`](https://github.com/stanbot8/pymmcore-plus/blob/adcc947ebae82720e3be70abc91fb0d8069d070b/src/pymmcore_plus/mda/handlers/_ome_tiff_writer.py). The design follows [The original review proposed reshape for singleton dimensions](https://github.com/pymmcore-plus/pymmcore-plus/pull/265#discussion_r1389131512).

### Tests

The baseline failed, and the candidate passed the same reproducer. The 12 OME-TIFF writer tests passed with NumPy 2.5.1. The full suite passed with 680 passed, 3 skipped, and 1 expected failure. The repository hooks passed for the changed file. The installed wheel returned a writable memory map with shape (1, 1, 4, 5) on Python 3.13.12 and NumPy 2.5.1.

16 [CI jobs](https://github.com/stanbot8/pymmcore-plus/actions/runs/30175088178) passed.

<details>
<summary>Commands</summary>

```console
uv run python -m pytest tests/io/test_ome_tiff.py -q
uv run python -m pytest -q
uv run python -m pre_commit run --files src/pymmcore_plus/mda/handlers/_ome_tiff_writer.py --verbose
```

</details>
